### PR TITLE
fix: background image on signin/signup loads slower than the components

### DIFF
--- a/apps/web/src/app/(unauthenticated)/signin/page.tsx
+++ b/apps/web/src/app/(unauthenticated)/signin/page.tsx
@@ -14,6 +14,7 @@ export default function SignInPage() {
             src={backgroundPattern}
             alt="background pattern"
             className="dark:brightness-95 dark:invert dark:sepia"
+            priority={true}
           />
         </div>
 

--- a/apps/web/src/app/(unauthenticated)/signup/page.tsx
+++ b/apps/web/src/app/(unauthenticated)/signup/page.tsx
@@ -14,6 +14,7 @@ export default function SignUpPage() {
             src={backgroundPattern}
             alt="background pattern"
             className="dark:brightness-95 dark:invert dark:sepia"
+            priority={true}
           />
         </div>
 


### PR DESCRIPTION
**Description:**

This PR sets `priority={true}` param in `nextjs/Image` to pre-load the images when user opens sign-in or sign-up pages