### PR TITLE
fix: active-tab correctly changes to the currently active documents section

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/page.tsx
+++ b/apps/web/src/app/(dashboard)/documents/page.tsx
@@ -74,7 +74,7 @@ export default async function DocumentsPage({ searchParams = {} }: DocumentsPage
         <h1 className="text-4xl font-semibold">Documents</h1>
 
         <div className="-m-1 flex flex-wrap gap-x-4 gap-y-6 overflow-hidden p-1">
-          <Tabs defaultValue={status} className="overflow-x-auto">
+          <Tabs defaultValue={status} value={status} className="overflow-x-auto">
             <TabsList>
               {[
                 ExtendedDocumentStatus.INBOX,

--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -57,6 +57,12 @@ module.exports = {
         },
       },
     ],
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
 
     // Safety with promises so we aren't running with scissors
     'no-promise-executor-return': 'error',


### PR DESCRIPTION
fixes: #890 