### PR TITLE
fix: use -p cli option for next dev

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "dev": "PORT=3001 next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "dev": "PORT=3000 next dev",
+    "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
Use the built-in `-p` cli option in next for handling port. This is to support Windows, another option would be to use [`cross-env`](https://www.npmjs.com/package/cross-env). 