### PR TITLE
ci: create build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Get npm cache directory
-        shell: bash
-        run: |
-          echo "CACHE_PATH=$(npm config get cache)" >> $GITHUB_ENV
-      - name: Setup npm cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATH }}
-          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-cache-
+          cache: npm
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build
-        run: npm run build --workspaces
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: "Continuous Integration"
+
+on:
+  push:
+    branches: [ "feat/refresh" ]
+  pull_request:
+    branches: [ "feat/refresh" ]
+
+env:
+  HUSKY: 0
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Get npm cache directory
+        shell: bash
+        run: |
+          echo "CACHE_PATH=$(npm config get cache)" >> $GITHUB_ENV
+      - name: Setup npm cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_PATH }}
+          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-cache-
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build
+        run: npm run build --workspaces


### PR DESCRIPTION
This creates an continuous integration workflow to ensure future pull requests successfully build. We'll want to update the branches to `main` once the refresh branch is released. 

You'll want to enable Actions in the repository/org settings, if it is disabled. 

Test local repo: https://github.com/nsylke/documenso/actions/runs/5885492640