### PR TITLE
Correct readme logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center" style="margin-top: 120px">
-  <a href="https://github.com/documenso/documenso.com">
+  <a href="https://github.com/documenso/documenso">
    <img width="250px" src="https://github.com/documenso/documenso/assets/1309312/cd7823ec-4baa-40b9-be78-4acb3b1c73cb" alt="Documenso Logo">
   </a>
 


### PR DESCRIPTION
Correct the logo url in readme as it currently points to a repository that doesn't exist. 