### PR TITLE
fix: deprecated type checks and imports from @prisma/client

### DIFF
--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -1,5 +1,5 @@
 import { HttpError } from "@documenso/lib/server";
-import { NotFoundError, PrismaClientKnownRequestError } from "@prisma/client/runtime";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 export function getServerErrorFromUnknown(cause: unknown): HttpError {
   // Error was manually thrown and does not need to be parsed.
@@ -18,7 +18,7 @@ export function getServerErrorFromUnknown(cause: unknown): HttpError {
     return new HttpError({ statusCode: 400, message: cause.message, cause });
   }
 
-  if (cause instanceof NotFoundError) {
+  if (cause instanceof PrismaClientKnownRequestError) {
     return new HttpError({ statusCode: 404, message: cause.message, cause });
   }
 


### PR DESCRIPTION
Fixes #170 

1. imports from "@prisma/client/runtime" are deprecated. Using "@prisma/client/runtime/library" instead
https://github.com/prisma/prisma/discussions/17832#discussioncomment-5051532

3. NotFoundError class is deprecated. This has changed to PrismaClientKnownRequestError in 4.10.x
https://github.com/prisma/prisma/blob/main/packages/client/src/runtime/utils/rejectOnNotFound.ts#L13-L24