### PR TITLE
fix: user name not updatable

### DIFF
--- a/apps/web/src/components/forms/profile.tsx
+++ b/apps/web/src/components/forms/profile.tsx
@@ -44,7 +44,7 @@ export const ProfileForm = ({ className, user }: ProfileFormProps) => {
   } = useForm<TProfileFormSchema>({
     values: {
       name: user.name ?? '',
-      signature: user.signature ? user.signature : '',
+      signature: user.signature || '',
     },
     resolver: zodResolver(ZProfileFormSchema),
   });

--- a/apps/web/src/components/forms/profile.tsx
+++ b/apps/web/src/components/forms/profile.tsx
@@ -44,7 +44,7 @@ export const ProfileForm = ({ className, user }: ProfileFormProps) => {
   } = useForm<TProfileFormSchema>({
     values: {
       name: user.name ?? '',
-      signature: '',
+      signature: user.signature ? user.signature : '',
     },
     resolver: zodResolver(ZProfileFormSchema),
   });


### PR DESCRIPTION
fix `Signature Pad cannot be empty` error while updating the username