### PR TITLE
chore: change root package.json name

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "^2.5.1",
     "turbo": "^1.9.3"
   },
-  "name": "documenso.next",
+  "name": "@documenso/root",
   "packageManager": "npm@8.19.2",
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
Maybe this was an oversight, or just opinionated, but with rest of apps and packages having `@documenso/[name]`, it makes sense to keep the root package.json consistent and name it `@documenso/root`. 