### PR TITLE
perf(web, lib): do not await inside promise statements

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
@@ -43,11 +43,11 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
   const { documentData } = document;
 
   const [recipients, fields] = await Promise.all([
-    await getRecipientsForDocument({
+    getRecipientsForDocument({
       documentId,
       userId: user.id,
     }),
-    await getFieldsForDocument({
+    getFieldsForDocument({
       documentId,
       userId: user.id,
     }),

--- a/packages/lib/server-only/user/get-all-users.ts
+++ b/packages/lib/server-only/user/get-all-users.ts
@@ -32,7 +32,7 @@ export const findUsers = async ({
   });
 
   const [users, count] = await Promise.all([
-    await prisma.user.findMany({
+    prisma.user.findMany({
       include: {
         Subscription: true,
         Document: {
@@ -45,7 +45,7 @@ export const findUsers = async ({
       skip: Math.max(page - 1, 0) * perPage,
       take: perPage,
     }),
-    await prisma.user.count({
+    prisma.user.count({
       where: whereClause,
     }),
   ]);


### PR DESCRIPTION
- removes `await` keyword from promises passed to `Promise.all`

Using `await` inside a `Promise.all` will make the awaited Promise resolve first, and only after that the Promise.all will be called.  This means the promises are run serially. In these two cases, we probably don't want that