### PR TITLE
fix: added CommandSeparator(s) to CommandMenu

### DIFF
--- a/apps/web/src/components/(dashboard)/common/command-menu.tsx
+++ b/apps/web/src/components/(dashboard)/common/command-menu.tsx
@@ -21,6 +21,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
   CommandShortcut,
 } from '@documenso/ui/primitives/command';
 import { THEMES_TYPE } from '@documenso/ui/primitives/constants';
@@ -185,15 +186,19 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
             <CommandGroup heading="Documents">
               <Commands push={push} pages={DOCUMENTS_PAGES} />
             </CommandGroup>
+            <CommandSeparator />
             <CommandGroup heading="Templates">
               <Commands push={push} pages={TEMPLATES_PAGES} />
             </CommandGroup>
+            <CommandSeparator />
             <CommandGroup heading="Settings">
               <Commands push={push} pages={SETTINGS_PAGES} />
             </CommandGroup>
+            <CommandSeparator />
             <CommandGroup heading="Preferences">
               <CommandItem onSelect={() => addPage('theme')}>Change theme</CommandItem>
             </CommandGroup>
+            <CommandSeparator />
             {searchResults.length > 0 && (
               <CommandGroup heading="Your documents">
                 <Commands push={push} pages={searchResults} />


### PR DESCRIPTION
## Related Issue
Fixes [#836](https://github.com/documenso/documenso/issues/836)

## Changes Made
Added Separators to Command Menu Groups

Before:
![image](https://github.com/documenso/documenso/assets/20276256/bad14618-fdc2-47a6-bdb0-8631a1cfbaa3)

After:
![image](https://github.com/documenso/documenso/assets/20276256/8775ef1d-38c9-413c-816e-aeddccef3d27)
