### PR TITLE
fix: fixed the deleting signature block issue on touchscreens

### DIFF
--- a/packages/ui/primitives/document-flow/field-item.tsx
+++ b/packages/ui/primitives/document-flow/field-item.tsx
@@ -121,6 +121,7 @@ export const FieldItem = ({
         <button
           className="text-muted-foreground/50 hover:text-muted-foreground/80 bg-background absolute -right-2 -top-2 z-20 flex h-8 w-8 items-center justify-center rounded-full border"
           onClick={() => onRemove?.()}
+          onTouchEnd={() => onRemove?.()}
         >
           <Trash className="h-4 w-4" />
         </button>


### PR DESCRIPTION
## Description

Fixed the deleting signature block issue on touchscreens, for some reason the `onClick` event isn't working on the touchscreens that's why I've added `onTouchEnd` event to delete the signature block when the user clicks on it.

## Changes
 1. Added an `onTouchEnd` event to the delete button on the signature block.

## Preview

https://github.com/documenso/documenso/assets/87828904/c952a5ff-3188-4859-852c-617547d4b369

## Issue

Closes #798 