### PR TITLE
fix(webapp): use checkout for expired plans

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/billing/create-checkout.action.ts
+++ b/apps/web/src/app/(dashboard)/settings/billing/create-checkout.action.ts
@@ -23,7 +23,7 @@ export const createCheckout = async ({ priceId }: CreateCheckoutOptions) => {
   let stripeCustomer: Stripe.Customer | null = null;
 
   // Find the Stripe customer for the current user subscription.
-  if (existingSubscription) {
+  if (existingSubscription?.periodEnd && existingSubscription.periodEnd >= new Date()) {
     stripeCustomer = await getStripeCustomerById(existingSubscription.customerId);
 
     if (!stripeCustomer) {


### PR DESCRIPTION
Currently customers with inactive/expired plans will be shown the BillingPlans component but upon hitting the subscribe button they will be redirected to their portal where they are unable to complete a checkout.

To resolve this we check for expiration of their subscription and use a normal stripe checkout instead.