### PR TITLE
fix: user avatar on admin documents table

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/documents/data-table.tsx
+++ b/apps/web/src/app/(dashboard)/admin/documents/data-table.tsx
@@ -8,6 +8,7 @@ import { Loader } from 'lucide-react';
 
 import { useUpdateSearchParams } from '@documenso/lib/client-only/hooks/use-update-search-params';
 import { FindResultSet } from '@documenso/lib/types/find-result-set';
+import { recipientInitials } from '@documenso/lib/utils/recipient-formatter';
 import { Document, User } from '@documenso/prisma/client';
 import { Avatar, AvatarFallback } from '@documenso/ui/primitives/avatar';
 import { DataTable } from '@documenso/ui/primitives/data-table';
@@ -62,7 +63,9 @@ export const DocumentsDataTable = ({ results }: DocumentsDataTableProps) => {
                 <Link href={`/admin/users/${row.original.User.id}`}>
                   <Avatar className="dark:border-border h-12 w-12 border-2 border-solid border-white">
                     <AvatarFallback className="text-gray-400">
-                      <span className="text-xs">{row.original.User.name}</span>
+                      <span className="text-sm">
+                        {recipientInitials(row.original.User.name ?? '')}
+                      </span>
                     </AvatarFallback>
                   </Avatar>
                 </Link>


### PR DESCRIPTION
Fixed an issue with the user avatar on the 'documents' page in the admin dashboard.

## Before

![CleanShot 2023-10-14 at 16 12 45@2x](https://github.com/documenso/documenso/assets/25515812/45701259-af1d-48c4-b328-b5f96782d5e3)

## After

![Screenshot 2023-10-16 at 16 00 35](https://github.com/documenso/documenso/assets/25515812/fa6ebdd3-48f0-45a9-af40-2371044edb2a)
