### PR TITLE
fixes - bug in disabling send button when email field is invalid

### DIFF
--- a/apps/web/pages/documents/[id]/recipients.tsx
+++ b/apps/web/pages/documents/[id]/recipients.tsx
@@ -112,8 +112,8 @@ const RecipientsPage: NextPageWithLayout = (props: any) => {
                   }}
                   disabled={
                     (formValues.length || 0) === 0 ||
-                    !formValues.some(
-                      (r: any) => r.email && !hasEmailError(r) && r.sendStatus === "NOT_SENT"
+                    formValues.some(
+                      (r: any) => r.email && hasEmailError(r) && r.sendStatus === "NOT_SENT"
                     ) ||
                     loading
                   }>


### PR DESCRIPTION
This is already implemented, its' just a minor boolean error.

preview: https://www.loom.com/share/4b6492e49bcc46dd9fd5d150ae0f2847