### PR TITLE
fix: hotkeys was overlapping with the browser hotkeys

### DIFF
--- a/apps/web/src/components/(dashboard)/common/command-menu.tsx
+++ b/apps/web/src/components/(dashboard)/common/command-menu.tsx
@@ -85,7 +85,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
 
   const currentPage = pages[pages.length - 1];
 
-  const toggleOpen = () => {
+  const toggleOpen = (e: KeyboardEvent) => {
+    e.preventDefault();
     setIsOpen((isOpen) => !isOpen);
     onOpenChange?.(!isOpen);
 


### PR DESCRIPTION
Issue  - The `Ctrl+K` hotkey in our application is conflicting with the browser's default search hotkey, leading to unintended browser actions.


https://github.com/documenso/documenso/assets/71957674/180b6028-58f7-4cf8-841c-1e13c9d4d355



