### PR TITLE
feat: set min/max lengths and autocomplete for password

### DIFF
--- a/apps/web/src/components/forms/password.tsx
+++ b/apps/web/src/components/forms/password.tsx
@@ -18,8 +18,8 @@ import { FormErrorMessage } from '../form/form-error-message';
 
 export const ZPasswordFormSchema = z
   .object({
-    password: z.string().min(6),
-    repeatedPassword: z.string().min(6),
+    password: z.string().min(6).max(72),
+    repeatedPassword: z.string().min(6).max(72),
   })
   .refine((data) => data.password === data.repeatedPassword, {
     message: 'Passwords do not match',
@@ -92,6 +92,8 @@ export const PasswordForm = ({ className }: PasswordFormProps) => {
         <Input
           id="password"
           type="password"
+          minLength={6}
+          maxLength={72}
           className="bg-background mt-2"
           {...register('password')}
         />
@@ -107,6 +109,8 @@ export const PasswordForm = ({ className }: PasswordFormProps) => {
         <Input
           id="repeated-password"
           type="password"
+          minLength={6}
+          maxLength={72}
           className="bg-background mt-2"
           {...register('repeatedPassword')}
         />

--- a/apps/web/src/components/forms/password.tsx
+++ b/apps/web/src/components/forms/password.tsx
@@ -94,6 +94,7 @@ export const PasswordForm = ({ className }: PasswordFormProps) => {
           type="password"
           minLength={6}
           maxLength={72}
+          autoComplete="new-password"
           className="bg-background mt-2"
           {...register('password')}
         />
@@ -111,6 +112,7 @@ export const PasswordForm = ({ className }: PasswordFormProps) => {
           type="password"
           minLength={6}
           maxLength={72}
+          autoComplete="new-password"
           className="bg-background mt-2"
           {...register('repeatedPassword')}
         />

--- a/apps/web/src/components/forms/signin.tsx
+++ b/apps/web/src/components/forms/signin.tsx
@@ -15,7 +15,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export const ZSignInFormSchema = z.object({
   email: z.string().email().min(1),
-  password: z.string().min(1),
+  password: z.string().min(6).max(72),
 });
 
 export type TSignInFormSchema = z.infer<typeof ZSignInFormSchema>;
@@ -99,6 +99,8 @@ export const SignInForm = ({ className }: SignInFormProps) => {
         <Input
           id="password"
           type="password"
+          minLength={6}
+          maxLength={72}
           className="bg-background mt-2"
           {...register('password')}
         />

--- a/apps/web/src/components/forms/signin.tsx
+++ b/apps/web/src/components/forms/signin.tsx
@@ -101,6 +101,7 @@ export const SignInForm = ({ className }: SignInFormProps) => {
           type="password"
           minLength={6}
           maxLength={72}
+          autoComplete="current-password"
           className="bg-background mt-2"
           {...register('password')}
         />

--- a/apps/web/src/components/forms/signup.tsx
+++ b/apps/web/src/components/forms/signup.tsx
@@ -18,7 +18,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 export const ZSignUpFormSchema = z.object({
   name: z.string().min(1),
   email: z.string().email().min(1),
-  password: z.string().min(1),
+  password: z.string().min(6).max(72),
 });
 
 export type TSignUpFormSchema = z.infer<typeof ZSignUpFormSchema>;
@@ -105,6 +105,8 @@ export const SignUpForm = ({ className }: SignUpFormProps) => {
         <Input
           id="password"
           type="password"
+          minLength={6}
+          maxLength={72}
           className="bg-background mt-2"
           {...register('password')}
         />

--- a/apps/web/src/components/forms/signup.tsx
+++ b/apps/web/src/components/forms/signup.tsx
@@ -107,6 +107,7 @@ export const SignUpForm = ({ className }: SignUpFormProps) => {
           type="password"
           minLength={6}
           maxLength={72}
+          autoComplete="new-password"
           className="bg-background mt-2"
           {...register('password')}
         />


### PR DESCRIPTION
I adjusted the `minLength` to 6 characters since the password change already had it at 6 characters but the signup/signin had it at 1 character. Lets make it consistent across the platform! 

Additionally, I added the `maxLength` to 72 characters since bcrypt supports up 72 bytes. We're currently doing a silent truncation which isn't ideal. In the future, if people request longer passwords, we could look into prehashing the password using `bcrypt(hmac-sha256(salt, password))` to avoid hash shucking and allow passwords longer than 72 characters. Alternatively, we could look at other algorithms like `scrypt`, `pbkdf2` or even `argon2id`.

**Edit:** Added `autoComplete` based on @adithyaakrishna suggestion. This configures password managers to either autofill with the current password or generate a new password. 