### PR TITLE
fix: add cascade delete for share links

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/data-table-action-dropdown.tsx
+++ b/apps/web/src/app/(dashboard)/documents/data-table-action-dropdown.tsx
@@ -61,7 +61,7 @@ export const DataTableActionDropdown = ({ row }: DataTableActionDropdownProps) =
 
   const isOwner = row.User.id === session.user.id;
   // const isRecipient = !!recipient;
-  // const isDraft = row.status === DocumentStatus.DRAFT;
+  const isDraft = row.status === DocumentStatus.DRAFT;
   // const isPending = row.status === DocumentStatus.PENDING;
   const isComplete = row.status === DocumentStatus.COMPLETED;
   // const isSigned = recipient?.signingStatus === SigningStatus.SIGNED;
@@ -166,7 +166,7 @@ export const DataTableActionDropdown = ({ row }: DataTableActionDropdownProps) =
           Resend
         </DropdownMenuItem>
 
-        <DropdownMenuItem onClick={onShareClick}>
+        <DropdownMenuItem disabled={isDraft} onClick={onShareClick}>
           {isCreatingShareLink ? (
             <Loader className="mr-2 h-4 w-4" />
           ) : (

--- a/packages/prisma/migrations/20231013012902_add_document_share_link_delete_cascade/migration.sql
+++ b/packages/prisma/migrations/20231013012902_add_document_share_link_delete_cascade/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "DocumentShareLink" DROP CONSTRAINT "DocumentShareLink_documentId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "DocumentShareLink" ADD CONSTRAINT "DocumentShareLink_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -219,7 +219,7 @@ model DocumentShareLink {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
-  document Document @relation(fields: [documentId], references: [id])
+  document Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
 
   @@unique([documentId, email])
 }


### PR DESCRIPTION
## Description

Currently if a user creates a draft document and shares it, they will not be able to delete it.

The following is the error log when you try:

```
PrismaClientKnownRequestError: 
Invalid `prisma.document.delete()` invocation:

Foreign key constraint failed on the field: `DocumentShareLink_documentId_fkey (index)`
    at wn.handleRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:123:6730)
    at wn.handleAndLogRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:123:6119)
    at wn.request (/var/task/node_modules/@prisma/client/runtime/library.js:123:5839)
    at async l (/var/task/node_modules/@prisma/client/runtime/library.js:128:9763)
    at async deleteDraftDocument (/var/task/apps/web/.next/server/pages/api/trpc/[trpc].js:534:12)
    at async /var/task/apps/web/.next/server/pages/api/trpc/[trpc].js:1458:20
    at async resolveMiddleware (/var/task/node_modules/@trpc/server/dist/index.js:418:30)
    at async callRecursive (/var/task/node_modules/@trpc/server/dist/index.js:454:32)
    at async callRecursive (/var/task/node_modules/@trpc/server/dist/index.js:454:32)
    at async /var/task/apps/web/.next/server/pages/api/trpc/[trpc].js:2541:12 {
  code: 'P2003',
  clientVersion: '5.3.1',
  meta: { field_name: 'DocumentShareLink_documentId_fkey (index)' }
}
```

## Changes Made

- Added cascade delete on the `DocumentShareLink` document relation
- Disable the share button for draft documents

## Testing Performed

- Tested deleting a document which contains share links