### PR TITLE
Fix typos in example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@
 # Option 3: Use the provided dx setup (RECOMMENDED)
 #   => postgres://documenso:password@127.0.0.1:54320/documenso
 #
-# ⚠ WARNING: The test database can be resetted or taken offline at any point.
-# ⚠ WARNING: Please be aware that nothing written to the test databae is private.
+# ⚠ WARNING: The test database can be reset or taken offline at any point.
+# ⚠ WARNING: Please be aware that nothing written to the test database is private.
 DATABASE_URL=''
 
 # URL


### PR DESCRIPTION
Just noticed some typos while setting up a local copy and thought I'd fix them up real quick.