### PR TITLE
fix: changed text of stepper

### DIFF
--- a/packages/ui/primitives/document-flow/document-flow-root.tsx
+++ b/packages/ui/primitives/document-flow/document-flow-root.tsx
@@ -97,10 +97,7 @@ export const DocumentFlowFormContainerStep = ({
   return (
     <div>
       <p className="text-muted-foreground text-sm">
-        {title}{' '}
-        <span>
-          ({step}/{maxStep})
-        </span>
+        Step <span>{`${step} of ${maxStep}`}</span>
       </p>
 
       <div className="bg-muted relative mt-4 h-[2px] rounded-md">


### PR DESCRIPTION
### Issue Type

UI Bug

### Current Issue

The stepper titles are a little confusing

### Fix

Changed to use Step of:

<img width="1302" alt="Screenshot 2023-10-03 at 19 54 25" src="https://github.com/documenso/documenso/assets/22655069/400eeb47-03da-4ef6-ab4d-482891fb8500">

Closes #500 

