### PR TITLE
feat(marketing): add careers page

### DIFF
--- a/apps/marketing/content/careers.mdx
+++ b/apps/marketing/content/careers.mdx
@@ -1,0 +1,13 @@
+---
+title: Careers at Documenso
+---
+
+# Careers at Documenso
+
+So you love Documenso and all the things that we do and now you want to work with us to unlock the future of open signing?
+
+---
+
+## Open Positions
+
+Unfortunately we have no open positions available at the moment. Our team has grown and so we must grow with it, please check back from time to time as now is not forever and we may be hiring again in the future.

--- a/apps/marketing/src/components/(marketing)/footer.tsx
+++ b/apps/marketing/src/components/(marketing)/footer.tsx
@@ -31,6 +31,7 @@ const FOOTER_LINKS = [
   { href: 'https://status.documenso.com', text: 'Status', target: '_blank' },
   { href: 'mailto:support@documenso.com', text: 'Support', target: '_blank' },
   { href: '/oss-friends', text: 'OSS Friends' },
+  { href: '/careers', text: 'Careers' },
   { href: '/privacy', text: 'Privacy' },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19227,6 +19227,7 @@
         "start-server-and-test": "^2.0.1"
       },
       "devDependencies": {
+        "@documenso/prisma": "*",
         "@documenso/web": "*",
         "@playwright/test": "^1.18.1",
         "@types/node": "^20.8.2"


### PR DESCRIPTION
Adds the careers page to the marketing site so we may publish open positions in the future once we are hiring again.