### PR TITLE
fix: frequency focus ring

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/page.tsx
@@ -66,7 +66,7 @@ export default async function DocumentsPage({ searchParams = {} }: DocumentsPage
       <div className="mt-12 flex flex-wrap items-center justify-between gap-x-4 gap-y-8">
         <h1 className="text-4xl font-semibold">Documents</h1>
 
-        <div className="flex flex-wrap gap-x-4 gap-y-6 overflow-hidden p-1">
+        <div className="-m-1 flex flex-wrap gap-x-4 gap-y-6 overflow-hidden p-1">
           <Tabs defaultValue={status} className="overflow-x-auto">
             <TabsList>
               {[

--- a/apps/web/src/app/(dashboard)/documents/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/page.tsx
@@ -66,7 +66,7 @@ export default async function DocumentsPage({ searchParams = {} }: DocumentsPage
       <div className="mt-12 flex flex-wrap items-center justify-between gap-x-4 gap-y-8">
         <h1 className="text-4xl font-semibold">Documents</h1>
 
-        <div className="flex flex-wrap gap-x-4 gap-y-6 overflow-hidden">
+        <div className="flex flex-wrap gap-x-4 gap-y-6 overflow-hidden p-1">
           <Tabs defaultValue={status} className="overflow-x-auto">
             <TabsList>
               {[


### PR DESCRIPTION
### Issue Type

Fix

### Current Issue

The frequency dropdown on focus ring is not fully showing correctly:

<img width="1287" alt="Screenshot 2023-10-06 at 13 09 14" src="https://github.com/documenso/documenso/assets/22655069/66babaee-9c99-4f79-84b1-34db64db6084">


### Fix

Added a tiny bit of padding so the full focus shows:

<img width="1287" alt="Screenshot 2023-10-06 at 13 08 51" src="https://github.com/documenso/documenso/assets/22655069/d99bbc11-9db4-4c45-9846-d61692f18f37">


