### PR TITLE
fix: auto verify google sso emails

### DIFF
--- a/packages/lib/next-auth/auth-options.ts
+++ b/packages/lib/next-auth/auth-options.ts
@@ -93,7 +93,7 @@ export const NEXT_AUTH_OPTIONS: AuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, account }) {
       const merged = {
         ...token,
         ...user,
@@ -132,6 +132,23 @@ export const NEXT_AUTH_OPTIONS: AuthOptions = {
           },
           data: {
             lastSignedIn: merged.lastSignedIn,
+          },
+        });
+
+        merged.emailVerified = user.emailVerified?.toISOString() ?? null;
+      }
+
+      if (
+        (trigger === 'signIn' || trigger === 'signUp') &&
+        merged.emailVerified === null &&
+        account?.provider === 'google'
+      ) {
+        const user = await prisma.user.update({
+          where: {
+            id: Number(merged.id),
+          },
+          data: {
+            emailVerified: new Date().toISOString(),
           },
         });
 


### PR DESCRIPTION
## Description

Currently logging in via Google SSO will still require you to verify your email. This shouldn't happen since going through Google SSO implies you have access to that email.

## Changes Made

This change resolves that by setting the `emailVerified` attribute in the database when you access the application via Google SSO.

This also updates the identity provider for users who log in through Google to have it correctly set as `GOOGLE`.

## Testing Performed

- Logged in via SSO and no email verification was requested
- Logged in via non SSO and email verification was requested

## Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have followed the project's coding style guidelines.
