### PR TITLE
fix: redirect URL preventing document flow

### DIFF
--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { URL_REGEX } from '@documenso/lib/constants/url-regex';
 import { DocumentStatus, FieldType, RecipientRole } from '@documenso/prisma/client';
 
 export const ZGetDocumentByIdQuerySchema = z.object({
@@ -74,12 +73,7 @@ export const ZSendDocumentMutationSchema = z.object({
     message: z.string(),
     timezone: z.string(),
     dateFormat: z.string(),
-    redirectUrl: z
-      .string()
-      .optional()
-      .refine((value) => value === undefined || URL_REGEX.test(value), {
-        message: 'Please enter a valid URL',
-      }),
+    redirectUrl: z.string().trim().url().optional().or(z.literal('')),
   }),
 });
 

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { URL_REGEX } from '@documenso/lib/constants/url-regex';
 import { DocumentStatus, FieldType, RecipientRole } from '@documenso/prisma/client';
 
 export const ZGetDocumentByIdQuerySchema = z.object({
@@ -73,7 +74,12 @@ export const ZSendDocumentMutationSchema = z.object({
     message: z.string(),
     timezone: z.string(),
     dateFormat: z.string(),
-    redirectUrl: z.string().trim().url().optional().or(z.literal('')),
+    redirectUrl: z
+      .string()
+      .optional()
+      .refine((value) => value === undefined || value === '' || URL_REGEX.test(value), {
+        message: 'Please enter a valid URL',
+      }),
   }),
 });
 

--- a/packages/ui/primitives/document-flow/add-subject.types.ts
+++ b/packages/ui/primitives/document-flow/add-subject.types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { DEFAULT_DOCUMENT_DATE_FORMAT } from '@documenso/lib/constants/date-formats';
 import { DEFAULT_DOCUMENT_TIME_ZONE } from '@documenso/lib/constants/time-zones';
+import { URL_REGEX } from '@documenso/lib/constants/url-regex';
 
 export const ZAddSubjectFormSchema = z.object({
   meta: z.object({
@@ -11,9 +12,10 @@ export const ZAddSubjectFormSchema = z.object({
     dateFormat: z.string().optional().default(DEFAULT_DOCUMENT_DATE_FORMAT),
     redirectUrl: z
       .string()
-      .url({ message: 'Please enter a valid URL' })
       .optional()
-      .or(z.literal('')),
+      .refine((value) => value === undefined || value === '' || URL_REGEX.test(value), {
+        message: 'Please enter a valid URL',
+      }),
   }),
 });
 

--- a/packages/ui/primitives/document-flow/add-subject.types.ts
+++ b/packages/ui/primitives/document-flow/add-subject.types.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 import { DEFAULT_DOCUMENT_DATE_FORMAT } from '@documenso/lib/constants/date-formats';
 import { DEFAULT_DOCUMENT_TIME_ZONE } from '@documenso/lib/constants/time-zones';
-import { URL_REGEX } from '@documenso/lib/constants/url-regex';
 
 export const ZAddSubjectFormSchema = z.object({
   meta: z.object({
@@ -12,10 +11,9 @@ export const ZAddSubjectFormSchema = z.object({
     dateFormat: z.string().optional().default(DEFAULT_DOCUMENT_DATE_FORMAT),
     redirectUrl: z
       .string()
+      .url({ message: 'Please enter a valid URL' })
       .optional()
-      .refine((value) => value === undefined || URL_REGEX.test(value), {
-        message: 'Please enter a valid URL',
-      }),
+      .or(z.literal('')),
   }),
 });
 


### PR DESCRIPTION
## Description

Currently the document redirect URL feature is preventing documents from being created unless a redirect URL is provided.

During the document edit flow, the redirect URL is hidden in an advanced tab with the value of an empty string, which will always fail the current Zod validation since `optional` requires undefined to pass.

There are multiple ways to fix this, but I think this is the easiest method where we can assume an empty string is valid.

## Testing Performed

Will require retesting the feature since I'm just assuming an empty string won't break anything downstream for the redirect URL feature.

Pinging @adithyaakrishna to retest the feature.