### PR TITLE
fix(web): fix stale documents list by forcing refresh after uploading

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/upload-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/upload-document.tsx
@@ -53,6 +53,7 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
         duration: 5000,
       });
 
+      router.refresh();
       router.push(`/documents/${id}`);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
This is an attempt at fixing #601 by forcing a router refresh before sending the user away. 

Note: I also attempted to use `revalidatePath` but it seems like Next.js isn't liking 

```
Error: Invariant: static generation store missing in revalidateTag _N_T_/(dashboard)/documents/page
```

So via https://github.com/vercel/next.js/issues/50714 it seems like a better way to do this is waiting for [`unstable_cache`](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) to become stable and setting cache keys for this. 

I'm not a fan of this hack as well. But if there's any better ways to handle this now, or if it's better to just wait for the cache API, please correct me! 

**
fixes #601