### PR TITLE
chore: ignore intellij editor settings and some of vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,13 @@ yarn-error.log*
 
 # contentlayer
 .contentlayer
+
+# intellij
+.idea
+
+# vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
Ignore all intellij/webstorm settings and ignore all of vscode settings except for `settings`, `tasks`, `launch` and `extensions`. 