### PR TITLE
fix: improved document-dropzone ui for small vertical screens

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/upload-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/upload-document.tsx
@@ -96,10 +96,12 @@ export const UploadDocument = ({ className }: UploadDocumentProps) => {
     }
   };
 
+  const isSmallVerticalScreen = typeof window !== 'undefined' && window.innerHeight < 800;
+
   return (
     <div className={cn('relative', className)}>
       <DocumentDropzone
-        className="min-h-[40vh]"
+        className={`${isSmallVerticalScreen ? 'min-h-[50vh]' : 'min-h-[40vh]'}`}
         disabled={remaining.documents === 0 || !session?.user.emailVerified}
         disabledMessage={disabledMessage}
         onDrop={onFileDrop}


### PR DESCRIPTION
Document Dropzone UI is not looking good in screens with small vertical size (size less than 800px)
This PR fixes it.

fixes: #840 