### PR TITLE
linking card metrics to filtered /documents

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -38,9 +38,15 @@ export default async function DashboardPage() {
       <h1 className="text-4xl font-semibold">Dashboard</h1>
 
       <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
-        <CardMetric icon={FileCheck} title="Completed" value={stats.COMPLETED} />
-        <CardMetric icon={File} title="Drafts" value={stats.DRAFT} />
-        <CardMetric icon={Clock} title="Pending" value={stats.PENDING} />
+        <Link href={'/documents?status=COMPLETED'} passHref>
+          <CardMetric icon={FileCheck} title="Completed" value={stats.COMPLETED} />
+        </Link>
+        <Link href={'/documents?status=DRAFT'} passHref>
+          <CardMetric icon={File} title="Drafts" value={stats.DRAFT} />
+        </Link>
+        <Link href={'/documents?status=PENDING'} passHref>
+          <CardMetric icon={Clock} title="Pending" value={stats.PENDING} />
+        </Link>
       </div>
 
       <div className="mt-12">


### PR DESCRIPTION
### **Summary**
Wrapped `<CardMetric />` with `<Link>` allowing for a one-click shortcut to filtered /documents page.

### **Video**
https://www.loom.com/share/5dd84e1e268c428aa7e5fab2fe008021?sid=2fa3c4ee-96dc-46be-964d-9feed5e004fa

