### PR TITLE
Started Migration to Next's App Directory

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { Montserrat, Qwigley } from "next/font/google";
 import { cn } from "../lib/utils";
+import "../styles/tailwind.css";
 
 export const metadata: Metadata = {
   title: {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,43 @@
+import { Metadata } from "next";
+import { Montserrat, Qwigley } from "next/font/google";
+import { cn } from "../lib/utils";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Documenso",
+    template: "%s | Documenso",
+  },
+};
+
+const montserrat = Montserrat({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  display: "swap",
+  variable: "--font-sans",
+});
+
+const qwigley = Qwigley({
+  subsets: ["latin"],
+  weight: ["400"],
+  display: "swap",
+  variable: "--font-qwigley",
+});
+
+interface RootLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body
+        className={cn(
+          "bg-background min-h-screen font-sans antialiased",
+          montserrat.variable,
+          qwigley.variable
+        )}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,8 +21,9 @@
     "avatar-from-initials": "^1.0.3",
     "base64-arraybuffer": "^1.0.2",
     "bcryptjs": "^2.4.3",
+    "clsx": "^1.2.1",
     "formidable": "^3.2.5",
-    "next": "13.2.4",
+    "next": "^13.4.4",
     "next-auth": "^4.22.0",
     "node-forge": "^1.3.1",
     "node-signpdf": "^1.5.0",
@@ -38,7 +39,8 @@
     "react-resizable": "^3.0.4",
     "react-tooltip": "^5.7.2",
     "short-uuid": "^4.2.2",
-    "string-to-color": "^2.2.2"
+    "string-to-color": "^2.2.2",
+    "tailwind-merge": "^1.12.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/apps/web/pages/api/auth/signup.ts
+++ b/apps/web/pages/api/auth/signup.ts
@@ -52,5 +52,5 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id].ts
+++ b/apps/web/pages/api/documents/[id].ts
@@ -90,6 +90,6 @@ async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
-  DELETE: Promise.resolve({ default: defaultResponder(deleteHandler) }),
+  GET: Promise.resolve({ default: defaultResponder(getHandler as any) }),
+  DELETE: Promise.resolve({ default: defaultResponder(deleteHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id]/fields/[fid].ts
+++ b/apps/web/pages/api/documents/[id]/fields/[fid].ts
@@ -28,5 +28,5 @@ async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  DELETE: Promise.resolve({ default: defaultResponder(deleteHandler) }),
+  DELETE: Promise.resolve({ default: defaultResponder(deleteHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id]/fields/index.ts
+++ b/apps/web/pages/api/documents/[id]/fields/index.ts
@@ -96,6 +96,6 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
+  GET: Promise.resolve({ default: defaultResponder(getHandler as any) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id]/recipients/[rid].ts
+++ b/apps/web/pages/api/documents/[id]/recipients/[rid].ts
@@ -25,5 +25,5 @@ async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  DELETE: Promise.resolve({ default: defaultResponder(deleteHandler) }),
+  DELETE: Promise.resolve({ default: defaultResponder(deleteHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id]/recipients/index.ts
+++ b/apps/web/pages/api/documents/[id]/recipients/index.ts
@@ -44,5 +44,5 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id]/send.ts
+++ b/apps/web/pages/api/documents/[id]/send.ts
@@ -56,5 +56,5 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
 });

--- a/apps/web/pages/api/documents/[id]/sign.ts
+++ b/apps/web/pages/api/documents/[id]/sign.ts
@@ -187,5 +187,5 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
 });

--- a/apps/web/pages/api/documents/index.ts
+++ b/apps/web/pages/api/documents/index.ts
@@ -65,6 +65,6 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
+  GET: Promise.resolve({ default: defaultResponder(getHandler as any) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
 });

--- a/apps/web/pages/api/health.ts
+++ b/apps/web/pages/api/health.ts
@@ -11,5 +11,5 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
+  GET: Promise.resolve({ default: defaultResponder(getHandler as any) }),
 });

--- a/apps/web/pages/api/test-sign/[id].ts
+++ b/apps/web/pages/api/test-sign/[id].ts
@@ -19,5 +19,5 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
+  GET: Promise.resolve({ default: defaultResponder(getHandler as any) }),
 });

--- a/apps/web/pages/api/users/index.ts
+++ b/apps/web/pages/api/users/index.ts
@@ -48,6 +48,6 @@ async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  POST: Promise.resolve({ default: defaultResponder(postHandler) }),
-  PATCH: Promise.resolve({ default: defaultResponder(patchHandler) }),
+  POST: Promise.resolve({ default: defaultResponder(postHandler as any) }),
+  PATCH: Promise.resolve({ default: defaultResponder(patchHandler as any) }),
 });

--- a/apps/web/pages/api/users/me.ts
+++ b/apps/web/pages/api/users/me.ts
@@ -19,5 +19,5 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default defaultHandler({
-  GET: Promise.resolve({ default: defaultResponder(getHandler) }),
+  GET: Promise.resolve({ default: defaultResponder(getHandler as any) }),
 });

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -5,6 +5,7 @@ const colors = require("tailwindcss/colors");
 
 module.exports = {
   content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
     "../../packages/ui/**/*.{js,ts,jsx,tsx}",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,14 +17,23 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "../../packages/types/*.d.ts",
     "../../packages/types/next-auth.d.ts",
     "**/*.ts",
-    "**/*.tsx"
-, "../../packages/lib/process-env.d.ts"  ],
-  "exclude": ["node_modules"]
+    "**/*.tsx",
+    "../../packages/lib/process-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.7",
         "prettier-plugin-tailwindcss": "^0.2.5",
-        "turbo": "^1.9.9",
+        "turbo": "^1.10.0",
         "typescript": "4.8.4"
       }
     },
@@ -58,8 +58,9 @@
         "avatar-from-initials": "^1.0.3",
         "base64-arraybuffer": "^1.0.2",
         "bcryptjs": "^2.4.3",
+        "clsx": "^1.2.1",
         "formidable": "^3.2.5",
-        "next": "13.2.4",
+        "next": "^13.4.4",
         "next-auth": "^4.22.0",
         "node-forge": "^1.3.1",
         "node-signpdf": "^1.5.0",
@@ -75,7 +76,8 @@
         "react-resizable": "^3.0.4",
         "react-tooltip": "^5.7.2",
         "short-uuid": "^4.2.2",
-        "string-to-color": "^2.2.2"
+        "string-to-color": "^2.2.2",
+        "tailwind-merge": "^1.12.0"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.3",
@@ -100,11 +102,111 @@
         "typescript": "4.8.4"
       }
     },
+    "apps/web/node_modules/@next/env": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
+      "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
+    },
+    "apps/web/node_modules/@next/swc-darwin-arm64": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
+      "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "apps/web/node_modules/@types/node": {
       "version": "18.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
       "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
       "dev": true
+    },
+    "apps/web/node_modules/next": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
+      "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
+      "dependencies": {
+        "@next/env": "13.4.4",
+        "@swc/helpers": "0.5.1",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.14",
+        "styled-jsx": "5.1.1",
+        "zod": "3.21.4"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=16.8.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "13.4.4",
+        "@next/swc-darwin-x64": "13.4.4",
+        "@next/swc-linux-arm64-gnu": "13.4.4",
+        "@next/swc-linux-arm64-musl": "13.4.4",
+        "@next/swc-linux-x64-gnu": "13.4.4",
+        "@next/swc-linux-x64-musl": "13.4.4",
+        "@next/swc-win32-arm64-msvc": "13.4.4",
+        "@next/swc-win32-ia32-msvc": "13.4.4",
+        "@next/swc-win32-x64-msvc": "13.4.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "fibers": ">= 3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "fibers": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/next/node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.21.4",
@@ -633,6 +735,36 @@
         "glob": "7.1.7"
       }
     },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.2.4",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
@@ -643,6 +775,156 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
+      "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
+      "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
+      "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
+      "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
+      "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
+      "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
+      "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
+      "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -1842,6 +2124,17 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "devOptional": true,
       "peer": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.0",
@@ -3472,6 +3765,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5075,6 +5369,126 @@
       "dev": true,
       "dependencies": {
         "enhanced-resolve": "^5.10.0"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-darwin-x64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
+      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
+      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
+      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
+      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
+      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
+      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
+      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
+      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -6789,6 +7203,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string-to-color": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/string-to-color/-/string-to-color-2.2.2.tgz",
@@ -7151,6 +7573,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.12.0.tgz",
+      "integrity": "sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz",
@@ -7485,27 +7916,40 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.9.tgz",
-      "integrity": "sha512-+ZS66LOT7ahKHxh6XrIdcmf2Yk9mNpAbPEj4iF2cs0cAeaDU3xLVPZFF0HbSho89Uxwhx7b5HBgPbdcjQTwQkg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.0.tgz",
+      "integrity": "sha512-GWxoL2zJduiNaEHz78o74l2jCQEeuUZ3MdpMPz0SpZOvt3nimpvQPNxiyfbqt3U9/V5G375PWKYSbXkVnIbQcA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.9.9",
-        "turbo-darwin-arm64": "1.9.9",
-        "turbo-linux-64": "1.9.9",
-        "turbo-linux-arm64": "1.9.9",
-        "turbo-windows-64": "1.9.9",
-        "turbo-windows-arm64": "1.9.9"
+        "turbo-darwin-64": "1.10.0",
+        "turbo-darwin-arm64": "1.10.0",
+        "turbo-linux-64": "1.10.0",
+        "turbo-linux-arm64": "1.10.0",
+        "turbo-windows-64": "1.10.0",
+        "turbo-windows-arm64": "1.10.0"
       }
     },
+    "node_modules/turbo-darwin-64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.0.tgz",
+      "integrity": "sha512-N0aVGFtBgOKd7pIdUiKREwnDhNHRIvpMJbmUw04c1AqEoTiKAKT6iuzcCozO5N/gYMVr0hxrXgLal5OLYXtcsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.9.tgz",
-      "integrity": "sha512-VyfkXzTJpYLTAQ9krq2myyEq7RPObilpS04lgJ4OO1piq76RNmSpX9F/t9JCaY9Pj/4TL7i0d8PM7NGhwEA5Ag==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.0.tgz",
+      "integrity": "sha512-boXzhaHTS5MsTMv48I/JmYp9/fYplXk5nACUDrqV6nD1hzO5PMn5wNg75ATbpkaMaeuD+hjuobeSxn1p4vpqQg==",
       "cpu": [
         "arm64"
       ],
@@ -7513,6 +7957,58 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.0.tgz",
+      "integrity": "sha512-crKQuS1jrp4vp+Th6EmUqqmAlvYNnzGmwWMLeckmYILrV7zAddu87eJu4hB7V6uV+W1qHZUTw8WXa1w1+8boBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.0.tgz",
+      "integrity": "sha512-Y2fhWe0xepLjl7doIvsJK7mp2h8E+OF6qJsUHRgxFeRWQWi1I6clD2aEQeykHK8Tp+qp8pKFMocj32nFBvuCcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.0.tgz",
+      "integrity": "sha512-uh8rEqH6teaHysEMjinwWBqyNwv4IvgSAwbq/OphP8jObstTYHoR+gFPo8RQUSTaBYy4QVszgi5eO5YLvEQqNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.0.tgz",
+      "integrity": "sha512-JaVj3iM7qyRD6xYGZLL/Gs4mQKfM1zL0f91AwHZLNkk1CrJ6i5kO4ZjhKkwXSpVOTNKW3sX0Q7dExXj85Vv7UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/tweetnacl": {
@@ -7982,6 +8478,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/features": {
       "name": "@documenso/features",
       "version": "0.0.0"
@@ -8360,12 +8864,13 @@
         "avatar-from-initials": "^1.0.3",
         "base64-arraybuffer": "^1.0.2",
         "bcryptjs": "^2.4.3",
+        "clsx": "^1.2.1",
         "dotenv": "^16.0.3",
         "eslint": "8.27.0",
         "eslint-config-next": "13.0.3",
         "file-loader": "^6.2.0",
         "formidable": "^3.2.5",
-        "next": "13.2.4",
+        "next": "^13.4.4",
         "next-auth": "^4.22.0",
         "node-forge": "^1.3.1",
         "node-signpdf": "^1.5.0",
@@ -8385,15 +8890,70 @@
         "short-uuid": "^4.2.2",
         "string-to-color": "^2.2.2",
         "stripe-cli": "^0.1.0",
+        "tailwind-merge": "^1.12.0",
         "tailwindcss": "^3.2.4",
         "typescript": "4.8.4"
       },
       "dependencies": {
+        "@next/env": {
+          "version": "13.4.4",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
+          "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "13.4.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
+          "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
+          "optional": true
+        },
+        "@swc/helpers": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+          "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
         "@types/node": {
           "version": "18.15.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
           "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
           "dev": true
+        },
+        "next": {
+          "version": "13.4.4",
+          "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
+          "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
+          "requires": {
+            "@next/env": "13.4.4",
+            "@next/swc-darwin-arm64": "13.4.4",
+            "@next/swc-darwin-x64": "13.4.4",
+            "@next/swc-linux-arm64-gnu": "13.4.4",
+            "@next/swc-linux-arm64-musl": "13.4.4",
+            "@next/swc-linux-x64-gnu": "13.4.4",
+            "@next/swc-linux-x64-musl": "13.4.4",
+            "@next/swc-win32-arm64-msvc": "13.4.4",
+            "@next/swc-win32-ia32-msvc": "13.4.4",
+            "@next/swc-win32-x64-msvc": "13.4.4",
+            "@swc/helpers": "0.5.1",
+            "busboy": "1.6.0",
+            "caniuse-lite": "^1.0.30001406",
+            "postcss": "8.4.14",
+            "styled-jsx": "5.1.1",
+            "zod": "3.21.4"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "8.4.14",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+              "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+              "requires": {
+                "nanoid": "^3.3.4",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+              }
+            }
+          }
         }
       }
     },
@@ -8530,10 +9090,82 @@
         "glob": "7.1.7"
       }
     },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
+      "optional": true
+    },
     "@next/swc-darwin-arm64": {
       "version": "13.2.4",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
       "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
+      "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
+      "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
+      "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
+      "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
+      "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
+      "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
+      "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
+      "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -9499,6 +10131,14 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "devOptional": true,
       "peer": true
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -10789,6 +11429,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -11940,6 +12581,54 @@
         "styled-jsx": "5.1.1"
       },
       "dependencies": {
+        "@next/swc-darwin-x64": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
+          "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
+          "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
+          "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
+          "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
+          "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
+          "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+          "optional": true
+        },
+        "@next/swc-win32-ia32-msvc": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
+          "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
+          "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+          "optional": true
+        },
         "postcss": {
           "version": "8.4.14",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -13121,6 +13810,11 @@
         "internal-slot": "^1.0.4"
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string-to-color": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/string-to-color/-/string-to-color-2.2.2.tgz",
@@ -13387,6 +14081,11 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tailwind-merge": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.12.0.tgz",
+      "integrity": "sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g=="
+    },
     "tailwindcss": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz",
@@ -13636,23 +14335,58 @@
       }
     },
     "turbo": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.9.tgz",
-      "integrity": "sha512-+ZS66LOT7ahKHxh6XrIdcmf2Yk9mNpAbPEj4iF2cs0cAeaDU3xLVPZFF0HbSho89Uxwhx7b5HBgPbdcjQTwQkg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.0.tgz",
+      "integrity": "sha512-GWxoL2zJduiNaEHz78o74l2jCQEeuUZ3MdpMPz0SpZOvt3nimpvQPNxiyfbqt3U9/V5G375PWKYSbXkVnIbQcA==",
       "dev": true,
       "requires": {
-        "turbo-darwin-64": "1.9.9",
-        "turbo-darwin-arm64": "1.9.9",
-        "turbo-linux-64": "1.9.9",
-        "turbo-linux-arm64": "1.9.9",
-        "turbo-windows-64": "1.9.9",
-        "turbo-windows-arm64": "1.9.9"
+        "turbo-darwin-64": "1.10.0",
+        "turbo-darwin-arm64": "1.10.0",
+        "turbo-linux-64": "1.10.0",
+        "turbo-linux-arm64": "1.10.0",
+        "turbo-windows-64": "1.10.0",
+        "turbo-windows-arm64": "1.10.0"
       }
     },
+    "turbo-darwin-64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.0.tgz",
+      "integrity": "sha512-N0aVGFtBgOKd7pIdUiKREwnDhNHRIvpMJbmUw04c1AqEoTiKAKT6iuzcCozO5N/gYMVr0hxrXgLal5OLYXtcsw==",
+      "dev": true,
+      "optional": true
+    },
     "turbo-darwin-arm64": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.9.tgz",
-      "integrity": "sha512-VyfkXzTJpYLTAQ9krq2myyEq7RPObilpS04lgJ4OO1piq76RNmSpX9F/t9JCaY9Pj/4TL7i0d8PM7NGhwEA5Ag==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.0.tgz",
+      "integrity": "sha512-boXzhaHTS5MsTMv48I/JmYp9/fYplXk5nACUDrqV6nD1hzO5PMn5wNg75ATbpkaMaeuD+hjuobeSxn1p4vpqQg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.0.tgz",
+      "integrity": "sha512-crKQuS1jrp4vp+Th6EmUqqmAlvYNnzGmwWMLeckmYILrV7zAddu87eJu4hB7V6uV+W1qHZUTw8WXa1w1+8boBw==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-arm64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.0.tgz",
+      "integrity": "sha512-Y2fhWe0xepLjl7doIvsJK7mp2h8E+OF6qJsUHRgxFeRWQWi1I6clD2aEQeykHK8Tp+qp8pKFMocj32nFBvuCcg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.0.tgz",
+      "integrity": "sha512-uh8rEqH6teaHysEMjinwWBqyNwv4IvgSAwbq/OphP8jObstTYHoR+gFPo8RQUSTaBYy4QVszgi5eO5YLvEQqNA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-arm64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.0.tgz",
+      "integrity": "sha512-JaVj3iM7qyRD6xYGZLL/Gs4mQKfM1zL0f91AwHZLNkk1CrJ6i5kO4ZjhKkwXSpVOTNKW3sX0Q7dExXj85Vv7UQ==",
       "dev": true,
       "optional": true
     },
@@ -13995,6 +14729,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.7",
     "prettier-plugin-tailwindcss": "^0.2.5",
-    "turbo": "^1.9.9",
+    "turbo": "^1.10.0",
     "typescript": "4.8.4"
   }
 }


### PR DESCRIPTION
@Mythie this version is a lot cleaner thanks to @leerob adding turbo with `globalEnv`

No routes have been migrated to `/app` in this PR. The purpose was to create the `/app` directory, load the fonts, add some metadata and make sure it would build. 

One thing you'll notice is that I appended `as any` to all of the `postHandler` and `getHandler`, without this the build would result in:
```
Type error: Argument of type '(req: NextApiRequest, res: NextApiResponse<any>) => Promise<void>' is not assignable to parameter of type 'Handle<void>'.
```


**Build Result**
```
@documenso/web:build: Route (pages)                              Size     First Load JS
@documenso/web:build: ┌ λ /                                      244 B          90.8 kB
@documenso/web:build: ├   /_app                                  0 B            90.6 kB
@documenso/web:build: ├ ○ /404                                   5.16 kB         119 kB
@documenso/web:build: ├ ○ /500                                   5.11 kB         119 kB
@documenso/web:build: ├ λ /api/auth/[...nextauth]                0 B            90.6 kB
@documenso/web:build: ├ λ /api/auth/signup                       0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents                         0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]                    0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]/fields             0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]/fields/[fid]       0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]/recipients         0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]/recipients/[rid]   0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]/send               0 B            90.6 kB
@documenso/web:build: ├ λ /api/documents/[id]/sign               0 B            90.6 kB
@documenso/web:build: ├ λ /api/health                            0 B            90.6 kB
@documenso/web:build: ├ λ /api/stripe/checkout-session           0 B            90.6 kB
@documenso/web:build: ├ λ /api/stripe/portal-session             0 B            90.6 kB
@documenso/web:build: ├ λ /api/stripe/subscription               0 B            90.6 kB
@documenso/web:build: ├ λ /api/stripe/webhook                    0 B            90.6 kB
@documenso/web:build: ├ λ /api/test-sign/[id]                    0 B            90.6 kB
@documenso/web:build: ├ λ /api/users                             0 B            90.6 kB
@documenso/web:build: ├ λ /api/users/me                          0 B            90.6 kB
@documenso/web:build: ├ λ /dashboard                             3 kB            170 kB
@documenso/web:build: ├ λ /documents                             4.36 kB         185 kB
@documenso/web:build: ├ λ /documents/[id]                        7.86 kB         180 kB
@documenso/web:build: ├ λ /documents/[id]/recipients             3.72 kB         184 kB
@documenso/web:build: ├ λ /documents/[id]/sign                   15.3 kB         145 kB
@documenso/web:build: ├ λ /documents/[id]/signed                 1.51 kB         116 kB
@documenso/web:build: ├ λ /login                                 6.24 kB         129 kB
@documenso/web:build: ├ ○ /settings                              222 B           177 kB
@documenso/web:build: ├ ○ /settings/account                      261 B           177 kB
@documenso/web:build: ├ ○ /settings/billing                      268 B           177 kB
@documenso/web:build: ├ ○ /settings/password                     262 B           177 kB
@documenso/web:build: ├ ○ /settings/profile                      261 B           177 kB
@documenso/web:build: └ λ /signup                                2.29 kB         125 kB
@documenso/web:build: + First Load JS shared by all              98.8 kB
@documenso/web:build:   ├ chunks/framework-25cb315fa3c61a79.js   45.3 kB
@documenso/web:build:   ├ chunks/main-2324ff1d8f14b74b.js        27.8 kB
@documenso/web:build:   ├ chunks/pages/_app-e0c4133317461815.js  15.5 kB
@documenso/web:build:   ├ chunks/webpack-77aaf8191d94da09.js     2.04 kB
@documenso/web:build:   └ css/42b4b9137f81990f.css               8.2 kB
@documenso/web:build: 
@documenso/web:build: λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
@documenso/web:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
@documenso/web:build: 

 Tasks:    1 successful, 1 total
Cached:    1 cached, 1 total
  Time:    3.285s >>> FULL TURBO
```

[More on incremental migration from Next.js docs.](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#migrating-from-pages-to-app)