### PR TITLE
fix: fixed the title box overlapping issue

### DIFF
--- a/packages/ui/primitives/document-flow/add-title.tsx
+++ b/packages/ui/primitives/document-flow/add-title.tsx
@@ -64,7 +64,7 @@ export const AddTitleFormPartial = ({
 
               <Input
                 id="title"
-                className="bg-background mt-2"
+                className="bg-background my-2"
                 disabled={isSubmitting}
                 {...register('title', { required: "Title can't be empty" })}
               />


### PR DESCRIPTION
The issue is fixed. Now the box is no more overlapping

<img width="305" alt="Screenshot 2023-12-26 at 10 20 32 AM" src="https://github.com/documenso/documenso/assets/77022877/bd17ed92-7bb0-4f3a-b0f6-173e5f6b5029">
