### PR TITLE
Doc 210 fix docker compose name attribute error

### DIFF
--- a/docker/compose-without-app.yml
+++ b/docker/compose-without-app.yml
@@ -1,4 +1,3 @@
-name: documenso
 services:
   database:
     image: postgres:15

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "db-migrate:dev": "prisma migrate dev",
     "db-seed": "prisma db seed",
     "db-studio": "prisma studio",
-    "docker:compose-up": "docker compose -f ./docker/compose-without-app.yml up -d || docker-compose -f ./docker/compose-without-app.yml up -d",
-    "docker:compose-down": "docker compose -f ./docker/compose-without-app.yml down || docker-compose -f ./docker/compose-without-app.yml down",
+    "docker:compose-up": "docker compose -p documenso -f ./docker/compose-without-app.yml up -d || docker-compose -p documenso -f ./docker/compose-without-app.yml up -d",
+    "docker:compose-down": "docker compose -p documenso -f ./docker/compose-without-app.yml down || docker-compose -p documenso -f ./docker/compose-without-app.yml down",
     "stripe:listen": "stripe listen --forward-to localhost:3000/api/stripe/webhook",
     "dx": "npm install && run-s docker:compose-up db-migrate:dev",
     "d": "npm install && run-s docker:compose-up db-migrate:dev && npm run db-seed && npm run dev"


### PR DESCRIPTION
This PR addresses an issue where Docker Compose would throw an error due to the invalid 'name' attribute at the top level of our Docker Compose configuration file. To solve this, the PR makes the following changes:

1. Removes the 'name' attribute from the Docker Compose configuration (docker/compose-without-app.yml).
2. Adds the -p documenso option to our Docker Compose commands in package.json. This sets the project name to "documenso", allowing us to manage resources more easily when running multiple Docker Compose projects.

Related issue: https://github.com/documenso/documenso/issues/210