### PR TITLE
feat: document version history view

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/data-table-action-dropdown.tsx
+++ b/apps/web/src/app/(dashboard)/documents/data-table-action-dropdown.tsx
@@ -10,6 +10,7 @@ import {
   Download,
   Edit,
   EyeIcon,
+  FileClock,
   Loader,
   MoreHorizontal,
   Pencil,
@@ -37,6 +38,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 
 import { ResendDocumentActionItem } from './_action-items/resend-document';
 import { DeleteDocumentDialog } from './delete-document-dialog';
+import { DocumentHistoryDialog } from './document-history-dialog';
 import { DuplicateDocumentDialog } from './duplicate-document-dialog';
 
 export type DataTableActionDropdownProps = {
@@ -54,6 +56,7 @@ export const DataTableActionDropdown = ({ row, team }: DataTableActionDropdownPr
 
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDuplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
+  const [isHistoryDialogOpen, setHistoryDialogOpen] = useState(false);
 
   if (!session) {
     return null;
@@ -168,6 +171,11 @@ export const DataTableActionDropdown = ({ row, team }: DataTableActionDropdownPr
           Delete
         </DropdownMenuItem>
 
+        <DropdownMenuItem onClick={() => setHistoryDialogOpen(true)}>
+          <FileClock className="mr-2 h-4 w-4" />
+          Version History
+        </DropdownMenuItem>
+
         <DropdownMenuLabel>Share</DropdownMenuLabel>
 
         <ResendDocumentActionItem document={row} recipients={nonSignedRecipients} team={team} />
@@ -201,6 +209,13 @@ export const DataTableActionDropdown = ({ row, team }: DataTableActionDropdownPr
           open={isDuplicateDialogOpen}
           onOpenChange={setDuplicateDialogOpen}
           team={team}
+        />
+      )}
+      {isHistoryDialogOpen && (
+        <DocumentHistoryDialog
+          id={row.id}
+          open={isHistoryDialogOpen}
+          onOpenChange={setHistoryDialogOpen}
         />
       )}
     </DropdownMenu>

--- a/apps/web/src/app/(dashboard)/documents/document-history-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/documents/document-history-dialog.tsx
@@ -1,0 +1,49 @@
+import { trpc as trpcReact } from '@documenso/trpc/react';
+import { Button } from '@documenso/ui/primitives/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@documenso/ui/primitives/dialog';
+
+type DocumentHistoryDialogProps = {
+  id: number;
+  open: boolean;
+  onOpenChange: (_open: boolean) => void;
+};
+
+export const DocumentHistoryDialog = ({ id, open, onOpenChange }: DocumentHistoryDialogProps) => {
+  const { data: history, isLoading } = trpcReact.document.getDocumentById.useQuery({ id });
+  return (
+    <Dialog open={open} onOpenChange={(value) => !isLoading && onOpenChange(value)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Version History</DialogTitle>
+        </DialogHeader>
+
+        <div className="mx-auto -mt-4 flex w-full max-w-screen-xl flex-col px-4 md:px-8">
+          <h1>Document Audit Logs</h1>
+        </div>
+
+        <DialogFooter>
+          <div className="flex w-full flex-1 flex-nowrap gap-4">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+              className="flex-1"
+            >
+              Download Certificate
+            </Button>
+
+            <Button type="button" disabled={isLoading} className="flex-1">
+              Save as PDF
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/src/app/(dashboard)/documents/document-history-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/documents/document-history-dialog.tsx
@@ -15,7 +15,8 @@ type DocumentHistoryDialogProps = {
 };
 
 export const DocumentHistoryDialog = ({ id, open, onOpenChange }: DocumentHistoryDialogProps) => {
-  const { data: history, isLoading } = trpcReact.document.getDocumentById.useQuery({ id });
+  const { data: auditLogs, isLoading } =
+    trpcReact.document.getDocumentAuditLogsByDocumentId.useQuery({ id });
   return (
     <Dialog open={open} onOpenChange={(value) => !isLoading && onOpenChange(value)}>
       <DialogContent>
@@ -23,9 +24,20 @@ export const DocumentHistoryDialog = ({ id, open, onOpenChange }: DocumentHistor
           <DialogTitle>Version History</DialogTitle>
         </DialogHeader>
 
-        <div className="mx-auto -mt-4 flex w-full max-w-screen-xl flex-col px-4 md:px-8">
-          <h1>Document Audit Logs</h1>
-        </div>
+        {!auditLogs || isLoading ? (
+          <div>loading...</div>
+        ) : (
+          <div className="mx-auto -mt-4 flex w-full max-w-screen-xl flex-col px-4 md:px-8">
+            <h1>Document Audit Logs ({auditLogs.length})</h1>
+            <ul>
+              {auditLogs.map((log) => (
+                <li key={log.id}>
+                  {log.createdAt.toString()}: {log.type} by {log.email}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         <DialogFooter>
           <div className="flex w-full flex-1 flex-nowrap gap-4">

--- a/packages/lib/server-only/document/get-document-audit-logs-by-document-id.ts
+++ b/packages/lib/server-only/document/get-document-audit-logs-by-document-id.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@documenso/prisma';
+
+export interface GetDocumentAuditLogsByDocumentIdOptions {
+  id: number;
+}
+
+export const getDocumentAuditLogsByDocumentId = async ({
+  id,
+}: GetDocumentAuditLogsByDocumentIdOptions) => {
+  const document = await prisma.document.findUnique({ where: { id } });
+
+  if (!document) {
+    throw new Error('Document not found');
+  }
+
+  return await prisma.documentAuditLog.findMany({ where: { documentId: id } });
+};

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -309,7 +309,7 @@ export const documentRouter = router({
 
   getDocumentAuditLogsByDocumentId: authenticatedProcedure
     .input(ZGetDocumentAuditLogsByDocumentIdQuerySchema)
-    .query(async ({ input, ctx }) => {
+    .query(async ({ input }) => {
       try {
         return await getDocumentAuditLogsByDocumentId(input);
       } catch (err) {

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -6,6 +6,7 @@ import { upsertDocumentMeta } from '@documenso/lib/server-only/document-meta/ups
 import { createDocument } from '@documenso/lib/server-only/document/create-document';
 import { deleteDocument } from '@documenso/lib/server-only/document/delete-document';
 import { duplicateDocumentById } from '@documenso/lib/server-only/document/duplicate-document-by-id';
+import { getDocumentAuditLogsByDocumentId } from '@documenso/lib/server-only/document/get-document-audit-logs-by-document-id';
 import { getDocumentById } from '@documenso/lib/server-only/document/get-document-by-id';
 import { getDocumentAndSenderByToken } from '@documenso/lib/server-only/document/get-document-by-token';
 import { resendDocument } from '@documenso/lib/server-only/document/resend-document';
@@ -21,6 +22,7 @@ import { authenticatedProcedure, procedure, router } from '../trpc';
 import {
   ZCreateDocumentMutationSchema,
   ZDeleteDraftDocumentMutationSchema,
+  ZGetDocumentAuditLogsByDocumentIdQuerySchema,
   ZGetDocumentByIdQuerySchema,
   ZGetDocumentByTokenQuerySchema,
   ZResendDocumentMutationSchema,
@@ -301,6 +303,21 @@ export const documentRouter = router({
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'We are unable to search for documents. Please try again later.',
+        });
+      }
+    }),
+
+  getDocumentAuditLogsByDocumentId: authenticatedProcedure
+    .input(ZGetDocumentAuditLogsByDocumentIdQuerySchema)
+    .query(async ({ input, ctx }) => {
+      try {
+        return await getDocumentAuditLogsByDocumentId(input);
+      } catch (err) {
+        console.error(err);
+
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'We were unable to find audit logs for this document. Please try again later.',
         });
       }
     }),

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -110,3 +110,7 @@ export type TDeleteDraftDocumentMutationSchema = z.infer<typeof ZDeleteDraftDocu
 export const ZSearchDocumentsMutationSchema = z.object({
   query: z.string(),
 });
+
+export const ZGetDocumentAuditLogsByDocumentIdQuerySchema = z.object({
+  id: z.number().min(1),
+});


### PR DESCRIPTION
This PR adds UI to the existing DocumentAuditLog records.
<img width="1257" alt="version-history-action" src="https://github.com/documenso/documenso/assets/21358/3adb1846-8d49-46c4-887b-8e498cf9c1c2">

Changes:
* Added new function to fetch document audit logs by document id
* Added the mentioned function into the document router
* Added a new Action/Dialog within the Documents list, and fetch available audit logs for the selected document.