### PR TITLE
fix: update field remove logic

### DIFF
--- a/packages/lib/server-only/field/set-fields-for-document.ts
+++ b/packages/lib/server-only/field/set-fields-for-document.ts
@@ -56,11 +56,7 @@ export const setFieldsForDocument = async ({
   });
 
   const removedFields = existingFields.filter(
-    (existingField) =>
-      !fields.find(
-        (field) =>
-          field.id === existingField.id || field.signerEmail === existingField.Recipient?.email,
-      ),
+    (existingField) => !fields.find((field) => field.id === existingField.id),
   );
 
   const linkedFields = fields


### PR DESCRIPTION
## Description

Fixed issue where you are prevented from removing fields for a recipient that has multiple fields.

Example:

Recipient has 3 fields, you remove 1 and proceed to next step. In the next step the field reappears as it was not deleted.

## Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have followed the project's coding style guidelines.
