### PR TITLE
fix: change from forgotten to forgot password

### DIFF
--- a/apps/web/src/app/(unauthenticated)/forgot-password/page.tsx
+++ b/apps/web/src/app/(unauthenticated)/forgot-password/page.tsx
@@ -5,7 +5,7 @@ import { ForgotPasswordForm } from '~/components/forms/forgot-password';
 export default function ForgotPasswordPage() {
   return (
     <div>
-      <h1 className="text-4xl font-semibold">Forgotten your password?</h1>
+      <h1 className="text-4xl font-semibold">Forgot your password?</h1>
 
       <p className="text-muted-foreground mt-2 text-sm">
         No worries, it happens! Enter your email and we'll email you a special link to reset your

--- a/apps/web/src/app/(unauthenticated)/signin/page.tsx
+++ b/apps/web/src/app/(unauthenticated)/signin/page.tsx
@@ -25,7 +25,7 @@ export default function SignInPage() {
           href="/forgot-password"
           className="text-muted-foreground text-sm duration-200 hover:opacity-70"
         >
-          Forgotten your password?
+          Forgot your password?
         </Link>
       </p>
     </div>


### PR DESCRIPTION
Forgotten your password is not a correct phrase. So, I changed it to 'forgot' in dev mode.
![Screenshot 2023-10-20 101525](https://github.com/documenso/documenso/assets/81948346/cde2a04d-dccc-4412-913b-a0a848396c6a)
