### PR TITLE
fix: completed/pending status gets incremented once if sender is one of the recipients

### DIFF
--- a/packages/lib/server-only/document/get-stats.ts
+++ b/packages/lib/server-only/document/get-stats.ts
@@ -42,6 +42,11 @@ export const getStats = async ({ user }: GetStatsInput) => {
         _all: true,
       },
       where: {
+        User: {
+          email: {
+            not: user.email,
+          },
+        },
         OR: [
           {
             status: ExtendedDocumentStatus.PENDING,
@@ -49,11 +54,6 @@ export const getStats = async ({ user }: GetStatsInput) => {
               some: {
                 email: user.email,
                 signingStatus: SigningStatus.SIGNED,
-              },
-            },
-            User: {
-              email: {
-                not: user.email,
               },
             },
             deletedAt: null,
@@ -64,11 +64,6 @@ export const getStats = async ({ user }: GetStatsInput) => {
               some: {
                 email: user.email,
                 signingStatus: SigningStatus.SIGNED,
-              },
-            },
-            User: {
-              email: {
-                not: user.email,
               },
             },
           },

--- a/packages/lib/server-only/document/get-stats.ts
+++ b/packages/lib/server-only/document/get-stats.ts
@@ -51,6 +51,11 @@ export const getStats = async ({ user }: GetStatsInput) => {
                 signingStatus: SigningStatus.SIGNED,
               },
             },
+            User: {
+              email: {
+                not: user.email,
+              },
+            },
             deletedAt: null,
           },
           {
@@ -59,6 +64,11 @@ export const getStats = async ({ user }: GetStatsInput) => {
               some: {
                 email: user.email,
                 signingStatus: SigningStatus.SIGNED,
+              },
+            },
+            User: {
+              email: {
+                not: user.email,
               },
             },
           },


### PR DESCRIPTION
completed/pending status gets incremented once if sender is one of the recipients

fixes #853 