### PR TITLE
fix: display the number of documents in mobile view

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/page.tsx
@@ -88,7 +88,7 @@ export default async function DocumentsPage({ searchParams = {} }: DocumentsPage
                     <DocumentStatus status={value} />
 
                     {value !== ExtendedDocumentStatus.ALL && (
-                      <span className="ml-1 opacity-50 md:inline-block">
+                      <span className="ml-1 inline-block opacity-50">
                         {Math.min(stats[value], 99)}
                         {stats[value] > 99 && '+'}
                       </span>

--- a/apps/web/src/app/(dashboard)/documents/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/page.tsx
@@ -88,7 +88,7 @@ export default async function DocumentsPage({ searchParams = {} }: DocumentsPage
                     <DocumentStatus status={value} />
 
                     {value !== ExtendedDocumentStatus.ALL && (
-                      <span className="ml-1 hidden opacity-50 md:inline-block">
+                      <span className="ml-1 opacity-50 md:inline-block">
                         {Math.min(stats[value], 99)}
                         {stats[value] > 99 && '+'}
                       </span>


### PR DESCRIPTION
This PR fixes #782.
It now displays the document count on mobile view.

Screenshot:

![Screenshot 2024-01-16 at 20 47 04](https://github.com/documenso/documenso/assets/67555014/5057a9fe-e374-4db5-ba6c-c5b92fe43d0b)
