### PR TITLE
fix: fix header layout shift

### DIFF
--- a/apps/web/src/components/(dashboard)/layout/desktop-nav.tsx
+++ b/apps/web/src/components/(dashboard)/layout/desktop-nav.tsx
@@ -42,7 +42,7 @@ export const DesktopNav = ({ className, ...props }: DesktopNavProps) => {
   return (
     <div
       className={cn(
-        'ml-8 hidden flex-1 items-center gap-x-12 md:flex md:justify-between',
+        'ml-8 hidden flex-1 items-center gap-x-12 lg:flex lg:justify-between',
         className,
       )}
       {...props}

--- a/apps/web/src/components/(dashboard)/layout/header.tsx
+++ b/apps/web/src/components/(dashboard)/layout/header.tsx
@@ -33,13 +33,13 @@ export const Header = ({ className, user, ...props }: HeaderProps) => {
   return (
     <header
       className={cn(
-        'supports-backdrop-blur:bg-background/60 bg-background/95 sticky top-0 z-[50] flex h-16 w-[calc(100vw-8rem)] items-center border-b border-b-transparent backdrop-blur duration-200',
+        'supports-backdrop-blur:bg-background/60 bg-background/95 sticky top-0 z-[50] flex h-16 w-[100vw] items-center border-b border-b-transparent backdrop-blur duration-200 lg:w-[calc(100vw-2rem)] lg:pl-4',
         scrollY > 5 && 'border-b-border',
         className,
       )}
       {...props}
     >
-      <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between gap-x-4 px-4 md:justify-normal md:px-8">
+      <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between gap-x-4 px-4 md:px-8">
         <Link
           href="/"
           className="focus-visible:ring-ring ring-offset-background rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"

--- a/apps/web/src/components/(dashboard)/layout/header.tsx
+++ b/apps/web/src/components/(dashboard)/layout/header.tsx
@@ -33,7 +33,7 @@ export const Header = ({ className, user, ...props }: HeaderProps) => {
   return (
     <header
       className={cn(
-        'supports-backdrop-blur:bg-background/60 bg-background/95 sticky top-0 z-[50] flex h-16 w-full items-center border-b border-b-transparent backdrop-blur duration-200',
+        'supports-backdrop-blur:bg-background/60 bg-background/95 sticky top-0 z-[50] flex h-16 w-[calc(100vw-8rem)] items-center border-b border-b-transparent backdrop-blur duration-200',
         scrollY > 5 && 'border-b-border',
         className,
       )}


### PR DESCRIPTION
fix #875 

The problem was due to the scroll bar. Solution is to use ``vw`` unit for header as they are not affected by scroll-bars.

Loom: https://www.loom.com/share/057755740fca48c18bccb08912b65f5c?sid=3b3b674c-3991-45bb-871d-f7795a145525