### PR TITLE
fix: disable cancel button when there is no window history

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/form.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/form.tsx
@@ -120,6 +120,7 @@ export const SigningForm = ({ document, recipient, fields }: SigningFormProps) =
                 className="dark:bg-muted dark:hover:bg-muted/80 w-full  bg-black/5 hover:bg-black/10"
                 variant="secondary"
                 size="lg"
+                disabled={typeof window !== 'undefined' && window.history.length <= 1}
                 onClick={() => router.back()}
               >
                 Cancel

--- a/packages/lib/server-only/document/viewed-document.ts
+++ b/packages/lib/server-only/document/viewed-document.ts
@@ -14,7 +14,6 @@ export const viewedDocument = async ({ token }: ViewedDocumentOptions) => {
   });
 
   if (!recipient) {
-    console.warn(`No recipient found for token ${token}`);
     return;
   }
 


### PR DESCRIPTION
Disable the cancel button when there are 1 or fewer entries in `window.history`, this enables cancellation to go back when signing a document in the Inbox while disabling it when navigating from an email.

Resolves #446 