### PR TITLE
#666 feat: disabled resend button for recipients

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/_action-items/resend-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/_action-items/resend-document.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { History } from 'lucide-react';
+import { useSession } from 'next-auth/react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -54,11 +55,14 @@ export const ResendDocumentActionItem = ({
   document,
   recipients,
 }: ResendDocumentActionItemProps) => {
+  const { data: session } = useSession();
   const { toast } = useToast();
 
   const [isOpen, setIsOpen] = useState(false);
+  const isOwner = document.userId === session?.user?.id;
 
   const isDisabled =
+    !isOwner ||
     document.status !== 'PENDING' ||
     !recipients.some((r) => r.signingStatus === SigningStatus.NOT_SIGNED);
 


### PR DESCRIPTION
fixes #666 
I have added changes so that the `Resend` button is disabled for the Recipients of the Document. `Resend` button is visible only for the Document senders.