### PR TITLE
feat: add recipient roles

### DIFF
--- a/apps/marketing/src/app/(marketing)/singleplayer/client.tsx
+++ b/apps/marketing/src/app/(marketing)/singleplayer/client.tsx
@@ -154,6 +154,7 @@ export const SinglePlayerClient = () => {
     token: '',
     expired: null,
     signedAt: null,
+    role: 'SIGNER',
     readStatus: 'OPENED',
     signingStatus: 'NOT_SIGNED',
     sendStatus: 'NOT_SENT',

--- a/packages/lib/server-only/recipient/set-recipients-for-document.ts
+++ b/packages/lib/server-only/recipient/set-recipients-for-document.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@documenso/prisma';
+import type { RecipientRole } from '@documenso/prisma/client';
 import { SendStatus, SigningStatus } from '@documenso/prisma/client';
 
 import { nanoid } from '../../universal/id';
@@ -10,6 +11,7 @@ export interface SetRecipientsForDocumentOptions {
     id?: number | null;
     email: string;
     name: string;
+    role: RecipientRole;
   }[];
 }
 
@@ -79,6 +81,7 @@ export const setRecipientsForDocument = async ({
         update: {
           name: recipient.name,
           email: recipient.email,
+          role: recipient.role,
           documentId,
         },
         create: {

--- a/packages/prisma/migrations/20230404095503_initial_migration/migration.sql
+++ b/packages/prisma/migrations/20230404095503_initial_migration/migration.sql
@@ -1,23 +1,27 @@
 -- CreateEnum
-CREATE TYPE "IdentityProvider" AS ENUM ('DOCUMENSO', 'GOOGLE');
+CREATE TYPE "IdentityProvider" AS ENUM('DOCUMENSO', 'GOOGLE');
 
 -- CreateEnum
-CREATE TYPE "DocumentStatus" AS ENUM ('DRAFT', 'PENDING', 'COMPLETED');
+CREATE TYPE "DocumentStatus" AS ENUM('DRAFT', 'PENDING', 'COMPLETED');
 
 -- CreateEnum
-CREATE TYPE "ReadStatus" AS ENUM ('NOT_OPENED', 'OPENED');
+CREATE TYPE "RecipientRole" AS ENUM('SIGNER', 'APPROVER', 'COPY', 'VIEWER');
 
 -- CreateEnum
-CREATE TYPE "SendStatus" AS ENUM ('NOT_SENT', 'SENT');
+CREATE TYPE "ReadStatus" AS ENUM('NOT_OPENED', 'OPENED');
 
 -- CreateEnum
-CREATE TYPE "SigningStatus" AS ENUM ('NOT_SIGNED', 'SIGNED');
+CREATE TYPE "SendStatus" AS ENUM('NOT_SENT', 'SENT');
 
 -- CreateEnum
-CREATE TYPE "FieldType" AS ENUM ('SIGNATURE', 'FREE_SIGNATURE', 'DATE', 'TEXT');
+CREATE TYPE "SigningStatus" AS ENUM('NOT_SIGNED', 'SIGNED');
+
+-- CreateEnum
+CREATE TYPE "FieldType" AS ENUM('SIGNATURE', 'FREE_SIGNATURE', 'DATE', 'TEXT');
 
 -- CreateTable
-CREATE TABLE "User" (
+CREATE TABLE
+  "User" (
     "id" SERIAL NOT NULL,
     "name" TEXT,
     "email" TEXT NOT NULL,
@@ -25,12 +29,12 @@ CREATE TABLE "User" (
     "password" TEXT,
     "source" TEXT,
     "identityProvider" "IdentityProvider" NOT NULL DEFAULT 'DOCUMENSO',
-
     CONSTRAINT "User_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateTable
-CREATE TABLE "Account" (
+CREATE TABLE
+  "Account" (
     "id" TEXT NOT NULL,
     "userId" INTEGER NOT NULL,
     "type" TEXT NOT NULL,
@@ -43,34 +47,34 @@ CREATE TABLE "Account" (
     "scope" TEXT,
     "id_token" TEXT,
     "session_state" TEXT,
-
     CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateTable
-CREATE TABLE "Session" (
+CREATE TABLE
+  "Session" (
     "id" TEXT NOT NULL,
     "sessionToken" TEXT NOT NULL,
     "userId" INTEGER NOT NULL,
     "expires" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateTable
-CREATE TABLE "Document" (
+CREATE TABLE
+  "Document" (
     "id" SERIAL NOT NULL,
     "created" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "userId" INTEGER NOT NULL,
     "title" TEXT NOT NULL,
     "status" "DocumentStatus" NOT NULL DEFAULT 'DRAFT',
     "document" TEXT NOT NULL,
-
     CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateTable
-CREATE TABLE "Recipient" (
+CREATE TABLE
+  "Recipient" (
     "id" SERIAL NOT NULL,
     "documentId" INTEGER NOT NULL,
     "email" VARCHAR(255) NOT NULL,
@@ -80,12 +84,12 @@ CREATE TABLE "Recipient" (
     "readStatus" "ReadStatus" NOT NULL DEFAULT 'NOT_OPENED',
     "signingStatus" "SigningStatus" NOT NULL DEFAULT 'NOT_SIGNED',
     "sendStatus" "SendStatus" NOT NULL DEFAULT 'NOT_SENT',
-
     CONSTRAINT "Recipient_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateTable
-CREATE TABLE "Field" (
+CREATE TABLE
+  "Field" (
     "id" SERIAL NOT NULL,
     "documentId" INTEGER NOT NULL,
     "recipientId" INTEGER,
@@ -95,54 +99,65 @@ CREATE TABLE "Field" (
     "positionY" INTEGER NOT NULL DEFAULT 0,
     "customText" TEXT NOT NULL,
     "inserted" BOOLEAN NOT NULL,
-
     CONSTRAINT "Field_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateTable
-CREATE TABLE "Signature" (
+CREATE TABLE
+  "Signature" (
     "id" SERIAL NOT NULL,
     "created" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "recipientId" INTEGER NOT NULL,
     "fieldId" INTEGER NOT NULL,
     "signatureImageAsBase64" TEXT,
     "typedSignature" TEXT,
-
     CONSTRAINT "Signature_pkey" PRIMARY KEY ("id")
-);
+  );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_email_key" ON "User" ("email");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account" ("provider", "providerAccountId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session" ("sessionToken");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Signature_fieldId_key" ON "Signature"("fieldId");
+CREATE UNIQUE INDEX "Signature_fieldId_key" ON "Signature" ("fieldId");
 
 -- AddForeignKey
-ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Account"
+ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Session"
+ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Document" ADD CONSTRAINT "Document_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Document"
+ADD CONSTRAINT "Document_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Recipient" ADD CONSTRAINT "Recipient_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Recipient"
+ADD CONSTRAINT "Recipient_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Field" ADD CONSTRAINT "Field_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Field"
+ADD CONSTRAINT "Field_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Field" ADD CONSTRAINT "Field_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "Recipient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Field"
+ADD CONSTRAINT "Field_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "Recipient" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Signature" ADD CONSTRAINT "Signature_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "Recipient"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Signature"
+ADD CONSTRAINT "Signature_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "Recipient" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Signature" ADD CONSTRAINT "Signature_fieldId_fkey" FOREIGN KEY ("fieldId") REFERENCES "Field"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Signature"
+ADD CONSTRAINT "Signature_fieldId_fkey" FOREIGN KEY ("fieldId") REFERENCES "Field" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "Recipient"
+ADD COLUMN "role" "RecipientRole" NOT NULL DEFAULT 'SIGNER';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -163,6 +163,14 @@ model DocumentMeta {
   document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
 }
 
+enum RecipientRole {
+  SIGNER
+  APPROVER
+  COPY
+  VIEWER
+}
+
+
 enum ReadStatus {
   NOT_OPENED
   OPENED
@@ -186,6 +194,7 @@ model Recipient {
   token         String
   expired       DateTime?
   signedAt      DateTime?
+  role          RecipientRole @default(SIGNER)
   readStatus    ReadStatus    @default(NOT_OPENED)
   signingStatus SigningStatus @default(NOT_SIGNED)
   sendStatus    SendStatus    @default(NOT_SENT)

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -35,6 +35,7 @@ export const ZSetRecipientsForDocumentMutationSchema = z.object({
       id: z.number().nullish(),
       email: z.string().min(1).email(),
       name: z.string(),
+      role: z.enum(['SIGNER', 'APPROVER', 'COPY', 'VIEWER']),
     }),
   ),
 });

--- a/packages/trpc/server/recipient-router/router.ts
+++ b/packages/trpc/server/recipient-router/router.ts
@@ -20,6 +20,7 @@ export const recipientRouter = router({
             id: signer.nativeId,
             email: signer.email,
             name: signer.name,
+            role: signer.role,
           })),
         });
       } catch (err) {

--- a/packages/trpc/server/recipient-router/schema.ts
+++ b/packages/trpc/server/recipient-router/schema.ts
@@ -8,6 +8,7 @@ export const ZAddSignersMutationSchema = z
         nativeId: z.number().optional(),
         email: z.string().email().min(1),
         name: z.string(),
+        role: z.enum(['SIGNER', 'APPROVER', 'COPY', 'VIEWER']),
       }),
     ),
   })

--- a/packages/ui/primitives/document-flow/add-signers.types.ts
+++ b/packages/ui/primitives/document-flow/add-signers.types.ts
@@ -8,6 +8,7 @@ export const ZAddSignersFormSchema = z
         nativeId: z.number().optional(),
         email: z.string().email().min(1),
         name: z.string(),
+        role: z.enum(['SIGNER', 'APPROVER', 'COPY', 'VIEWER']),
       }),
     ),
   })


### PR DESCRIPTION
This PR adds a Recipient Role feature for #705

4 Roles added - Signer, Approver, Recieves copy, and Viewer.

Emails go out to everyone, because it seems logicially that everyone would want to see the document, regardless if they are signing it.  This would mean the email messaging would need to change also.

It seems like anyone can sign a document for any signer if they have the link to the document.  I tried this on a new browser window with a different browser account.  I hadn't signed into the app yet, but I could see the document and sign.  I do have a little doubt that I might have done something wrong on my side, but if I'm correct, this would seem like a bug because you'd only want only the signer to sign for themselves.

Not sure if I should continue and complete the entire path, I see there is someone else that submitted for this issue also and it's getting late where I am.  

Cheers,
