### PR TITLE
fix: signature text overflow truncated for longer signature texts

### DIFF
--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -425,7 +425,7 @@ export const AddFieldsFormPartial = ({
                   <CardContent className="flex flex-col items-center justify-center px-6 py-4">
                     <p
                       className={cn(
-                        'text-muted-foreground group-data-[selected]:text-foreground text-3xl font-medium',
+                        'text-muted-foreground group-data-[selected]:text-foreground w-full truncate text-3xl font-medium',
                         fontCaveat.className,
                       )}
                     >


### PR DESCRIPTION
Bug:

https://github.com/documenso/documenso/assets/60930192/1a368f70-ba4b-401d-94ee-e822d2ac58c8


After fix:
![Screenshot 2023-10-02 at 5 58 38 PM](https://github.com/documenso/documenso/assets/60930192/e788853a-a70b-4534-a73a-19035c53bdf3)
