### PR TITLE
fix: signing email breaks on small devices

### DIFF
--- a/packages/lib/mail/signingRequestTemplate.ts
+++ b/packages/lib/mail/signingRequestTemplate.ts
@@ -11,8 +11,8 @@ export const signingRequestTemplate = (
   user: any
 ) => {
   const customContent = `
-  <p style="margin: 30px;">
-    <a href="${ctaLink}" style="background-color: #37f095; color: white; border-color: transparent; border-width: 1px; border-radius: 0.375rem; font-size: 18px; padding-left: 16px; padding-right: 16px; padding-top: 10px; padding-bottom: 10px; text-decoration: none; margin-top: 4px; margin-bottom: 4px;">
+  <p style="margin: 30px 0px; text-align: center">
+    <a href="${ctaLink}" style="background-color: #37f095; white-space: nowrap; color: white; border-color: transparent; border-width: 1px; border-radius: 0.375rem; font-size: 18px; padding-left: 16px; padding-right: 16px; padding-top: 10px; padding-bottom: 10px; text-decoration: none; margin-top: 4px; margin-bottom: 4px;">
       ${ctaLabel}
     </a>
   </p>


### PR DESCRIPTION
Currently the signing email displays poorly on small devices with the line wrapping causing the button to look broken.

Resolve this by using whitespace no-wrap.

![image](https://user-images.githubusercontent.com/13398220/232342023-909591bc-6d15-4485-841c-ec678718a0b3.png)

Closes #46 