### PR TITLE
feat: improve the UX for password protected documents

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/edit-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/edit-document.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import type { DocumentData, Field, Recipient, User } from '@documenso/prisma/client';
+import type { DocumentData, DocumentMeta, Field, Recipient, User } from '@documenso/prisma/client';
 import { DocumentStatus } from '@documenso/prisma/client';
 import type { DocumentWithData } from '@documenso/prisma/types/document-with-data';
 import { trpc } from '@documenso/trpc/react';
@@ -29,6 +29,7 @@ export type EditDocumentFormProps = {
   user: User;
   document: DocumentWithData;
   recipients: Recipient[];
+  documentMeta: DocumentMeta | null;
   fields: Field[];
   documentData: DocumentData;
 };
@@ -41,6 +42,7 @@ export const EditDocumentForm = ({
   document,
   recipients,
   fields,
+  documentMeta,
   user: _user,
   documentData,
 }: EditDocumentFormProps) => {
@@ -185,7 +187,7 @@ export const EditDocumentForm = ({
         gradient
       >
         <CardContent className="p-2">
-          <LazyPDFViewer key={documentData.id} documentData={documentData} />
+          <LazyPDFViewer key={documentData.id} documentData={documentData} document={document} documentMeta={documentMeta} />
         </CardContent>
       </Card>
 

--- a/apps/web/src/app/(dashboard)/documents/[id]/edit-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/edit-document.tsx
@@ -58,6 +58,8 @@ export const EditDocumentForm = ({
   const { mutateAsync: addFields } = trpc.field.addFields.useMutation();
   const { mutateAsync: addSigners } = trpc.recipient.addSigners.useMutation();
   const { mutateAsync: sendDocument } = trpc.document.sendDocument.useMutation();
+  const { mutateAsync: setPasswordForDocument } =
+    trpc.document.setPasswordForDocument.useMutation();
 
   const documentFlow: Record<EditDocumentStep, DocumentFlowStep> = {
     title: {
@@ -178,6 +180,13 @@ export const EditDocumentForm = ({
     }
   };
 
+  const onPasswordSubmit = async (password: string) => {
+    await setPasswordForDocument({
+      documentId: document.id,
+      password,
+    });
+  };
+
   const currentDocumentFlow = documentFlow[step];
 
   return (
@@ -187,7 +196,13 @@ export const EditDocumentForm = ({
         gradient
       >
         <CardContent className="p-2">
-          <LazyPDFViewer key={documentData.id} documentData={documentData} document={document} documentMeta={documentMeta} />
+          <LazyPDFViewer
+            key={documentData.id}
+            documentData={documentData}
+            document={document}
+            password={documentMeta?.password}
+            onPasswordSubmit={onPasswordSubmit}
+          />
         </CardContent>
       </Card>
 

--- a/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
@@ -13,7 +13,6 @@ import { LazyPDFViewer } from '@documenso/ui/primitives/lazy-pdf-viewer';
 import { EditDocumentForm } from '~/app/(dashboard)/documents/[id]/edit-document';
 import { StackAvatarsWithTooltip } from '~/components/(dashboard)/avatar/stack-avatars-with-tooltip';
 import { DocumentStatus } from '~/components/formatter/document-status';
-import { getDocumentMetaByDocumentId } from '@documenso/lib/server-only/document/get-document-meta-by-document-id';
 
 export type DocumentPageProps = {
   params: {
@@ -41,8 +40,7 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
     redirect('/documents');
   }
 
-  const { documentData } = document;
-  const documentMeta = await getDocumentMetaByDocumentId({ id: document!.id }).catch(() => null);
+  const { documentData, documentMeta } = document;
 
   const [recipients, fields] = await Promise.all([
     getRecipientsForDocument({
@@ -94,7 +92,12 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
 
       {document.status === InternalDocumentStatus.COMPLETED && (
         <div className="mx-auto mt-12 max-w-2xl">
-          <LazyPDFViewer document={document} key={documentData.id} documentMeta={documentMeta} documentData={documentData} />
+          <LazyPDFViewer
+            document={document}
+            key={documentData.id}
+            documentMeta={documentMeta}
+            documentData={documentData}
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/page.tsx
@@ -13,6 +13,7 @@ import { LazyPDFViewer } from '@documenso/ui/primitives/lazy-pdf-viewer';
 import { EditDocumentForm } from '~/app/(dashboard)/documents/[id]/edit-document';
 import { StackAvatarsWithTooltip } from '~/components/(dashboard)/avatar/stack-avatars-with-tooltip';
 import { DocumentStatus } from '~/components/formatter/document-status';
+import { getDocumentMetaByDocumentId } from '@documenso/lib/server-only/document/get-document-meta-by-document-id';
 
 export type DocumentPageProps = {
   params: {
@@ -41,6 +42,7 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
   }
 
   const { documentData } = document;
+  const documentMeta = await getDocumentMetaByDocumentId({ id: document!.id }).catch(() => null);
 
   const [recipients, fields] = await Promise.all([
     getRecipientsForDocument({
@@ -83,6 +85,7 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
           className="mt-8"
           document={document}
           user={user}
+          documentMeta={documentMeta}
           recipients={recipients}
           fields={fields}
           documentData={documentData}
@@ -91,7 +94,7 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
 
       {document.status === InternalDocumentStatus.COMPLETED && (
         <div className="mx-auto mt-12 max-w-2xl">
-          <LazyPDFViewer key={documentData.id} documentData={documentData} />
+          <LazyPDFViewer document={document} key={documentData.id} documentMeta={documentMeta} documentData={documentData} />
         </div>
       )}
     </div>

--- a/apps/web/src/app/(signing)/sign/[token]/page.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/page.tsx
@@ -101,7 +101,7 @@ export default async function SigningPage({ params: { token } }: SigningPageProp
             gradient
           >
             <CardContent className="p-2">
-              <LazyPDFViewer key={documentData.id} documentData={documentData} />
+              <LazyPDFViewer key={documentData.id} documentData={documentData} document={document} documentMeta={documentMeta} />
             </CardContent>
           </Card>
 

--- a/apps/web/src/app/(signing)/sign/[token]/page.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/page.tsx
@@ -101,7 +101,12 @@ export default async function SigningPage({ params: { token } }: SigningPageProp
             gradient
           >
             <CardContent className="p-2">
-              <LazyPDFViewer key={documentData.id} documentData={documentData} document={document} documentMeta={documentMeta} />
+              <LazyPDFViewer
+                key={documentData.id}
+                documentData={documentData}
+                document={document}
+                password={documentMeta?.password}
+              />
             </CardContent>
           </Card>
 

--- a/apps/web/src/app/(signing)/sign/[token]/page.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from 'next/navigation';
 
 import { match } from 'ts-pattern';
 
+import { DOCUMENSO_ENCRYPTION_KEY } from '@documenso/lib/constants/crypto';
 import { DEFAULT_DOCUMENT_DATE_FORMAT } from '@documenso/lib/constants/date-formats';
 import { PDF_VIEWER_PAGE_SELECTOR } from '@documenso/lib/constants/pdf-viewer';
 import { DEFAULT_DOCUMENT_TIME_ZONE } from '@documenso/lib/constants/time-zones';
@@ -12,6 +13,7 @@ import { viewedDocument } from '@documenso/lib/server-only/document/viewed-docum
 import { getFieldsForToken } from '@documenso/lib/server-only/field/get-fields-for-token';
 import { getRecipientByToken } from '@documenso/lib/server-only/recipient/get-recipient-by-token';
 import { getRecipientSignatures } from '@documenso/lib/server-only/recipient/get-recipient-signatures';
+import { symmetricDecrypt } from '@documenso/lib/universal/crypto';
 import { DocumentStatus, FieldType, SigningStatus } from '@documenso/prisma/client';
 import { Card, CardContent } from '@documenso/ui/primitives/card';
 import { ElementVisible } from '@documenso/ui/primitives/element-visible';
@@ -64,6 +66,23 @@ export default async function SigningPage({ params: { token } }: SigningPageProp
     recipient.signingStatus === SigningStatus.SIGNED
   ) {
     redirect(`/sign/${token}/complete`);
+  }
+
+  if (documentMeta?.password) {
+    const key = DOCUMENSO_ENCRYPTION_KEY;
+
+    if (!key) {
+      throw new Error('Missing DOCUMENSO_ENCRYPTION_KEY');
+    }
+
+    const securePassword = Buffer.from(
+      symmetricDecrypt({
+        key,
+        data: documentMeta.password,
+      }),
+    ).toString('utf-8');
+
+    documentMeta.password = securePassword;
   }
 
   const [recipientSignature] = await getRecipientSignatures({ recipientId: recipient.id });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19869,7 +19869,8 @@
         "react-rnd": "^10.4.1",
         "tailwind-merge": "^1.12.0",
         "tailwindcss-animate": "^1.0.5",
-        "ts-pattern": "^5.0.5"
+        "ts-pattern": "^5.0.5",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@documenso/tailwind-config": "*",

--- a/packages/lib/server-only/document-meta/upsert-document-meta.ts
+++ b/packages/lib/server-only/document-meta/upsert-document-meta.ts
@@ -4,10 +4,11 @@ import { prisma } from '@documenso/prisma';
 
 export type CreateDocumentMetaOptions = {
   documentId: number;
-  subject: string;
-  message: string;
-  timezone: string;
-  dateFormat: string;
+  subject?: string;
+  message?: string;
+  timezone?: string;
+  documentPassword?: string;
+  dateFormat?: string;
   userId: number;
 };
 
@@ -18,6 +19,7 @@ export const upsertDocumentMeta = async ({
   dateFormat,
   documentId,
   userId,
+  documentPassword,
 }: CreateDocumentMetaOptions) => {
   await prisma.document.findFirstOrThrow({
     where: {
@@ -35,12 +37,14 @@ export const upsertDocumentMeta = async ({
       message,
       dateFormat,
       timezone,
+      documentPassword,
       documentId,
     },
     update: {
       subject,
       message,
       dateFormat,
+      documentPassword,
       timezone,
     },
   });

--- a/packages/lib/server-only/document-meta/upsert-document-meta.ts
+++ b/packages/lib/server-only/document-meta/upsert-document-meta.ts
@@ -7,7 +7,7 @@ export type CreateDocumentMetaOptions = {
   subject?: string;
   message?: string;
   timezone?: string;
-  documentPassword?: string;
+  password?: string;
   dateFormat?: string;
   userId: number;
 };
@@ -19,7 +19,7 @@ export const upsertDocumentMeta = async ({
   dateFormat,
   documentId,
   userId,
-  documentPassword,
+  password,
 }: CreateDocumentMetaOptions) => {
   await prisma.document.findFirstOrThrow({
     where: {
@@ -37,14 +37,14 @@ export const upsertDocumentMeta = async ({
       message,
       dateFormat,
       timezone,
-      documentPassword,
+      password,
       documentId,
     },
     update: {
       subject,
       message,
       dateFormat,
-      documentPassword,
+      password,
       timezone,
     },
   });

--- a/packages/lib/server-only/document/duplicate-document-by-id.ts
+++ b/packages/lib/server-only/document/duplicate-document-by-id.ts
@@ -26,7 +26,7 @@ export const duplicateDocumentById = async ({ id, userId }: DuplicateDocumentByI
           message: true,
           subject: true,
           dateFormat: true,
-          documentPassword: true,
+          password: true,
           timezone: true,
         },
       },

--- a/packages/lib/server-only/document/duplicate-document-by-id.ts
+++ b/packages/lib/server-only/document/duplicate-document-by-id.ts
@@ -26,6 +26,7 @@ export const duplicateDocumentById = async ({ id, userId }: DuplicateDocumentByI
           message: true,
           subject: true,
           dateFormat: true,
+          documentPassword: true,
           timezone: true,
         },
       },

--- a/packages/prisma/migrations/20240115031508_add_password_to_document_meta/migration.sql
+++ b/packages/prisma/migrations/20240115031508_add_password_to_document_meta/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DocumentMeta" ADD COLUMN     "password" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -162,7 +162,7 @@ model DocumentMeta {
   subject    String?
   message    String?
   timezone   String?  @db.Text @default("Etc/UTC")
-  documentPassword String?
+  password String?
   dateFormat String?  @db.Text @default("yyyy-MM-dd hh:mm a")
   documentId Int      @unique
   document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -162,6 +162,7 @@ model DocumentMeta {
   subject    String?
   message    String?
   timezone   String?  @db.Text @default("Etc/UTC")
+  documentPassword String?
   dateFormat String?  @db.Text @default("yyyy-MM-dd hh:mm a")
   documentId Int      @unique
   document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 
 import { getServerLimits } from '@documenso/ee/server-only/limits/server';
+import { DOCUMENSO_ENCRYPTION_KEY } from '@documenso/lib/constants/crypto';
 import { upsertDocumentMeta } from '@documenso/lib/server-only/document-meta/upsert-document-meta';
 import { createDocument } from '@documenso/lib/server-only/document/create-document';
 import { deleteDocument } from '@documenso/lib/server-only/document/delete-document';
@@ -13,6 +14,7 @@ import { sendDocument } from '@documenso/lib/server-only/document/send-document'
 import { updateTitle } from '@documenso/lib/server-only/document/update-title';
 import { setFieldsForDocument } from '@documenso/lib/server-only/field/set-fields-for-document';
 import { setRecipientsForDocument } from '@documenso/lib/server-only/recipient/set-recipients-for-document';
+import { symmetricEncrypt } from '@documenso/lib/universal/crypto';
 
 import { authenticatedProcedure, procedure, router } from '../trpc';
 import {
@@ -182,9 +184,20 @@ export const documentRouter = router({
       try {
         const { documentId, password } = input;
 
+        const key = DOCUMENSO_ENCRYPTION_KEY;
+
+        if (!key) {
+          throw new Error('Missing encryption key');
+        }
+
+        const securePassword = symmetricEncrypt({
+          data: password,
+          key,
+        });
+
         await upsertDocumentMeta({
           documentId,
-          password,
+          password: securePassword,
           userId: ctx.user.id,
         });
       } catch (err) {

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -24,6 +24,7 @@ import {
   ZSearchDocumentsMutationSchema,
   ZSendDocumentMutationSchema,
   ZSetFieldsForDocumentMutationSchema,
+  ZSetPasswordForDocumentMutationSchema,
   ZSetRecipientsForDocumentMutationSchema,
   ZSetTitleForDocumentMutationSchema,
 } from './schema';
@@ -174,6 +175,29 @@ export const documentRouter = router({
         });
       }
     }),
+  
+  setDocumentPassword: authenticatedProcedure
+     .input(ZSetPasswordForDocumentMutationSchema)
+     .mutation(async ({ input, ctx }) => {
+        try {
+          const { documentId, documentPassword } = input;
+          await upsertDocumentMeta({
+            documentId,
+            documentPassword,
+            userId: ctx.user.id,
+          });
+        
+        } catch (err) {
+          console.error(err);
+  
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'We were unable to send this document. Please try again later.',
+          });
+        }
+      }),
+
+      
 
   sendDocument: authenticatedProcedure
     .input(ZSendDocumentMutationSchema)

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -175,29 +175,27 @@ export const documentRouter = router({
         });
       }
     }),
-  
-  setDocumentPassword: authenticatedProcedure
-     .input(ZSetPasswordForDocumentMutationSchema)
-     .mutation(async ({ input, ctx }) => {
-        try {
-          const { documentId, documentPassword } = input;
-          await upsertDocumentMeta({
-            documentId,
-            documentPassword,
-            userId: ctx.user.id,
-          });
-        
-        } catch (err) {
-          console.error(err);
-  
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'We were unable to send this document. Please try again later.',
-          });
-        }
-      }),
 
-      
+  setPasswordForDocument: authenticatedProcedure
+    .input(ZSetPasswordForDocumentMutationSchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { documentId, password } = input;
+
+        await upsertDocumentMeta({
+          documentId,
+          password,
+          userId: ctx.user.id,
+        });
+      } catch (err) {
+        console.error(err);
+
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'We were unable to set the password for this document. Please try again later.',
+        });
+      }
+    }),
 
   sendDocument: authenticatedProcedure
     .input(ZSendDocumentMutationSchema)

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -73,6 +73,11 @@ export const ZSendDocumentMutationSchema = z.object({
   }),
 });
 
+export const ZSetPasswordForDocumentMutationSchema = z.object({
+  documentId: z.number(),
+  documentPassword: z.string(),
+});
+
 export const ZResendDocumentMutationSchema = z.object({
   documentId: z.number(),
   recipients: z.array(z.number()).min(1),

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -75,8 +75,12 @@ export const ZSendDocumentMutationSchema = z.object({
 
 export const ZSetPasswordForDocumentMutationSchema = z.object({
   documentId: z.number(),
-  documentPassword: z.string(),
+  password: z.string(),
 });
+
+export type TSetPasswordForDocumentMutationSchema = z.infer<
+  typeof ZSetPasswordForDocumentMutationSchema
+>;
 
 export const ZResendDocumentMutationSchema = z.object({
   documentId: z.number(),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -70,6 +70,7 @@
     "react-rnd": "^10.4.1",
     "tailwind-merge": "^1.12.0",
     "tailwindcss-animate": "^1.0.5",
-    "ts-pattern": "^5.0.5"
+    "ts-pattern": "^5.0.5",
+    "zod": "^3.22.4"
   }
 }

--- a/packages/ui/primitives/document-password-dialog.tsx
+++ b/packages/ui/primitives/document-password-dialog.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from './dialog'; 
+
+import { Input } from './input'; 
+import { Button } from './button'; 
+
+type PasswordDialogProps = {
+  open: boolean;
+  onOpenChange: (_open: boolean) => void;
+  setPassword: (_password: string) => void;
+  handleSubmit: () => void;
+  isError?: boolean;
+}
+
+export const PasswordDialog = ({ open, onOpenChange, handleSubmit, isError, setPassword }: PasswordDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Password Required</DialogTitle>
+          <DialogDescription>
+            {isError ? (
+              <p className="text-red-500">Incorrect password. Please try again.</p>
+            ) : (
+              <p className="text-muted-foreground">
+                This document is password protected. Please enter the password to view the document.
+              </p>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex w-full items-center justify-center gap-4">
+          <Input
+            id="password"
+            type="password"
+            className="bg-background mt-1.5"
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button onClick={handleSubmit}>Submit</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/ui/primitives/document-password-dialog.tsx
+++ b/packages/ui/primitives/document-password-dialog.tsx
@@ -1,55 +1,95 @@
-import React from 'react';
+import { useEffect } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { Button } from './button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from './dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './dialog';
+import { Form, FormControl, FormField, FormItem, FormMessage } from './form/form';
 import { Input } from './input';
+
+const ZPasswordDialogFormSchema = z.object({
+  password: z.string(),
+});
+
+type TPasswordDialogFormSchema = z.infer<typeof ZPasswordDialogFormSchema>;
 
 type PasswordDialogProps = {
   open: boolean;
   onOpenChange: (_open: boolean) => void;
-  setPassword: (_password: string) => void;
-  onPasswordSubmit: () => void;
+  defaultPassword?: string;
+  onPasswordSubmit?: (password: string) => void;
   isError?: boolean;
 };
 
 export const PasswordDialog = ({
   open,
   onOpenChange,
+  defaultPassword,
   onPasswordSubmit,
   isError,
-  setPassword,
 }: PasswordDialogProps) => {
+  const form = useForm<TPasswordDialogFormSchema>({
+    defaultValues: {
+      password: defaultPassword ?? '',
+    },
+    resolver: zodResolver(ZPasswordDialogFormSchema),
+  });
+
+  const onFormSubmit = ({ password }: TPasswordDialogFormSchema) => {
+    onPasswordSubmit?.(password);
+  };
+
+  useEffect(() => {
+    if (isError) {
+      form.setError('password', {
+        type: 'manual',
+        message: 'The password you have entered is incorrect. Please try again.',
+      });
+    }
+  }, [form, isError]);
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+    <Dialog open={open}>
+      <DialogContent className="w-full max-w-md">
         <DialogHeader>
           <DialogTitle>Password Required</DialogTitle>
+
           <DialogDescription className="text-muted-foreground">
             This document is password protected. Please enter the password to view the document.
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="flex w-full items-center justify-center gap-4">
-          <Input
-            type="password"
-            className="bg-background mt-1.5"
-            placeholder="Enter password"
-            onChange={(e) => setPassword(e.target.value)}
-            autoComplete="off"
-          />
-          <Button onClick={onPasswordSubmit}>Submit</Button>
-        </DialogFooter>
-        {isError && (
-          <span className="text-xs text-red-500">
-            The password you entered is incorrect. Please try again.
-          </span>
-        )}
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onFormSubmit)}>
+            <fieldset className="flex flex-wrap items-start justify-between gap-4">
+              <FormField
+                name="password"
+                control={form.control}
+                render={({ field }) => (
+                  <FormItem className="relative flex-1">
+                    <FormControl>
+                      <Input
+                        type="password"
+                        className="bg-background"
+                        placeholder="Enter password"
+                        autoComplete="off"
+                        {...field}
+                      />
+                    </FormControl>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div>
+                <Button>Submit</Button>
+              </div>
+            </fieldset>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/packages/ui/primitives/document-password-dialog.tsx
+++ b/packages/ui/primitives/document-password-dialog.tsx
@@ -28,19 +28,19 @@ export const PasswordDialog = ({ open, onOpenChange, handleSubmit, isError, setP
           <DialogTitle>Password Required</DialogTitle>
           <DialogDescription>
             {isError ? (
-              <p className="text-red-500">Incorrect password. Please try again.</p>
+              <span className="text-red-500">Incorrect password. Please try again.</span>
             ) : (
-              <p className="text-muted-foreground">
+              <span className="text-muted-foreground">
                 This document is password protected. Please enter the password to view the document.
-              </p>
+              </span>
             )}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex w-full items-center justify-center gap-4">
           <Input
-            id="password"
             type="password"
             className="bg-background mt-1.5"
+            placeholder='Enter password'
             onChange={(e) => setPassword(e.target.value)}
           />
           <Button onClick={handleSubmit}>Submit</Button>

--- a/packages/ui/primitives/document-password-dialog.tsx
+++ b/packages/ui/primitives/document-password-dialog.tsx
@@ -1,50 +1,55 @@
 import React from 'react';
 
+import { Button } from './button';
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
   DialogFooter,
-} from './dialog'; 
-
-import { Input } from './input'; 
-import { Button } from './button'; 
+  DialogHeader,
+  DialogTitle,
+} from './dialog';
+import { Input } from './input';
 
 type PasswordDialogProps = {
   open: boolean;
   onOpenChange: (_open: boolean) => void;
   setPassword: (_password: string) => void;
-  handleSubmit: () => void;
+  onPasswordSubmit: () => void;
   isError?: boolean;
-}
+};
 
-export const PasswordDialog = ({ open, onOpenChange, handleSubmit, isError, setPassword }: PasswordDialogProps) => {
+export const PasswordDialog = ({
+  open,
+  onOpenChange,
+  onPasswordSubmit,
+  isError,
+  setPassword,
+}: PasswordDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Password Required</DialogTitle>
-          <DialogDescription>
-            {isError ? (
-              <span className="text-red-500">Incorrect password. Please try again.</span>
-            ) : (
-              <span className="text-muted-foreground">
-                This document is password protected. Please enter the password to view the document.
-              </span>
-            )}
+          <DialogDescription className="text-muted-foreground">
+            This document is password protected. Please enter the password to view the document.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex w-full items-center justify-center gap-4">
           <Input
             type="password"
             className="bg-background mt-1.5"
-            placeholder='Enter password'
+            placeholder="Enter password"
             onChange={(e) => setPassword(e.target.value)}
+            autoComplete="off"
           />
-          <Button onClick={handleSubmit}>Submit</Button>
+          <Button onClick={onPasswordSubmit}>Submit</Button>
         </DialogFooter>
+        {isError && (
+          <span className="text-xs text-red-500">
+            The password you entered is incorrect. Please try again.
+          </span>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Current Behaviour - 
Presently, the behavior is quite default, which does not align with the theme. Additionally, the alert box appears to be somewhat stubborn.

https://github.com/documenso/documenso/assets/71957674/d681bef6-7ee3-4f27-b6db-34c6aaec6139


This PR fixes - 
I am overriding the default behavior by adding a password dialog component, which will only appear for password-protected documents.

https://github.com/documenso/documenso/assets/71957674/b1d05968-3c15-4abe-810f-e4186cfd1fcb

