### PR TITLE
Redirect to /dashboard if auth user tries to access /login or /signup

### DIFF
--- a/apps/web/pages/login.tsx
+++ b/apps/web/pages/login.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import { getUserFromToken } from "@documenso/lib/server";
 import Login from "../components/login";
 
 export default function LoginPage(props: any) {
@@ -13,6 +14,16 @@ export default function LoginPage(props: any) {
 }
 
 export async function getServerSideProps(context: any) {
+  const user = await getUserFromToken(context.req, context.res);
+  if (user)
+    return {
+      redirect: {
+        source: "/login",
+        destination: "/dashboard",
+        permanent: false,
+      },
+    };
+
   const ALLOW_SIGNUP = process.env.ALLOW_SIGNUP === "true";
 
   return {

--- a/apps/web/pages/signup.tsx
+++ b/apps/web/pages/signup.tsx
@@ -1,5 +1,6 @@
 import { NextPageContext } from "next";
 import Head from "next/head";
+import { getUserFromToken } from "@documenso/lib/server";
 import Signup from "../components/signup";
 
 export default function SignupPage(props: { source: string }) {
@@ -18,6 +19,16 @@ export async function getServerSideProps(context: any) {
     return {
       redirect: {
         destination: "/login",
+        permanent: false,
+      },
+    };
+
+  const user = await getUserFromToken(context.req, context.res);
+  if (user)
+    return {
+      redirect: {
+        source: "/signup",
+        destination: "/dashboard",
         permanent: false,
       },
     };


### PR DESCRIPTION
fixes #131

I think we should be using [next middleware](https://nextjs.org/docs/advanced-features/middleware) to do all the redirecting. What do you think? Do you want me to try to do that instead?