### PR TITLE
Fix-#41: Change referential action for Signature_recipientId_fkey

### DIFF
--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -130,6 +130,6 @@ model Signature {
   signatureImageAsBase64 String?
   typedSignature         String?
 
-  Recipient Recipient @relation(fields: [recipientId], references: [id], onDelete: Restrict)
+  Recipient Recipient @relation(fields: [recipientId], references: [id], onDelete: Cascade)
   Field     Field     @relation(fields: [fieldId], references: [id], onDelete: Restrict)
 }


### PR DESCRIPTION
An easy way to allow for PDF document deletion after being signed is changing the Signature_recipientId_fkey's onDelete referential action to Cascade, such that signatures of the recipients are deleted along with the PDF document. 

Draft for issue #41 
