### PR TITLE
Fix: Multiple network requests on longer "Enter/Return" key press to improve backend performance.

### DIFF
--- a/apps/web/components/settings.tsx
+++ b/apps/web/components/settings.tsx
@@ -61,24 +61,24 @@ export default function Setttings() {
 
   const [savingTimeout, setSavingTimeout] = useState<any>();
   const [password, setPassword] = useState("");
-  function handleNameChange(e: ChangeEvent<HTMLInputElement>): void {
-    let u = { ...user };
-    u.name = e.target.value;
-    setUser(u);
+
+  function updateUserDebounce(newUser: typeof user, debounceTime: number) {
     clearTimeout(savingTimeout);
     const t = setTimeout(() => {
-      updateUser(u);
-    }, 1000);
+      updateUser(newUser);
+    }, debounceTime);
 
     setSavingTimeout(t);
   }
 
-  const handleKeyPress = (event: any) => {
-    if (event.key === "Enter") {
-      clearTimeout(savingTimeout);
-      updateUser(user);
-    }
-  };
+  function handleNameChange(e: ChangeEvent<HTMLInputElement>): void {
+    let u = { ...user };
+    u.name = e.target.value;
+    setUser(u);
+    updateUserDebounce(u, 1000);
+  }
+
+  const handleKeyPress = (event: any) => event.key === "Enter" && updateUserDebounce(user, 300);
 
   return (
     <div>


### PR DESCRIPTION
---
name: Pull Request
about: Multiple network requests on longer "Enter/Return" key press to improve backend performance.
---

## Description

Debounces network requests when a user presses and holds "Enter/Return" key on settings page while updating their name 
Fixes multiple network requests on longer "Enter/Return" key press to improve backend performance.

## Related Issue

Addresses #364

## Changes Made

This PR uses the existing implementation to debounce network request when a holds "Enter/Return" key while updating there name on `/settings/profile` route.

This creates a higher order function `updateUserDebounce(user,duration)`  to prevent multiple network request sent.

## Checklist


- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have followed the project's coding style guidelines.


