### PR TITLE
fix: typo in `dx` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "commitlint": "commitlint --edit",
     "clean": "turbo run clean && rimraf node_modules",
     "d": "npm run dx && npm run dev",
-    "dx": "npm i && npm run dx:up && npm run prisma:migrate-dev -w @documesno/prisma",
+    "dx": "npm i && npm run dx:up && npm run prisma:migrate-dev -w @documenso/prisma",
     "dx:up": "docker compose -f docker/compose-services.yml up -d",
     "dx:down": "docker compose -f docker/compose-services.yml down"
   },


### PR DESCRIPTION
**Description:**

The `package.json` has a typo causing `prisma:migrate-dev` not to work

Gives the below error while running `npm run dx`

![Screenshot 2023-09-30 at 1 43 30 AM](https://github.com/documenso/documenso/assets/23498248/10463e17-d98d-4668-a77a-e012b7e8d4f2)
