### PR TITLE
docs: fix typo in CONTRUBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ If you plan to contribute to Documenso, please take a moment to feel awesome ✨
 ## Before getting started
 
 - Before jumping into a PR be sure to search [existing PRs](https://github.com/documenso/documenso/pulls) or [issues](https://github.com/documenso/documenso/issues) for an open or closed item that relates to your submission.
-- Select and issue from [here](https://github.com/documenso/documenso/issues) or create a new one
+- Select an issue from [here](https://github.com/documenso/documenso/issues) or create a new one
 - Consider the results from the discussion in the issue
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We're currently working on a redesign of the application including a revamp of t
 
 ## Contributing
 
-- To contribute please see our [contribution guide](https://github.com/documenso/documenso/blob/main/CONTRIBUTING.md).
+- To contribute, please see our [contribution guide](https://github.com/documenso/documenso/blob/main/CONTRIBUTING.md).
 
 ## Contact us
 


### PR DESCRIPTION
# What?
This PR fixes a typo in CONTRIBUTING.md

before: 
<img width="1042" alt="Screenshot 2023-08-29 at 7 59 15 PM" src="https://github.com/documenso/documenso/assets/79561774/4ed18529-eaf9-4ceb-bc14-60cd65b70a0f">

# What changes I have made?

It should be "Select an issue from here or create a new one"
