### PR TITLE
chore: improve plan subscription user experience

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/billing/billing-plans.tsx
+++ b/apps/web/src/app/(dashboard)/settings/billing/billing-plans.tsx
@@ -40,11 +40,11 @@ export const BillingPlans = ({ prices }: BillingPlansProps) => {
   const isMounted = useIsMounted();
 
   const [interval, setInterval] = useState<Interval>('month');
-  const [isFetchingCheckoutSession, setIsFetchingCheckoutSession] = useState(false);
+  const [creatingCheckoutSessionPerPriceId, setCreatingCheckoutSessionPerPriceId] = useState('');
 
   const onSubscribeClick = async (priceId: string) => {
     try {
-      setIsFetchingCheckoutSession(true);
+      setCreatingCheckoutSessionPerPriceId(priceId);
 
       const url = await createCheckout({ priceId });
 
@@ -60,7 +60,7 @@ export const BillingPlans = ({ prices }: BillingPlansProps) => {
         variant: 'destructive',
       });
     } finally {
-      setIsFetchingCheckoutSession(false);
+      setCreatingCheckoutSessionPerPriceId('');
     }
   };
 
@@ -118,7 +118,8 @@ export const BillingPlans = ({ prices }: BillingPlansProps) => {
 
                 <Button
                   className="mt-4"
-                  loading={isFetchingCheckoutSession}
+                  disabled={Boolean(creatingCheckoutSessionPerPriceId.length)}
+                  loading={creatingCheckoutSessionPerPriceId === price.id}
                   onClick={() => void onSubscribeClick(price.id)}
                 >
                   Subscribe


### PR DESCRIPTION
This PR fixes #577 
Now when a user clicks on a subscribe button of a plan, `loading=true` is only set on the button that was clicked, the other subscribe buttons are disabled (`disabled=true`) to prevent the user from reinitiating another checkout session