### PR TITLE
fix: update icons

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -31,7 +31,7 @@
     "react-confetti": "^6.1.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.9",
-    "react-icons": "^4.8.0",
+    "react-icons": "^4.11.0",
     "recharts": "^2.7.2",
     "sharp": "0.32.5",
     "typescript": "5.1.6",

--- a/apps/marketing/src/components/(marketing)/callout.tsx
+++ b/apps/marketing/src/components/(marketing)/callout.tsx
@@ -2,8 +2,8 @@
 
 import Link from 'next/link';
 
-import { Github } from 'lucide-react';
 import { usePlausible } from 'next-plausible';
+import { LuGithub } from 'react-icons/lu';
 
 import { Button } from '@documenso/ui/primitives/button';
 
@@ -52,7 +52,7 @@ export const Callout = ({ starCount }: CalloutProps) => {
         onClick={() => event('view-github')}
       >
         <Button variant="outline" className="rounded-full bg-transparent backdrop-blur-sm">
-          <Github className="mr-2 h-5 w-5" />
+          <LuGithub className="mr-2 h-5 w-5" />
           Star on Github
           {starCount && starCount > 0 && (
             <span className="bg-primary dark:text-background -mr-2.5 ml-2.5 rounded-full px-2 py-1.5 text-xs">

--- a/apps/marketing/src/components/(marketing)/footer.tsx
+++ b/apps/marketing/src/components/(marketing)/footer.tsx
@@ -5,17 +5,20 @@ import { HTMLAttributes } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { Github, MessagesSquare, Moon, Sun, Twitter } from 'lucide-react';
+import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
+import { FaXTwitter } from 'react-icons/fa6';
+import { LiaDiscord } from 'react-icons/lia';
+import { LuGithub } from 'react-icons/lu';
 
 import { cn } from '@documenso/ui/lib/utils';
 
 export type FooterProps = HTMLAttributes<HTMLDivElement>;
 
 const SOCIAL_LINKS = [
-  { href: 'https://twitter.com/documenso', icon: <Twitter className="h-6 w-6" /> },
-  { href: 'https://github.com/documenso/documenso', icon: <Github className="h-6 w-6" /> },
-  { href: 'https://documen.so/discord', icon: <MessagesSquare className="h-6 w-6" /> },
+  { href: 'https://twitter.com/documenso', icon: <FaXTwitter className="h-6 w-6" /> },
+  { href: 'https://github.com/documenso/documenso', icon: <LuGithub className="h-6 w-6" /> },
+  { href: 'https://documen.so/discord', icon: <LiaDiscord className="h-7 w-7" /> },
 ];
 
 const FOOTER_LINKS = [

--- a/apps/marketing/src/components/(marketing)/hero.tsx
+++ b/apps/marketing/src/components/(marketing)/hero.tsx
@@ -4,8 +4,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { Variants, motion } from 'framer-motion';
-import { Github } from 'lucide-react';
 import { usePlausible } from 'next-plausible';
+import { LuGithub } from 'react-icons/lu';
 import { match } from 'ts-pattern';
 
 import { useFeatureFlags } from '@documenso/lib/client-only/providers/feature-flag';
@@ -122,7 +122,7 @@ export const Hero = ({ className, ...props }: HeroProps) => {
 
           <Link href="https://github.com/documenso/documenso" onClick={() => event('view-github')}>
             <Button variant="outline" className="rounded-full bg-transparent backdrop-blur-sm">
-              <Github className="mr-2 h-5 w-5" />
+              <LuGithub className="mr-2 h-5 w-5" />
               Star on Github
             </Button>
           </Link>

--- a/apps/marketing/src/components/(marketing)/mobile-navigation.tsx
+++ b/apps/marketing/src/components/(marketing)/mobile-navigation.tsx
@@ -4,7 +4,9 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { motion, useReducedMotion } from 'framer-motion';
-import { Github, MessagesSquare, Twitter } from 'lucide-react';
+import { FaXTwitter } from 'react-icons/fa6';
+import { LiaDiscord } from 'react-icons/lia';
+import { LuGithub } from 'react-icons/lu';
 
 import { Sheet, SheetContent } from '@documenso/ui/primitives/sheet';
 
@@ -111,7 +113,7 @@ export const MobileNavigation = ({ isMenuOpen, onMenuOpenChange }: MobileNavigat
             target="_blank"
             className="text-foreground hover:text-foreground/80"
           >
-            <Twitter className="h-6 w-6" />
+            <FaXTwitter className="h-6 w-6" />
           </Link>
 
           <Link
@@ -119,7 +121,7 @@ export const MobileNavigation = ({ isMenuOpen, onMenuOpenChange }: MobileNavigat
             target="_blank"
             className="text-foreground hover:text-foreground/80"
           >
-            <Github className="h-6 w-6" />
+            <LuGithub className="h-6 w-6" />
           </Link>
 
           <Link
@@ -127,7 +129,7 @@ export const MobileNavigation = ({ isMenuOpen, onMenuOpenChange }: MobileNavigat
             target="_blank"
             className="text-foreground hover:text-foreground/80"
           >
-            <MessagesSquare className="h-6 w-6" />
+            <LiaDiscord className="h-7 w-7" />
           </Link>
         </div>
       </SheetContent>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,7 @@
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.43.9",
-    "react-icons": "^4.8.0",
+    "react-icons": "^4.11.0",
     "react-rnd": "^10.4.1",
     "sharp": "0.32.5",
     "ts-pattern": "^5.0.5",

--- a/apps/web/src/app/(signing)/sign/[token]/complete/share-button.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/complete/share-button.tsx
@@ -2,7 +2,8 @@
 
 import { HTMLAttributes, useState } from 'react';
 
-import { Copy, Share, Twitter } from 'lucide-react';
+import { Copy, Share } from 'lucide-react';
+import { FaXTwitter } from 'react-icons/fa6';
 
 import { generateTwitterIntent } from '@documenso/lib/universal/generate-twitter-intent';
 import { trpc } from '@documenso/trpc/react';
@@ -125,7 +126,7 @@ export const ShareButton = ({ token, documentId }: ShareButtonProps) => {
           </div>
 
           <Button variant="outline" className="mt-4" onClick={onTweetClick}>
-            <Twitter className="mr-2 h-4 w-4" />
+            <FaXTwitter className="mr-2 h-4 w-4" />
             Tweet
           </Button>
 

--- a/apps/web/src/components/(dashboard)/layout/profile-dropdown.tsx
+++ b/apps/web/src/components/(dashboard)/layout/profile-dropdown.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 
 import {
   CreditCard,
-  Github,
   Key,
   LogOut,
   User as LucideUser,
@@ -16,6 +15,7 @@ import {
 } from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useTheme } from 'next-themes';
+import { LuGithub } from 'react-icons/lu';
 
 import { useFeatureFlags } from '@documenso/lib/client-only/providers/feature-flag';
 import { isAdmin } from '@documenso/lib/next-auth/guards/is-admin';
@@ -130,7 +130,7 @@ export const ProfileDropdown = ({ user }: ProfileDropdownProps) => {
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link href="https://github.com/documenso/documenso" className="cursor-pointer">
-            <Github className="mr-2 h-4 w-4" />
+            <LuGithub className="mr-2 h-4 w-4" />
             Star on Github
           </Link>
         </DropdownMenuItem>

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "react-confetti": "^6.1.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.43.9",
-        "react-icons": "^4.8.0",
+        "react-icons": "^4.11.0",
         "recharts": "^2.7.2",
         "sharp": "0.32.5",
         "typescript": "5.1.6",
@@ -95,7 +95,7 @@
         "react-dom": "18.2.0",
         "react-dropzone": "^14.2.3",
         "react-hook-form": "^7.43.9",
-        "react-icons": "^4.8.0",
+        "react-icons": "^4.11.0",
         "react-rnd": "^10.4.1",
         "sharp": "0.32.5",
         "ts-pattern": "^5.0.5",
@@ -16348,9 +16348,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
-      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
       "peerDependencies": {
         "react": "*"
       }


### PR DESCRIPTION
fixes #358 
Update footer and mobile navigation icons.
As Lucide Icon is not supporting any brand icons and also twitter new icon, so I've updated it to react-icons.

![Screenshot 2023-09-29 183046](https://github.com/documenso/documenso/assets/81948346/c2f72c22-fe89-441e-8a75-41f4c70cb9af)
