### PR TITLE
feat: document thumbnails

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/data-table-title.tsx
+++ b/apps/web/src/app/(dashboard)/documents/data-table-title.tsx
@@ -37,7 +37,7 @@ export const DataTableTitle = ({ row }: DataTableTitleProps) => {
         className="block max-w-[10rem] truncate font-medium hover:underline md:max-w-[20rem]"
       >
         <img
-          className="mr-2 inline-block h-10"
+          className="mr-2 inline-block h-10 w-7 object-cover"
           src={row.documentThumbnail ?? '/static/document.png'}
           alt="document-preview"
         />
@@ -51,7 +51,7 @@ export const DataTableTitle = ({ row }: DataTableTitleProps) => {
         className="block max-w-[10rem] truncate font-medium hover:underline md:max-w-[20rem]"
       >
         <img
-          className="mr-2 inline-block h-10"
+          className="mr-2 inline-block h-10 w-7 object-cover"
           src={row.documentThumbnail ?? '/static/document.png'}
           alt="document-preview"
         />
@@ -61,7 +61,7 @@ export const DataTableTitle = ({ row }: DataTableTitleProps) => {
     .otherwise(() => (
       <span className="block max-w-[10rem] truncate font-medium hover:underline md:max-w-[20rem]">
         <img
-          className="mr-2 inline-block h-10"
+          className="mr-2 inline-block h-10 w-7 object-cover"
           src={row.documentThumbnail ?? '/static/document.png'}
           alt="document-preview"
         />

--- a/apps/web/src/app/(dashboard)/documents/data-table-title.tsx
+++ b/apps/web/src/app/(dashboard)/documents/data-table-title.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { match } from 'ts-pattern';
 
-import { Document, Recipient, User } from '@documenso/prisma/client';
+import type { Document, Recipient, User } from '@documenso/prisma/client';
 
 export type DataTableTitleProps = {
   row: Document & {
@@ -36,6 +36,11 @@ export const DataTableTitle = ({ row }: DataTableTitleProps) => {
         title={row.title}
         className="block max-w-[10rem] truncate font-medium hover:underline md:max-w-[20rem]"
       >
+        <img
+          className="mr-2 inline-block h-10"
+          src={row.documentThumbnail ?? '/static/document.png'}
+          alt="document-preview"
+        />
         {row.title}
       </Link>
     ))
@@ -45,11 +50,21 @@ export const DataTableTitle = ({ row }: DataTableTitleProps) => {
         title={row.title}
         className="block max-w-[10rem] truncate font-medium hover:underline md:max-w-[20rem]"
       >
+        <img
+          className="mr-2 inline-block h-10"
+          src={row.documentThumbnail ?? '/static/document.png'}
+          alt="document-preview"
+        />
         {row.title}
       </Link>
     ))
     .otherwise(() => (
       <span className="block max-w-[10rem] truncate font-medium hover:underline md:max-w-[20rem]">
+        <img
+          className="mr-2 inline-block h-10"
+          src={row.documentThumbnail ?? '/static/document.png'}
+          alt="document-preview"
+        />
         {row.title}
       </span>
     ));

--- a/apps/web/src/app/(dashboard)/documents/upload-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/upload-document.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -11,15 +11,20 @@ import { useSession } from 'next-auth/react';
 import { useLimits } from '@documenso/ee/server-only/limits/provider/client';
 import { createDocumentData } from '@documenso/lib/server-only/document-data/create-document-data';
 import { putFile } from '@documenso/lib/universal/upload/put-file';
+import { DocumentDataType } from '@documenso/prisma/client';
 import { TRPCClientError } from '@documenso/trpc/client';
 import { trpc } from '@documenso/trpc/react';
 import { cn } from '@documenso/ui/lib/utils';
 import { DocumentDropzone } from '@documenso/ui/primitives/document-dropzone';
+import { LazyPDFViewer } from '@documenso/ui/primitives/lazy-pdf-viewer';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export type UploadDocumentProps = {
   className?: string;
 };
+
+const THUMBNAIL_MAX_DIMENSION = 260;
+const THUMBNAIL_TIMEOUT = 500;
 
 export const UploadDocument = ({ className }: UploadDocumentProps) => {
   const router = useRouter();
@@ -33,11 +38,28 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
 
   const { mutateAsync: createDocument } = trpc.document.createDocument.useMutation();
 
+  const [docData, setDocData] = useState('');
+
+  const thumbnailResolveRef = useRef<(value: unknown) => void | null>({ current: null });
+
   const onFileDrop = async (file: File) => {
     try {
       setIsLoading(true);
 
       const { type, data } = await putFile(file);
+
+      // render the pdf to generate thumbnail
+      setDocData(data);
+
+      // if failed to generate thumbnail in 500ms, skip thumbnail generation
+      const thumbnailData = await Promise.race([
+        new Promise((resolve) => {
+          thumbnailResolveRef.current = resolve;
+        }),
+        new Promise((resolve) => {
+          setTimeout(resolve, THUMBNAIL_TIMEOUT);
+        }),
+      ]);
 
       const { id: documentDataId } = await createDocumentData({
         type,
@@ -47,6 +69,7 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
       const { id } = await createDocument({
         title: file.name,
         documentDataId,
+        documentThumbnail: typeof thumbnailData === 'string' ? thumbnailData : undefined,
       });
 
       toast({
@@ -74,6 +97,41 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
       }
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const generateThumbnail = (page: number, canvas: HTMLCanvasElement | null) => {
+    if (page !== 1) return;
+    if (!canvas) return;
+
+    try {
+      // Determine whether the width or height is the larger side
+      let thumbnailWidth, thumbnailHeight;
+      if (canvas.width > canvas.height) {
+        thumbnailWidth = THUMBNAIL_MAX_DIMENSION;
+        thumbnailHeight = (canvas.height / canvas.width) * THUMBNAIL_MAX_DIMENSION;
+      } else {
+        thumbnailHeight = THUMBNAIL_MAX_DIMENSION;
+        thumbnailWidth = (canvas.width / canvas.height) * THUMBNAIL_MAX_DIMENSION;
+      }
+
+      // Create a new canvas to resize for thumbnail
+      const thumbnailCanvas = document.createElement('canvas');
+      thumbnailCanvas.width = thumbnailWidth;
+      thumbnailCanvas.height = thumbnailHeight;
+
+      // Copy and scale the content of the original canvas to the new canvas
+      const ctx = thumbnailCanvas.getContext('2d');
+      if (ctx === null) return thumbnailResolveRef.current?.(undefined);
+      ctx.drawImage(canvas, 0, 0, thumbnailWidth, thumbnailHeight);
+
+      // Convert the canvas content to a base64 image
+      const base64Image = thumbnailCanvas.toDataURL('image/png'); // You can choose the desired image format
+
+      // Resolve the promise with the base64 image
+      thumbnailResolveRef.current?.(base64Image);
+    } catch (error) {
+      return thumbnailResolveRef.current?.(undefined);
     }
   };
 
@@ -118,6 +176,19 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
             </Link>
           </div>
         </div>
+      )}
+
+      {Boolean(docData) && (
+        <LazyPDFViewer
+          className="hidden"
+          documentData={{
+            id: '',
+            data: docData,
+            initialData: docData,
+            type: DocumentDataType.BYTES_64,
+          }}
+          onPageRender={generateThumbnail}
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/(dashboard)/documents/upload-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/upload-document.tsx
@@ -16,7 +16,7 @@ import { TRPCClientError } from '@documenso/trpc/client';
 import { trpc } from '@documenso/trpc/react';
 import { cn } from '@documenso/ui/lib/utils';
 import { DocumentDropzone } from '@documenso/ui/primitives/document-dropzone';
-import { LazyPDFViewer } from '@documenso/ui/primitives/lazy-pdf-viewer';
+import { LazyPDFViewerNoLoader } from '@documenso/ui/primitives/lazy-pdf-viewer';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export type UploadDocumentProps = {
@@ -24,7 +24,7 @@ export type UploadDocumentProps = {
 };
 
 const THUMBNAIL_MAX_DIMENSION = 260;
-const THUMBNAIL_TIMEOUT = 500;
+const THUMBNAIL_TIMEOUT = 1000;
 
 export const UploadDocument = ({ className }: UploadDocumentProps) => {
   const router = useRouter();
@@ -101,8 +101,7 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
   };
 
   const generateThumbnail = (page: number, canvas: HTMLCanvasElement | null) => {
-    if (page !== 1) return;
-    if (!canvas) return;
+    if (page !== 1 || !canvas) return;
 
     try {
       // Determine whether the width or height is the larger side
@@ -179,7 +178,7 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
       )}
 
       {Boolean(docData) && (
-        <LazyPDFViewer
+        <LazyPDFViewerNoLoader
           className="hidden"
           documentData={{
             id: '',
@@ -187,6 +186,7 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
             initialData: docData,
             type: DocumentDataType.BYTES_64,
           }}
+          maxPages={1}
           onPageRender={generateThumbnail}
         />
       )}

--- a/packages/lib/server-only/document/create-document.ts
+++ b/packages/lib/server-only/document/create-document.ts
@@ -6,14 +6,21 @@ export type CreateDocumentOptions = {
   title: string;
   userId: number;
   documentDataId: string;
+  documentThumbnail?: string;
 };
 
-export const createDocument = async ({ userId, title, documentDataId }: CreateDocumentOptions) => {
+export const createDocument = async ({
+  userId,
+  title,
+  documentDataId,
+  documentThumbnail,
+}: CreateDocumentOptions) => {
   return await prisma.document.create({
     data: {
       title,
       documentDataId,
       userId,
+      documentThumbnail,
     },
   });
 };

--- a/packages/prisma/migrations/20231203063921_/migration.sql
+++ b/packages/prisma/migrations/20231203063921_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Document" ADD COLUMN     "documentThumbnail" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -121,20 +121,21 @@ enum DocumentStatus {
 }
 
 model Document {
-  id             Int                 @id @default(autoincrement())
-  userId         Int
-  User           User                @relation(fields: [userId], references: [id], onDelete: Cascade)
-  title          String
-  status         DocumentStatus      @default(DRAFT)
-  Recipient      Recipient[]
-  Field          Field[]
-  ShareLink      DocumentShareLink[]
-  documentDataId String
-  documentData   DocumentData        @relation(fields: [documentDataId], references: [id], onDelete: Cascade)
-  documentMeta   DocumentMeta?
-  createdAt      DateTime            @default(now())
-  updatedAt      DateTime            @default(now()) @updatedAt
-  completedAt    DateTime?
+  id                Int                 @id @default(autoincrement())
+  userId            Int
+  User              User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title             String
+  status            DocumentStatus      @default(DRAFT)
+  Recipient         Recipient[]
+  Field             Field[]
+  ShareLink         DocumentShareLink[]
+  documentThumbnail String? // base 64 encoded
+  documentDataId    String
+  documentData      DocumentData        @relation(fields: [documentDataId], references: [id], onDelete: Cascade)
+  documentMeta      DocumentMeta?
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @default(now()) @updatedAt
+  completedAt       DateTime?
 
   @@unique([documentDataId])
   @@index([userId])

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -68,7 +68,7 @@ export const documentRouter = router({
     .input(ZCreateDocumentMutationSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        const { title, documentDataId } = input;
+        const { title, documentDataId, documentThumbnail } = input;
 
         const { remaining } = await getServerLimits({ email: ctx.user.email });
 
@@ -84,6 +84,7 @@ export const documentRouter = router({
           userId: ctx.user.id,
           title,
           documentDataId,
+          documentThumbnail,
         });
       } catch (err) {
         if (err instanceof TRPCError) {

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -17,6 +17,7 @@ export type TGetDocumentByTokenQuerySchema = z.infer<typeof ZGetDocumentByTokenQ
 export const ZCreateDocumentMutationSchema = z.object({
   title: z.string().min(1),
   documentDataId: z.string().min(1),
+  documentThumbnail: z.string().min(1).optional(),
 });
 
 export type TCreateDocumentMutationSchema = z.infer<typeof ZCreateDocumentMutationSchema>;

--- a/packages/ui/primitives/pdf-viewer.tsx
+++ b/packages/ui/primitives/pdf-viewer.tsx
@@ -44,6 +44,7 @@ export type PDFViewerProps = {
   className?: string;
   documentData: DocumentData;
   onDocumentLoad?: (_doc: LoadedPDFDocument) => void;
+  maxPages?: number;
   onPageRender?: (page: number, el: HTMLCanvasElement | null) => void;
   onPageClick?: OnPDFViewerPageClick;
   [key: string]: unknown;
@@ -52,6 +53,7 @@ export type PDFViewerProps = {
 export const PDFViewer = ({
   className,
   documentData,
+  maxPages,
   onDocumentLoad,
   onPageRender,
   onPageClick,
@@ -77,7 +79,7 @@ export const PDFViewer = ({
   const isLoading = isDocumentBytesLoading || !documentBytes;
 
   const onDocumentLoaded = (doc: LoadedPDFDocument) => {
-    setNumPages(doc.numPages);
+    setNumPages(maxPages ? Math.min(maxPages, doc.numPages) : doc.numPages);
     onDocumentLoad?.(doc);
   };
 

--- a/packages/ui/primitives/pdf-viewer.tsx
+++ b/packages/ui/primitives/pdf-viewer.tsx
@@ -3,14 +3,14 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Loader } from 'lucide-react';
-import { PDFDocumentProxy } from 'pdfjs-dist';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
 import { Document as PDFDocument, Page as PDFPage, pdfjs } from 'react-pdf';
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
 
 import { PDF_VIEWER_PAGE_SELECTOR } from '@documenso/lib/constants/pdf-viewer';
 import { getFile } from '@documenso/lib/universal/upload/get-file';
-import { DocumentData } from '@documenso/prisma/client';
+import type { DocumentData } from '@documenso/prisma/client';
 import { cn } from '@documenso/ui/lib/utils';
 
 import { useToast } from './use-toast';
@@ -44,6 +44,7 @@ export type PDFViewerProps = {
   className?: string;
   documentData: DocumentData;
   onDocumentLoad?: (_doc: LoadedPDFDocument) => void;
+  onPageRender?: (page: number, el: HTMLCanvasElement | null) => void;
   onPageClick?: OnPDFViewerPageClick;
   [key: string]: unknown;
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'onPageClick'>;
@@ -52,12 +53,14 @@ export const PDFViewer = ({
   className,
   documentData,
   onDocumentLoad,
+  onPageRender,
   onPageClick,
   ...props
 }: PDFViewerProps) => {
   const { toast } = useToast();
 
   const $el = useRef<HTMLDivElement>(null);
+  const $canvas = useRef<HTMLCanvasElement>(null);
 
   const [isDocumentBytesLoading, setIsDocumentBytesLoading] = useState(false);
   const [documentBytes, setDocumentBytes] = useState<Uint8Array | null>(null);
@@ -211,6 +214,8 @@ export const PDFViewer = ({
               >
                 <PDFPage
                   pageNumber={i + 1}
+                  canvasRef={$canvas}
+                  onRenderSuccess={() => onPageRender?.(i + 1, $canvas.current)}
                   width={width}
                   renderAnnotationLayer={false}
                   renderTextLayer={false}


### PR DESCRIPTION
Closes #704

### Implementation:

- Generate a thumbnail on the client side using the rendering of an invisible LazyPDFViewer
- Store the base 64 string of the thumbnail in the database
- Error handling: reject the thumbnail generation if timeout (500ms)
- Keep the aspect ratio of the thumbnail but enforce the max dimension
- Implemented the primitive UI to display thumbnails in the table

### Preview:

<img width="900" alt="Screenshot 2023-12-03 at 05 07 48" src="https://github.com/documenso/documenso/assets/23418428/ca0289b4-63e2-4afc-b93a-26ead4dfed04">
(For compatibility, previous document without thumbnail will show default icon as last one)

