### PR TITLE
Delete empty recipient fields

### DIFF
--- a/apps/web/pages/documents/[id]/recipients.tsx
+++ b/apps/web/pages/documents/[id]/recipients.tsx
@@ -68,6 +68,20 @@ const RecipientsPage: NextPageWithLayout = (props: any) => {
     return !!errors?.signers?.[index]?.email;
   };
 
+  const deleteEmptyFields = () => {
+    let counter = 0;
+    formValues.forEach((item: any, index) => {
+      if (!item.email && item.sendStatus === "NOT_SENT") {
+        remove(index - counter);
+        counter += 1;
+        deleteRecipient(item)?.catch((err) => {
+          append(item);
+          counter -= 1;
+        });
+      }
+    });
+  };
+
   return (
     <>
       <Head>
@@ -109,6 +123,7 @@ const RecipientsPage: NextPageWithLayout = (props: any) => {
                   icon={PaperAirplaneIcon}
                   onClick={() => {
                     setOpen(true);
+                    deleteEmptyFields();
                   }}
                   disabled={
                     (formValues.length || 0) === 0 ||


### PR DESCRIPTION
||comments|
|--|--|
|`issue`| - Application allows for sending signing requests to empty recipients <br> - An empty recipient record is added to the `Recipient` in db. (at first I thought this was unnecessary,  but the implementation of  [useFieldArray](https://react-hook-form.com/api/usefieldarray/) forces us to so) <br> - This is why the status is `pending` even after completion|
|`fix`| - A possible workaround is deleting the empty records (from db and fieldArray) when user clicks `Send`. |
|preview| https://www.loom.com/share/1eadbf82efcb4de2ac0b0e00b62cf01f| 

I have opened another related issue here #69

Fixes #39