### PR TITLE
feat: jump to next field

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/form.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/form.tsx
@@ -49,6 +49,11 @@ export const SigningForm = ({ document, recipient, fields }: SigningFormProps) =
     return sortFieldsByPosition(fields.filter((field) => !field.inserted));
   }, [fields]);
 
+  const fieldsValidated = () => {
+    setValidateUninsertedFields(true);
+    validateFieldsInserted(fields);
+  };
+
   const onFormSubmit = async () => {
     setValidateUninsertedFields(true);
 
@@ -154,6 +159,7 @@ export const SigningForm = ({ document, recipient, fields }: SigningFormProps) =
                 onSignatureComplete={handleSubmit(onFormSubmit)}
                 document={document}
                 fields={fields}
+                fieldsValidated={fieldsValidated}
               />
             </div>
           </div>

--- a/apps/web/src/app/(signing)/sign/[token]/sign-dialog.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/sign-dialog.tsx
@@ -37,11 +37,10 @@ export const SignDialog = ({
           className="w-full"
           type="button"
           size="lg"
-          variant={isComplete ? 'default' : 'outline'}
           onClick={fieldsValidated}
           loading={isSubmitting}
         >
-          {isComplete ? 'Complete' : 'Fill fields'}
+          {isComplete ? 'Complete' : 'Next field'}
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/apps/web/src/app/(signing)/sign/[token]/sign-dialog.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/sign-dialog.tsx
@@ -15,6 +15,7 @@ export type SignDialogProps = {
   isSubmitting: boolean;
   document: Document;
   fields: Field[];
+  fieldsValidated: () => void | Promise<void>;
   onSignatureComplete: () => void | Promise<void>;
 };
 
@@ -22,6 +23,7 @@ export const SignDialog = ({
   isSubmitting,
   document,
   fields,
+  fieldsValidated,
   onSignatureComplete,
 }: SignDialogProps) => {
   const [showDialog, setShowDialog] = useState(false);
@@ -29,16 +31,17 @@ export const SignDialog = ({
   const isComplete = fields.every((field) => field.inserted);
 
   return (
-    <Dialog open={showDialog} onOpenChange={setShowDialog}>
+    <Dialog open={showDialog && isComplete} onOpenChange={isComplete ? setShowDialog : undefined}>
       <DialogTrigger asChild>
         <Button
           className="w-full"
           type="button"
           size="lg"
-          disabled={!isComplete}
+          variant={isComplete ? 'default' : 'outline'}
+          onClick={fieldsValidated}
           loading={isSubmitting}
         >
-          Complete
+          {isComplete ? 'Complete' : 'Fill fields'}
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/apps/web/src/app/(signing)/sign/[token]/sign-dialog.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/sign-dialog.tsx
@@ -31,7 +31,7 @@ export const SignDialog = ({
   const isComplete = fields.every((field) => field.inserted);
 
   return (
-    <Dialog open={showDialog && isComplete} onOpenChange={isComplete ? setShowDialog : undefined}>
+    <Dialog open={showDialog && isComplete} onOpenChange={setShowDialog}>
       <DialogTrigger asChild>
         <Button
           className="w-full"


### PR DESCRIPTION
Fixes #710

When the fields are not filled, the button will have the `outline` variant and it'll say "Fill fields". Clicking on the button takes you to the unfilled field.

![CleanShot 2024-01-05 at 12 58 24](https://github.com/documenso/documenso/assets/25515812/ed92b15a-47f1-4700-958b-071574868445)

Once all fields are filled, the button will be green and it'll say "Complete".

![CleanShot 2024-01-05 at 12 58 30](https://github.com/documenso/documenso/assets/25515812/d8b4f7a3-4b90-4766-bf67-7fd3b0d7b2e8)

Created the PR to move faster and ship the changes asap.

PR based on these PRs:
- https://github.com/documenso/documenso/pull/739 by @Hiperultimate
- https://github.com/documenso/documenso/pull/729 by @ksushant6566
- https://github.com/documenso/documenso/pull/730 by @ketanMehtaa

Thank you for the work, folks!