### PR TITLE
fix: truncate long file name in admin dashboard

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/documents/data-table.tsx
+++ b/apps/web/src/app/(dashboard)/admin/documents/data-table.tsx
@@ -52,7 +52,11 @@ export const DocumentsDataTable = ({ results }: DocumentsDataTableProps) => {
             header: 'Title',
             accessorKey: 'title',
             cell: ({ row }) => {
-              return <div>{row.original.title}</div>;
+              return (
+                <div className="block max-w-[5rem] truncate font-medium md:max-w-[10rem]">
+                  {row.original.title}
+                </div>
+              );
             },
           },
           {


### PR DESCRIPTION
## Issue

If the user uploaded a file with a long name, it created a huge horizontal scroll.

## Solution

The name of the file is now truncated if it's too long. Thus, it doesn't break the UI anymore.