### PR TITLE
improved loading state for /document/id

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/loading.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/loading.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+import { ChevronLeft, Loader } from 'lucide-react';
+
+export default function Loading() {
+  return (
+    <div className="mx-auto -mt-4 flex w-full max-w-screen-xl flex-col px-4 md:px-8">
+      <Link href="/documents" className="flex grow-0 items-center text-[#7AC455] hover:opacity-80">
+        <ChevronLeft className="mr-2 inline-block h-5 w-5" />
+        Documents
+      </Link>
+      <h1 className="mt-4 max-w-xs grow-0 truncate text-2xl font-semibold md:text-3xl">
+        Loading Document...
+      </h1>
+      <div className="mt-8 grid min-h-[80vh] w-full grid-cols-12 gap-x-8">
+        <div className="dark:bg-background border-documenso col-span-7 rounded-xl border-2 bg-white/50 p-2 before:rounded-xl">
+          <div className="flex min-h-[80vh] flex-col items-center justify-center">
+            <Loader className="text-documenso h-12 w-12 animate-spin" />
+
+            <p className="text-muted-foreground mt-4">Loading document...</p>
+          </div>
+        </div>
+
+        <div className="bg-background border-documenso col-span-5  rounded-xl border-2 before:rounded-xl" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
@@ -38,7 +38,7 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
       <Link href="/documents" className="flex items-center text-[#7AC455] hover:opacity-80">
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
-        Dashboard
+        Documents
       </Link>
 
       <h1

--- a/apps/web/src/components/(dashboard)/pdf-viewer/pdf-viewer.tsx
+++ b/apps/web/src/components/(dashboard)/pdf-viewer/pdf-viewer.tsx
@@ -120,10 +120,10 @@ export const PDFViewer = ({ className, document, onPageClick, ...props }: PDFVie
         onLoadSuccess={(d) => onDocumentLoaded(d)}
         externalLinkTarget="_blank"
         loading={
-          <div className="flex min-h-[80vh] flex-col items-center justify-center bg-white/50">
-            <Loader className="h-12 w-12 animate-spin text-slate-500" />
+          <div className="dark:bg-background flex min-h-[80vh] flex-col items-center justify-center bg-white/50">
+            <Loader className="text-documenso h-12 w-12 animate-spin" />
 
-            <p className="mt-4 text-slate-500">Loading document...</p>
+            <p className="text-muted-foreground mt-4">Loading document...</p>
           </div>
         }
       >

--- a/apps/web/src/components/forms/edit-document.tsx
+++ b/apps/web/src/components/forms/edit-document.tsx
@@ -22,7 +22,7 @@ const PDFViewer = dynamic(async () => import('~/components/(dashboard)/pdf-viewe
   ssr: false,
   loading: () => (
     <div className="dark:bg-background flex min-h-[80vh] flex-col items-center justify-center bg-white/50">
-      <Loader className="text-muted-foreground h-12 w-12 animate-spin" />
+      <Loader className="text-documenso h-12 w-12 animate-spin" />
 
       <p className="text-muted-foreground mt-4">Loading document...</p>
     </div>


### PR DESCRIPTION
Added a `loading.tsx` to `/documents/[id]`

>[**Instant Loading States**](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming#instant-loading-states)
An instant loading state is fallback UI that is shown immediately upon navigation. You can pre-render loading indicators such as skeletons and spinners, or a small but meaningful part of future screens such as a cover photo, title, etc. This helps users understand the app is responding and provides a better user experience.

I styled it so that it would flow seamlessly into the other loading client side loading states provided by `edit-documents.tsx` and `pdf-viewer.tsx`

### **Video:**
https://www.loom.com/share/e9ff4de4fb6647ffa1d04986d57cfd38?sid=a5cd2fe2-a7ee-4a58-a1c9-7d31562d120f

### **Minor Fix:**
The back link on the `/documents/[id]` page had a text of `Dashboard` even though it led to `/documents` The link text was changed to `Documents` for clarity.

### **Build Output:**
```bash
web % npm run build

> @documenso/web@0.1.0 build
> next build

...
...
...

Route (app)                                Size     First Load JS
┌ ○ /                                      135 B          77.6 kB
├ λ /dashboard                             0 B                0 B
├ λ /documents                             0 B                0 B
├ λ /documents/[id]                        0 B                0 B
├ λ /settings                              0 B                0 B
├ λ /settings/billing                      0 B                0 B
├ λ /settings/password                     0 B                0 B
├ λ /settings/profile                      0 B                0 B
├ ○ /signin                                0 B                0 B
└ ○ /signup                                0 B                0 B
+ First Load JS shared by all              77.5 kB
  ├ chunks/7fd0f9f1-3fb3dc3e14815666.js    50.5 kB
  ├ chunks/9-cf592fc7a319a8e7.js           24.4 kB
  ├ chunks/main-app-9a6c377ca6c4fdfa.js    211 B
  └ chunks/webpack-d4c2325dbbeb6494.js     2.33 kB

Route (pages)                              Size     First Load JS
┌ ○ /404                                   178 B          86.7 kB
├ λ /api/auth/[...nextauth]                0 B            86.5 kB
├ λ /api/claim-plan                        0 B            86.5 kB
├ λ /api/document/create                   0 B            86.5 kB
├ λ /api/stripe/webhook                    0 B            86.5 kB
└ λ /api/trpc/[trpc]                       0 B            86.5 kB
+ First Load JS shared by all              86.5 kB
  ├ chunks/main-c32231f5001c0b96.js        84 kB
  ├ chunks/pages/_app-415a5670032b79f5.js  190 B
  └ chunks/webpack-d4c2325dbbeb6494.js     2.33 kB

ƒ Middleware                               22.9 kB

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
```

