### PR TITLE
fix: restrict team verification tokens

### DIFF
--- a/apps/web/src/app/(teams)/t/[teamUrl]/settings/team-transfer-status.tsx
+++ b/apps/web/src/app/(teams)/t/[teamUrl]/settings/team-transfer-status.tsx
@@ -18,7 +18,7 @@ export type TeamTransferStatusProps = {
   className?: string;
   currentUserTeamRole: TeamMemberRole;
   teamId: number;
-  transferVerification: TeamTransferVerification | null;
+  transferVerification: Pick<TeamTransferVerification, 'email' | 'expiresAt' | 'name'> | null;
 };
 
 export const TeamTransferStatus = ({

--- a/packages/lib/server-only/team/get-team.ts
+++ b/packages/lib/server-only/team/get-team.ts
@@ -72,8 +72,20 @@ export const getTeamByUrl = async ({ userId, teamUrl }: GetTeamByUrlOptions) => 
     where: whereFilter,
     include: {
       teamEmail: true,
-      emailVerification: true,
-      transferVerification: true,
+      emailVerification: {
+        select: {
+          expiresAt: true,
+          name: true,
+          email: true,
+        },
+      },
+      transferVerification: {
+        select: {
+          expiresAt: true,
+          name: true,
+          email: true,
+        },
+      },
       subscription: true,
       members: {
         where: {


### PR DESCRIPTION
## Description

Currently we're not restricting team transfer and email verification tokens from flowing into the frontend.

This changes restricts it to only return the required information instead of the whole data object.