### PR TITLE
Fixes Showing ask null from SigningEmail Template

### DIFF
--- a/packages/lib/mail/signingRequestTemplate.ts
+++ b/packages/lib/mail/signingRequestTemplate.ts
@@ -18,7 +18,7 @@ export const signingRequestTemplate = (
   </p>
   <hr size="1" style="height:1px;border:none;color:#e0e0e0;background-color:#e0e0e0">
   Click the button to view "${document.title}".<br>
-  <small>If you have questions about this document, you should ask ${user.name}.</small>
+  <small>If you have questions about this document, you should ask ${user.name ?? user.email}.</small>
   <hr size="1" style="height:1px;border:none;color:#e0e0e0;background-color:#e0e0e0">
   <p style="margin-top: 14px;">
     <small>Want to send you own signing links? <a href="https://documenso.com">Hosted Documenso is here!</a>.</small>


### PR DESCRIPTION
![Screenshot 2023-08-18 at 5 52 02 PM](https://github.com/documenso/documenso/assets/14201280/fd9913e9-c005-4a88-a77f-8cd097c1b6a3)
