### PR TITLE
feat: add avatar email fallback

### DIFF
--- a/apps/web/src/components/(dashboard)/avatar/stack-avatar.tsx
+++ b/apps/web/src/components/(dashboard)/avatar/stack-avatar.tsx
@@ -15,7 +15,7 @@ export type StackAvatarProps = {
   type: 'unsigned' | 'waiting' | 'opened' | 'completed';
 };
 
-export const StackAvatar = ({ first, zIndex, fallbackText, type }: StackAvatarProps) => {
+export const StackAvatar = ({ first, zIndex, fallbackText = '', type }: StackAvatarProps) => {
   let classes = '';
   let zIndexClass = '';
   const firstClass = first ? '' : '-ml-3';
@@ -48,7 +48,7 @@ export const StackAvatar = ({ first, zIndex, fallbackText, type }: StackAvatarPr
         ${firstClass}
         dark:border-border h-10 w-10 border-2 border-solid border-white`}
     >
-      <AvatarFallback className={classes}>{fallbackText ?? 'UK'}</AvatarFallback>
+      <AvatarFallback className={classes}>{fallbackText}</AvatarFallback>
     </Avatar>
   );
 };

--- a/apps/web/src/components/(dashboard)/avatar/stack-avatars-with-tooltip.tsx
+++ b/apps/web/src/components/(dashboard)/avatar/stack-avatars-with-tooltip.tsx
@@ -1,5 +1,5 @@
-import { recipientAvatarFallback } from '@documenso/lib/client-only/recipient-avatar-fallback';
 import { getRecipientType } from '@documenso/lib/client-only/recipient-type';
+import { recipientAbbreviation } from '@documenso/lib/utils/recipient-formatter';
 import { Recipient } from '@documenso/prisma/client';
 import {
   Tooltip,
@@ -56,7 +56,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={recipientAvatarFallback(recipient)}
+                      fallbackText={recipientAbbreviation(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>
@@ -73,7 +73,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={recipientAvatarFallback(recipient)}
+                      fallbackText={recipientAbbreviation(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>
@@ -90,7 +90,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={recipientAvatarFallback(recipient)}
+                      fallbackText={recipientAbbreviation(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>
@@ -107,7 +107,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={recipientAvatarFallback(recipient)}
+                      fallbackText={recipientAbbreviation(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>

--- a/apps/web/src/components/(dashboard)/avatar/stack-avatars-with-tooltip.tsx
+++ b/apps/web/src/components/(dashboard)/avatar/stack-avatars-with-tooltip.tsx
@@ -1,4 +1,4 @@
-import { initials } from '@documenso/lib/client-only/recipient-initials';
+import { recipientAvatarFallback } from '@documenso/lib/client-only/recipient-avatar-fallback';
 import { getRecipientType } from '@documenso/lib/client-only/recipient-type';
 import { Recipient } from '@documenso/prisma/client';
 import {
@@ -56,7 +56,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={initials(recipient.name)}
+                      fallbackText={recipientAvatarFallback(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>
@@ -73,7 +73,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={initials(recipient.name)}
+                      fallbackText={recipientAvatarFallback(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>
@@ -90,7 +90,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={initials(recipient.name)}
+                      fallbackText={recipientAvatarFallback(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>
@@ -107,7 +107,7 @@ export const StackAvatarsWithTooltip = ({
                       first={true}
                       key={recipient.id}
                       type={getRecipientType(recipient)}
-                      fallbackText={initials(recipient.name)}
+                      fallbackText={recipientAvatarFallback(recipient)}
                     />
                     <span className="text-sm text-gray-500">{recipient.email}</span>
                   </div>

--- a/apps/web/src/components/(dashboard)/avatar/stack-avatars.tsx
+++ b/apps/web/src/components/(dashboard)/avatar/stack-avatars.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { initials } from '@documenso/lib/client-only/recipient-initials';
+import { recipientAvatarFallback } from '@documenso/lib/client-only/recipient-avatar-fallback';
 import { getRecipientType } from '@documenso/lib/client-only/recipient-type';
 import { Recipient } from '@documenso/prisma/client';
 
@@ -26,7 +26,7 @@ export function StackAvatars({ recipients }: { recipients: Recipient[] }) {
           first={first}
           zIndex={String(zIndex - index * 10)}
           type={lastItemText && index === 4 ? 'unsigned' : getRecipientType(recipient)}
-          fallbackText={lastItemText ? lastItemText : initials(recipient.name)}
+          fallbackText={lastItemText ? lastItemText : recipientAvatarFallback(recipient)}
         />
       );
     });

--- a/apps/web/src/components/(dashboard)/avatar/stack-avatars.tsx
+++ b/apps/web/src/components/(dashboard)/avatar/stack-avatars.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { recipientAvatarFallback } from '@documenso/lib/client-only/recipient-avatar-fallback';
 import { getRecipientType } from '@documenso/lib/client-only/recipient-type';
+import { recipientAbbreviation } from '@documenso/lib/utils/recipient-formatter';
 import { Recipient } from '@documenso/prisma/client';
 
 import { StackAvatar } from './stack-avatar';
@@ -26,7 +26,7 @@ export function StackAvatars({ recipients }: { recipients: Recipient[] }) {
           first={first}
           zIndex={String(zIndex - index * 10)}
           type={lastItemText && index === 4 ? 'unsigned' : getRecipientType(recipient)}
-          fallbackText={lastItemText ? lastItemText : recipientAvatarFallback(recipient)}
+          fallbackText={lastItemText ? lastItemText : recipientAbbreviation(recipient)}
         />
       );
     });

--- a/apps/web/src/components/(dashboard)/layout/profile-dropdown.tsx
+++ b/apps/web/src/components/(dashboard)/layout/profile-dropdown.tsx
@@ -15,7 +15,7 @@ import {
 import { signOut } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 
-import { initials } from '@documenso/lib/client-only/recipient-initials';
+import { recipientInitials } from '@documenso/lib/utils/recipient-formatter';
 import { User } from '@documenso/prisma/client';
 import { Avatar, AvatarFallback } from '@documenso/ui/primitives/avatar';
 import { Button } from '@documenso/ui/primitives/button';
@@ -41,7 +41,9 @@ export const ProfileDropdown = ({ user }: ProfileDropdownProps) => {
 
   const isBillingEnabled = getFlag('app_billing');
 
-  const avatarFallback = user.name ? initials(user.name) : user.email.slice(0, 1).toUpperCase();
+  const avatarFallback = user.name
+    ? recipientInitials(user.name)
+    : user.email.slice(0, 1).toUpperCase();
 
   return (
     <DropdownMenu>

--- a/apps/web/src/components/(dashboard)/layout/profile-dropdown.tsx
+++ b/apps/web/src/components/(dashboard)/layout/profile-dropdown.tsx
@@ -15,6 +15,7 @@ import {
 import { signOut } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 
+import { initials } from '@documenso/lib/client-only/recipient-initials';
 import { User } from '@documenso/prisma/client';
 import { Avatar, AvatarFallback } from '@documenso/ui/primitives/avatar';
 import { Button } from '@documenso/ui/primitives/button';
@@ -40,19 +41,14 @@ export const ProfileDropdown = ({ user }: ProfileDropdownProps) => {
 
   const isBillingEnabled = getFlag('app_billing');
 
-  const initials =
-    user.name
-      ?.split(' ')
-      .map((name: string) => name.slice(0, 1).toUpperCase())
-      .slice(0, 2)
-      .join('') ?? 'UK';
+  const avatarFallback = user.name ? initials(user.name) : user.email.slice(0, 1).toUpperCase();
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="relative h-10 w-10 rounded-full">
           <Avatar className="h-10 w-10">
-            <AvatarFallback>{initials}</AvatarFallback>
+            <AvatarFallback>{avatarFallback}</AvatarFallback>
           </Avatar>
         </Button>
       </DropdownMenuTrigger>

--- a/packages/lib/client-only/recipient-avatar-fallback.ts
+++ b/packages/lib/client-only/recipient-avatar-fallback.ts
@@ -1,0 +1,7 @@
+import { Recipient } from '@documenso/prisma/client';
+
+import { initials } from './recipient-initials';
+
+export const recipientAvatarFallback = (recipient: Recipient) => {
+  return initials(recipient.name) || recipient.email.slice(0, 1).toUpperCase();
+};

--- a/packages/lib/client-only/recipient-avatar-fallback.ts
+++ b/packages/lib/client-only/recipient-avatar-fallback.ts
@@ -1,7 +1,0 @@
-import { Recipient } from '@documenso/prisma/client';
-
-import { initials } from './recipient-initials';
-
-export const recipientAvatarFallback = (recipient: Recipient) => {
-  return initials(recipient.name) || recipient.email.slice(0, 1).toUpperCase();
-};

--- a/packages/lib/client-only/recipient-initials.ts
+++ b/packages/lib/client-only/recipient-initials.ts
@@ -1,6 +1,0 @@
-export const initials = (text: string) =>
-  text
-    ?.split(' ')
-    .map((name: string) => name.slice(0, 1).toUpperCase())
-    .slice(0, 2)
-    .join('');

--- a/packages/lib/client-only/recipient-initials.ts
+++ b/packages/lib/client-only/recipient-initials.ts
@@ -3,4 +3,4 @@ export const initials = (text: string) =>
     ?.split(' ')
     .map((name: string) => name.slice(0, 1).toUpperCase())
     .slice(0, 2)
-    .join('') ?? 'UK';
+    .join('');

--- a/packages/lib/utils/recipient-formatter.ts
+++ b/packages/lib/utils/recipient-formatter.ts
@@ -1,0 +1,12 @@
+import { Recipient } from '@documenso/prisma/client';
+
+export const recipientInitials = (text: string) =>
+  text
+    .split(' ')
+    .map((name: string) => name.slice(0, 1).toUpperCase())
+    .slice(0, 2)
+    .join('');
+
+export const recipientAbbreviation = (recipient: Recipient) => {
+  return recipientInitials(recipient.name) || recipient.email.slice(0, 1).toUpperCase();
+};


### PR DESCRIPTION
Added a fallback to avatars so that when no name is provided, it will use the first letter of the email if possible.

Examples:
- Recipient John Doe (foo@bar.com) will have the fallback text be 'JD'
- Recipient with no name (foo@bar.com) will have the fallback text be 'F'
