### PR TITLE
fix: cancel button handler

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/form.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/form.tsx
@@ -101,6 +101,7 @@ export const SigningForm = ({ document, recipient, fields }: SigningFormProps) =
                 className="dark:bg-muted dark:hover:bg-muted/80 w-full  bg-black/5 hover:bg-black/10"
                 variant="secondary"
                 size="lg"
+                onClick={() => router.back()}
               >
                 Cancel
               </Button>


### PR DESCRIPTION
It appears that there may have been an oversight in the code, as the cancel button did not have any associated action. I have addressed this issue by adding a router.back function to facilitate a return to the home page.