### PR TITLE
feat: save document logs as pdf

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -25,6 +25,7 @@ const config = {
     serverActions: {
       bodySizeLimit: '50mb',
     },
+    serverComponentsExternalPackages: ['@react-pdf/renderer'],
   },
   reactStrictMode: true,
   transpilePackages: [

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -7,7 +7,7 @@ import { getRequiredServerComponentSession } from '@documenso/lib/next-auth/get-
 import { getDocumentById } from '@documenso/lib/server-only/document/get-document-by-id';
 import { getRecipientsForDocument } from '@documenso/lib/server-only/recipient/get-recipients-for-document';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
-import type { Recipient, Team } from '@documenso/prisma/client';
+import { DocumentStatus, type Recipient, type Team } from '@documenso/prisma/client';
 import { Button } from '@documenso/ui/primitives/button';
 import { Card } from '@documenso/ui/primitives/card';
 
@@ -108,17 +108,19 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
           {document.title}
         </h1>
 
-        <div className="mt-4 flex w-full flex-row sm:mt-0 sm:w-auto sm:self-end">
-          <Button variant="outline" className="mr-2 w-full sm:w-auto">
-            <DownloadIcon className="mr-1.5 h-4 w-4" />
-            Download certificate
-          </Button>
+        {document.status === DocumentStatus.COMPLETED && (
+          <div className="mt-4 flex w-full flex-row sm:mt-0 sm:w-auto sm:self-end">
+            <Button variant="outline" className="mr-2 w-full sm:w-auto">
+              <DownloadIcon className="mr-1.5 h-4 w-4" />
+              Download certificate
+            </Button>
 
-          <Button className="w-full sm:w-auto">
-            <DownloadIcon className="mr-1.5 h-4 w-4" />
-            Download PDF
-          </Button>
-        </div>
+            <Button className="w-full sm:w-auto">
+              <DownloadIcon className="mr-1.5 h-4 w-4" />
+              Download PDF
+            </Button>
+          </div>
+        )}
       </div>
 
       <section className="mt-6">

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, DownloadIcon } from 'lucide-react';
 
 import { getRequiredServerComponentSession } from '@documenso/lib/next-auth/get-server-component-session';
 import { getDocumentById } from '@documenso/lib/server-only/document/get-document-by-id';
+import { getOrGenerateDocumentLogs } from '@documenso/lib/server-only/document/get-or-generate-document-logs';
 import { getRecipientsForDocument } from '@documenso/lib/server-only/recipient/get-recipients-for-document';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { DocumentStatus, type Recipient, type Team } from '@documenso/prisma/client';
@@ -50,6 +51,16 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
 
   if (!document || !document.documentData) {
     redirect(documentRootPath);
+  }
+
+  const isCompleted = document.status === DocumentStatus.COMPLETED;
+
+  if (isCompleted) {
+    const auditLogsData = await getOrGenerateDocumentLogs({
+      documentId,
+      userId: user.id,
+      teamId: team?.id,
+    });
   }
 
   const documentInformation: { description: string; value: string }[] = [
@@ -108,7 +119,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
           {document.title}
         </h1>
 
-        {document.status === DocumentStatus.COMPLETED && (
+        {isCompleted && (
           <div className="mt-4 flex w-full flex-row sm:mt-0 sm:w-auto sm:self-end">
             <Button variant="outline" className="mr-2 w-full sm:w-auto">
               <DownloadIcon className="mr-1.5 h-4 w-4" />

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -9,6 +9,7 @@ import { getOrGenerateDocumentLogs } from '@documenso/lib/server-only/document/g
 import { getRecipientsForDocument } from '@documenso/lib/server-only/recipient/get-recipients-for-document';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { DocumentStatus, type Recipient, type Team } from '@documenso/prisma/client';
+import { DocumentAdditionalDataDownloadButton } from '@documenso/ui/components/document/document-additional-data-download-button';
 import { Button } from '@documenso/ui/primitives/button';
 import { Card } from '@documenso/ui/primitives/card';
 
@@ -55,13 +56,13 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
 
   const isCompleted = document.status === DocumentStatus.COMPLETED;
 
-  if (isCompleted) {
-    const auditLogsData = await getOrGenerateDocumentLogs({
-      documentId,
-      userId: user.id,
-      teamId: team?.id,
-    });
-  }
+  const logDocumentData = isCompleted
+    ? await getOrGenerateDocumentLogs({
+        documentId,
+        userId: user.id,
+        teamId: team?.id,
+      })
+    : null;
 
   const documentInformation: { description: string; value: string }[] = [
     {
@@ -126,10 +127,15 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
               Download certificate
             </Button>
 
-            <Button className="w-full sm:w-auto">
-              <DownloadIcon className="mr-1.5 h-4 w-4" />
-              Download PDF
-            </Button>
+            {logDocumentData !== null && (
+              <DocumentAdditionalDataDownloadButton
+                className="w-full sm:w-auto"
+                docTitle={document.title}
+                documentData={logDocumentData}
+              >
+                Download PDF
+              </DocumentAdditionalDataDownloadButton>
+            )}
           </div>
         )}
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5557,6 +5557,167 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-2.2.1.tgz",
+      "integrity": "sha512-s78aDg0vDYaijU5lLOCsUD+qinQbfOvcNeaoX9AiE7+kZzzCo6B/nX+l48cmt9OosJmvZvE9DWR9cLhrhOi2pA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13"
+      }
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-2.4.4.tgz",
+      "integrity": "sha512-yjK5eSY+LcbxS0m+sOYln8GdgIbUgti4xjwf14kx8OSsOMJQJyHFALHMh2cLcKJR9yZeqVDo1FwCsY6gw1yCkg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/types": "^2.4.1",
+        "cross-fetch": "^3.1.5",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-2.3.4.tgz",
+      "integrity": "sha512-IE34l7gfTdaxXe3XR9240xMZsFdxF1myIwmEWK28XoeTaucUPAUyOiNcFSGRT59vNuZVBuakYz3BlGGrkvAPVQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^2.3.1",
+        "cross-fetch": "^3.1.5",
+        "jay-peg": "^1.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-3.11.2.tgz",
+      "integrity": "sha512-5EiHJ+Eb0odqnkWll9pWbTp+dwH1QRm7mOXDMiklqIWK98eI7e3cEae5Dgr0TtdnB7KgPW9Tvul2CwRJTwq54A==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "2.2.1",
+        "@react-pdf/image": "^2.3.4",
+        "@react-pdf/pdfkit": "^3.1.6",
+        "@react-pdf/primitives": "^3.1.1",
+        "@react-pdf/stylesheet": "^4.2.4",
+        "@react-pdf/textkit": "^4.4.1",
+        "@react-pdf/types": "^2.4.1",
+        "cross-fetch": "^3.1.5",
+        "emoji-regex": "^10.3.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^2.0.1"
+      }
+    },
+    "node_modules/@react-pdf/layout/node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-3.1.6.tgz",
+      "integrity": "sha512-U96VVhphniDBsLbmeJHgEml15nng8cr90mmEfPATh98gsqg6wev0avBr4k9XPjLdaN1f2xTXD4VdlaMYJZ+n7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^2.3.1",
+        "browserify-zlib": "^0.2.0",
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/png-js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-2.3.1.tgz",
+      "integrity": "sha512-pEZ18I4t1vAUS4lmhvXPmXYP4PHeblpWP/pAlMMRkEyP7tdAeHUN7taQl9sf9OPq7YITMY3lWpYpJU6t4CZgZg==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-3.1.1.tgz",
+      "integrity": "sha512-miwjxLwTnO3IjoqkTVeTI+9CdyDggwekmSLhVCw+a/7FoQc+gF3J2dSKwsHvAcVFM0gvU8mzCeTofgw0zPDq0w=="
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-3.4.3.tgz",
+      "integrity": "sha512-9LL059vfwrK1gA0uIA4utpQ/pUH9EW/yia4bb7pCoARs8IlupY5UP265jgax15ua0p+MdUwShZzQ9rilu7kGsw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "2.2.1",
+        "@react-pdf/primitives": "^3.1.1",
+        "@react-pdf/textkit": "^4.4.1",
+        "@react-pdf/types": "^2.4.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^1.9.1",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-3.3.8.tgz",
+      "integrity": "sha512-wJESEZCNNbog4MxDjRgKtgdmyGm+lDce9cMX2THRs1Jltckq3M8N0yt/fkvGyB8nwiDPtEBOsz9JKlw5vLidbw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/font": "^2.4.4",
+        "@react-pdf/layout": "^3.11.2",
+        "@react-pdf/pdfkit": "^3.1.6",
+        "@react-pdf/primitives": "^3.1.1",
+        "@react-pdf/render": "^3.4.3",
+        "@react-pdf/types": "^2.4.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1",
+        "scheduler": "^0.17.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer/node_modules/scheduler": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+      "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-4.2.4.tgz",
+      "integrity": "sha512-CgRfDzeMtnV0GL7zSn381NubmgwqKhFKcK1YrWX3azl/KWVh52jjFd3HWi6dvcETNT862mjWz5MnExe4WOBJXA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "2.2.1",
+        "@react-pdf/types": "^2.4.1",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-4.4.1.tgz",
+      "integrity": "sha512-Jl9wdTqIvJ5pX+vAGz0EOhP7ut5Two9H6CzTKo/YYPeD79cM2yTXF3JzTERBC28y7LR0Waq9D2LHQjI+b/EYUQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "2.2.1",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.4.1.tgz",
+      "integrity": "sha512-w8pk7svhjVj5f7d7kjEGXSk26ffCqRSQcgWR4DwcFltNpSM18ZJmzmM6WrNeeP437y48LlykLnmGDA3oATakgw=="
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.6.0.tgz",
@@ -7434,6 +7595,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
+    },
     "node_modules/acorn": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
@@ -7966,6 +8132,14 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -8055,6 +8229,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -9134,6 +9324,33 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9559,6 +9776,11 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -11030,6 +11252,14 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -11306,6 +11536,39 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.2.tgz",
+      "integrity": "sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==",
+      "dependencies": {
+        "@swc/helpers": "^0.4.2",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/@swc/helpers": {
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
+      "dependencies": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/for-each": {
@@ -12145,6 +12408,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="
+    },
     "node_modules/html-dom-parser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
@@ -12277,6 +12553,11 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.4.tgz",
+      "integrity": "sha512-SejXzIpv9gOVdDWXd4suM1fdF1k2dxZGvuTdkOVLoazYfK7O4DykIQbdrvuyG+EaTNlXAGhMndtKrhykgbt0gg=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -12887,6 +13168,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
@@ -12999,6 +13285,14 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
+    "node_modules/jay-peg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.0.1.tgz",
+      "integrity": "sha512-zBfjkGbuuNXk8JW+rEePpPEbRRjupS8q+5yPak7kjy3e2GvvNwsLle9okEFvfGyZA6HvtSSiYrVd1/jgnYebaQ==",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.0",
@@ -13341,6 +13635,15 @@
       "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/legacy-swc-helpers": {
+      "name": "@swc/helpers",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/leven": {
@@ -14089,6 +14392,11 @@
       "peerDependencies": {
         "esbuild": "0.*"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg=="
     },
     "node_modules/memfs": {
       "version": "3.5.3",
@@ -15350,6 +15658,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -15776,6 +16092,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -16561,6 +16882,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -17859,7 +18188,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17953,6 +18281,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.0.tgz",
+      "integrity": "sha512-Xj8/MEIhhfj9X2rmD9iJ4Gga9EFqVlpMj3vfLnV2r/Mh5jRMryNV+6lWh9GdJtDBcBSPIqzRdfBQ3wDtNFv/uw=="
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -19011,6 +19344,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
     "node_modules/swagger-client": {
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.25.0.tgz",
@@ -19316,6 +19654,11 @@
       "dependencies": {
         "readable-stream": "3"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
@@ -20083,6 +20426,29 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "node_modules/unified": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
@@ -20502,6 +20868,19 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/wait-on": {
@@ -20948,6 +21327,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-2.0.1.tgz",
+      "integrity": "sha512-tT/oChyDXelLo2A+UVnlW9GU7CsvFMaEnd9kVFsaiCQonFAXd3xrHhkLYu+suwwosrAEQ746xBU+HvYtm1Zs2Q=="
     },
     "node_modules/zenscroll": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21362,6 +21362,7 @@
         "@noble/ciphers": "0.4.0",
         "@noble/hashes": "1.3.2",
         "@pdf-lib/fontkit": "^1.1.1",
+        "@react-pdf/renderer": "^3.3.8",
         "@scure/base": "^1.1.3",
         "@sindresorhus/slugify": "^2.2.1",
         "@upstash/redis": "^1.20.6",

--- a/packages/lib/client-only/download-pdf.ts
+++ b/packages/lib/client-only/download-pdf.ts
@@ -1,10 +1,10 @@
-import type { DocumentData } from '@documenso/prisma/client';
+import type { DocumentAdditionalData, DocumentData } from '@documenso/prisma/client';
 
 import { getFile } from '../universal/upload/get-file';
 import { downloadFile } from './download-file';
 
 type DownloadPDFProps = {
-  documentData: DocumentData;
+  documentData: DocumentData | DocumentAdditionalData;
   fileName?: string;
 };
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -28,6 +28,7 @@
     "@noble/ciphers": "0.4.0",
     "@noble/hashes": "1.3.2",
     "@pdf-lib/fontkit": "^1.1.1",
+    "@react-pdf/renderer": "^3.3.8",
     "@scure/base": "^1.1.3",
     "@sindresorhus/slugify": "^2.2.1",
     "@upstash/redis": "^1.20.6",

--- a/packages/lib/server-only/document/get-or-generate-document-logs.ts
+++ b/packages/lib/server-only/document/get-or-generate-document-logs.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@documenso/prisma';
+import { AdditionalDataType, DocumentDataType, DocumentStatus } from '@documenso/prisma/client';
+
+import { getDocumentById } from './get-document-by-id';
+
+export type GetOrGenerateDocumentOptions = {
+  documentId: number;
+  userId: number;
+  teamId?: number;
+  overwrite?: boolean;
+};
+
+export const getOrGenerateDocumentLogs = async ({
+  documentId,
+  userId,
+  teamId,
+  overwrite,
+}: GetOrGenerateDocumentOptions) => {
+  const document = await getDocumentById({ id: documentId, userId, teamId });
+
+  if (document.status === DocumentStatus.COMPLETED) {
+    throw new Error('Document has not been completed yet');
+  }
+
+  const additionalDataWhereInput = {
+    documentId_contentType: { documentId, contentType: AdditionalDataType.LOGS },
+  };
+
+  const documentLogsData = await prisma.documentAdditionalData.findUnique({
+    where: additionalDataWhereInput,
+  });
+
+  if (documentLogsData && !overwrite) {
+    return documentLogsData;
+  }
+
+  // Generate PDF and save it as DocumentData
+  const { type, data } = { type: DocumentDataType.BYTES_64, data: '' };
+  // Assigng the DocumentData to the document as auditLogsDataId
+  return prisma.documentAdditionalData.upsert({
+    where: additionalDataWhereInput,
+    create: { type, data, documentId, contentType: AdditionalDataType.LOGS },
+    update: { type, data },
+  });
+};

--- a/packages/lib/server-only/document/get-or-generate-document-logs.ts
+++ b/packages/lib/server-only/document/get-or-generate-document-logs.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@documenso/prisma';
 import { AdditionalDataType, DocumentStatus } from '@documenso/prisma/client';
 
-import { generateDocumentLogs } from '../pdf/generate-document-logs';
+import { buildDocumentLogs } from '../pdf/build-document-logs';
 import { getRecipientsForDocument } from '../recipient/get-recipients-for-document';
 import { findDocumentAuditLogs } from './find-document-audit-logs';
 import { getDocumentById } from './get-document-by-id';
@@ -56,7 +56,7 @@ export const getOrGenerateDocumentLogs = async ({
   });
 
   // Generate PDF and save it as DocumentData
-  const { type, data } = await generateDocumentLogs({
+  const { type, data } = await buildDocumentLogs({
     document,
     recipientsList,
     auditLogs,

--- a/packages/lib/server-only/pdf/build-document-logs.tsx
+++ b/packages/lib/server-only/pdf/build-document-logs.tsx
@@ -1,0 +1,235 @@
+import { Document, Page, StyleSheet, Text, View, renderToStream } from '@react-pdf/renderer';
+import { UAParser } from 'ua-parser-js';
+
+import type { DocumentFromDocumentById } from '@documenso/prisma/types/document';
+import { signPdf } from '@documenso/signing';
+
+import type { TDocumentAuditLog } from '../../types/document-audit-logs';
+import { putFile } from '../../universal/upload/put-file';
+import { formatDocumentAuditLogAction } from '../../utils/document-audit-logs';
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 20,
+    fontFamily: 'Helvetica',
+  },
+  title: {
+    marginBottom: 15,
+    fontSize: 16,
+  },
+  subTitle: {
+    marginBottom: 10,
+    fontSize: 14,
+  },
+  details: {
+    borderColor: '#a2e771',
+    paddingTop: 8,
+    paddingRight: 5,
+    paddingBottom: 5,
+    paddingLeft: 5,
+    borderWidth: 1,
+    marginBottom: 15,
+  },
+  detailsRow: {
+    flexDirection: 'row',
+    paddingBottom: 8,
+  },
+  detailsCell: {
+    flex: 1,
+  },
+  detailsCellText: {
+    fontSize: 10,
+    color: '#64748B',
+  },
+  headerText: {
+    fontSize: 10,
+    fontWeight: 500,
+  },
+  logsHeaderRow: {
+    width: '100%',
+    flexDirection: 'row',
+    padding: 5,
+    borderColor: '#cccccc',
+    borderWidth: 1,
+    fontSize: 10,
+  },
+  logsRow: {
+    width: '100%',
+    flexDirection: 'row',
+    padding: 5,
+    borderColor: '#cccccc',
+    borderBottomWidth: 1,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    fontSize: 10,
+  },
+  logsCol1: {
+    width: '15%',
+  },
+  logsCol2: {
+    width: '27%',
+  },
+  logsCol3: {
+    width: '28%',
+  },
+  logsCol4: {
+    width: '15%',
+  },
+  logsCol5: {
+    width: '15%',
+  },
+});
+
+export type BuildDocumentLogsOptions = {
+  document: DocumentFromDocumentById;
+  recipientsList: string[];
+  auditLogs: TDocumentAuditLog[];
+};
+
+export const buildDocumentLogs = async ({
+  document,
+  recipientsList,
+  auditLogs,
+}: BuildDocumentLogsOptions) => {
+  const parser = new UAParser();
+  const logs = auditLogs.map((auditLog) => {
+    return {
+      id: auditLog.id,
+      datetime: {
+        date: auditLog.createdAt.toLocaleDateString(),
+        time: auditLog.createdAt.toLocaleTimeString(),
+      },
+      user:
+        auditLog.name || auditLog.email ? { name: auditLog.name, email: auditLog.email } : 'N/A',
+      action: formatDocumentAuditLogAction(auditLog).description,
+      ipAddress: auditLog.ipAddress,
+      browser: auditLog.userAgent
+        ? parser.setUA(auditLog.userAgent).getResult().browser.name ?? 'N/A'
+        : 'N/A',
+    };
+  });
+  const documentLogs = (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.title}>
+          <Text>{document.title} - Audit Logs</Text>
+        </View>
+        <View style={styles.subTitle}>
+          <Text>Details</Text>
+        </View>
+        <View style={styles.details}>
+          <View style={styles.detailsRow}>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Document title</Text>
+              <Text style={styles.detailsCellText}>{document.title}</Text>
+            </View>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Document ID</Text>
+              <Text style={styles.detailsCellText}>{document.id.toString()}</Text>
+            </View>
+          </View>
+          <View style={styles.detailsRow}>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Document status</Text>
+              <Text style={styles.detailsCellText}>{document.status}</Text>
+            </View>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Created by</Text>
+              <Text style={styles.detailsCellText}>
+                {document.User.name ?? document.User.email}
+              </Text>
+            </View>
+          </View>
+          <View style={styles.detailsRow}>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Date created</Text>
+              <Text style={styles.detailsCellText}>{document.createdAt.toISOString()}</Text>
+            </View>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Last updated</Text>
+              <Text style={styles.detailsCellText}>{document.updatedAt.toISOString()}</Text>
+            </View>
+          </View>
+          <View style={styles.detailsRow}>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Time zone</Text>
+              <Text style={styles.detailsCellText}>{document.documentMeta?.timezone ?? 'N/A'}</Text>
+            </View>
+            <View style={styles.detailsCell}>
+              <Text style={styles.headerText}>Recipients</Text>
+              <View>
+                {recipientsList.map((recipient) => (
+                  <Text style={styles.detailsCellText} key={recipient}>
+                    • {recipient}
+                  </Text>
+                ))}
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.logsHeaderRow}>
+          <View style={styles.logsCol1}>
+            <Text>Date</Text>
+          </View>
+          <View style={styles.logsCol2}>
+            <Text>User</Text>
+          </View>
+          <View style={styles.logsCol3}>
+            <Text>Action</Text>
+          </View>
+          <View style={styles.logsCol4}>
+            <Text>IP Address</Text>
+          </View>
+          <View style={styles.logsCol5}>
+            <Text>Browser</Text>
+          </View>
+        </View>
+        {logs.map((log) => (
+          <View key={log.id} style={styles.logsRow}>
+            <View style={styles.logsCol1}>
+              <Text>{log.datetime.date}</Text>
+              <Text>{log.datetime.time}</Text>
+            </View>
+            <View style={styles.logsCol2}>
+              {typeof log.user === 'string' ? (
+                <Text>{log.user}</Text>
+              ) : (
+                <>
+                  <Text>{log.user.name}</Text>
+                  <Text>{log.user.email}</Text>
+                </>
+              )}
+            </View>
+            <View style={styles.logsCol3}>
+              <Text>{log.action}</Text>
+            </View>
+            <View style={styles.logsCol4}>
+              <Text>{log.ipAddress}</Text>
+            </View>
+            <View style={styles.logsCol5}>
+              <Text>{log.browser}</Text>
+            </View>
+          </View>
+        ))}
+      </Page>
+    </Document>
+  );
+
+  const pdfBuffer: Buffer = await renderToStream(documentLogs).then(
+    async (stream) =>
+      new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        stream.on('data', (chunk) => chunks.push(chunk));
+        stream.on('end', () => resolve(Buffer.concat(chunks)));
+        stream.on('error', (error) => reject(error));
+      }),
+  );
+  const signedBuffer = await signPdf({ pdf: pdfBuffer });
+
+  return putFile({
+    name: `${document.title}_logs.pdf`,
+    type: 'application/pdf',
+    arrayBuffer: async () => Promise.resolve(signedBuffer),
+  });
+};

--- a/packages/lib/server-only/pdf/build-document-logs.tsx
+++ b/packages/lib/server-only/pdf/build-document-logs.tsx
@@ -227,9 +227,12 @@ export const buildDocumentLogs = async ({
   );
   const signedBuffer = await signPdf({ pdf: pdfBuffer });
 
-  return putFile({
-    name: `${document.title}_logs.pdf`,
-    type: 'application/pdf',
-    arrayBuffer: async () => Promise.resolve(signedBuffer),
-  });
+  return putFile(
+    {
+      name: `${document.title}_logs.pdf`,
+      type: 'application/pdf',
+      arrayBuffer: async () => Promise.resolve(signedBuffer),
+    },
+    { skipDocumentDataCreate: true },
+  );
 };

--- a/packages/lib/server-only/pdf/generate-document-logs.ts
+++ b/packages/lib/server-only/pdf/generate-document-logs.ts
@@ -1,0 +1,143 @@
+import fontkit from '@pdf-lib/fontkit';
+import { PDFDocument, StandardFonts, grayscale, rgb } from 'pdf-lib';
+
+import type { DocumentAuditLog } from '@documenso/prisma/client';
+import type { DocumentFromDocumentById } from '@documenso/prisma/types/document';
+import { signPdf } from '@documenso/signing';
+
+import { putFile } from '../../universal/upload/put-file';
+
+export type GenerateDocumentLogsOptions = {
+  document: DocumentFromDocumentById;
+  recipientsList: string[];
+  auditLogs: DocumentAuditLog[];
+  pageSize?: [number, number];
+};
+
+export const generateDocumentLogs = async ({
+  document,
+  recipientsList,
+  auditLogs,
+  pageSize = [595.28, 841.89], // A4 Page Size
+}: GenerateDocumentLogsOptions) => {
+  const documentInformation: { description: string; value: string }[] = [
+    {
+      description: 'Document title',
+      value: document.title,
+    },
+    {
+      description: 'Document ID',
+      value: document.id.toString(),
+    },
+    {
+      description: 'Document status',
+      value: document.status,
+    },
+    {
+      description: 'Created by',
+      value: document.User.name ?? document.User.email,
+    },
+    {
+      description: 'Date created',
+      value: document.createdAt.toISOString(),
+    },
+    {
+      description: 'Last updated',
+      value: document.updatedAt.toISOString(),
+    },
+    {
+      description: 'Time zone',
+      value: document.documentMeta?.timezone ?? 'N/A',
+    },
+  ];
+
+  const doc = await PDFDocument.create();
+
+  doc.registerFontkit(fontkit);
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+
+  const page = doc.addPage(pageSize);
+  let currentY = pageSize[1] - 30;
+  page.drawText(`${document.title} - Audit Logs`, {
+    x: 30,
+    y: currentY,
+    size: 18,
+    color: rgb(0, 0, 0),
+    font: font,
+  });
+  currentY -= 30;
+
+  page.drawText('Details', {
+    x: 30,
+    y: currentY,
+    size: 16,
+    color: rgb(0, 0, 0),
+    font: font,
+  });
+  currentY -= 15;
+
+  page.drawLine({
+    start: { x: 30, y: currentY },
+    end: { x: pageSize[0] - 60, y: currentY },
+    thickness: 1,
+    color: rgb(0.6, 0.9, 0.4),
+    opacity: 0.8,
+  });
+
+  let leftColumn = true;
+  currentY -= 20;
+  documentInformation.forEach((docInfo) => {
+    page.drawText(docInfo.description, {
+      x: leftColumn ? 35 : pageSize[0] / 2,
+      y: currentY,
+      size: 12,
+      color: rgb(0, 0, 0),
+      font: font,
+    });
+    page.drawText(docInfo.value, {
+      x: leftColumn ? 35 : pageSize[0] / 2,
+      y: currentY - 16,
+      size: 11,
+      color: grayscale(0.5),
+      font: font,
+    });
+
+    leftColumn = !leftColumn;
+    currentY = leftColumn ? currentY - 36 : currentY;
+  });
+  page.drawText('Recipiets', {
+    x: pageSize[0] / 2,
+    y: currentY,
+    size: 12,
+    color: rgb(0, 0, 0),
+    font: font,
+  });
+  currentY -= 18;
+  recipientsList.forEach((recipient) => {
+    page.drawText(`• ${recipient}`, {
+      x: pageSize[0] / 2,
+      y: currentY,
+      size: 11,
+      color: grayscale(0.5),
+      font: font,
+    });
+    currentY -= 14;
+  });
+
+  page.drawLine({
+    start: { x: 30, y: currentY },
+    end: { x: pageSize[0] - 60, y: currentY },
+    thickness: 1,
+    color: rgb(0.6, 0.9, 0.4),
+    opacity: 0.8,
+  });
+
+  const pdfBytes = await doc.save();
+  const pdfBuffer = await signPdf({ pdf: Buffer.from(pdfBytes) });
+
+  return putFile({
+    name: `${document.title}_logs.pdf`,
+    type: 'application/pdf',
+    arrayBuffer: async () => Promise.resolve(pdfBuffer),
+  });
+};

--- a/packages/lib/universal/upload/put-file.ts
+++ b/packages/lib/universal/upload/put-file.ts
@@ -23,7 +23,9 @@ export const putFile = async (file: File, options: PutFileOptions = {}) => {
     .with('s3', async () => putFileInS3(file))
     .otherwise(async () => putFileInDatabase(file));
 
-  return options.skipDocumentDataCreate ? { type, data } : await createDocumentData({ type, data });
+  return options.skipDocumentDataCreate
+    ? { id: '', type, data }
+    : await createDocumentData({ type, data });
 };
 
 const putFileInDatabase = async (file: File) => {

--- a/packages/lib/universal/upload/put-file.ts
+++ b/packages/lib/universal/upload/put-file.ts
@@ -12,14 +12,18 @@ type File = {
   arrayBuffer: () => Promise<ArrayBuffer>;
 };
 
-export const putFile = async (file: File) => {
+type PutFileOptions = {
+  skipDocumentDataCreate?: boolean;
+};
+
+export const putFile = async (file: File, options: PutFileOptions = {}) => {
   const NEXT_PUBLIC_UPLOAD_TRANSPORT = env('NEXT_PUBLIC_UPLOAD_TRANSPORT');
 
   const { type, data } = await match(NEXT_PUBLIC_UPLOAD_TRANSPORT)
     .with('s3', async () => putFileInS3(file))
     .otherwise(async () => putFileInDatabase(file));
 
-  return await createDocumentData({ type, data });
+  return options.skipDocumentDataCreate ? { type, data } : await createDocumentData({ type, data });
 };
 
 const putFileInDatabase = async (file: File) => {

--- a/packages/prisma/migrations/20240229161806_document_additional_data/migration.sql
+++ b/packages/prisma/migrations/20240229161806_document_additional_data/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "AdditionalDataType" AS ENUM ('LOGS', 'CERTIFICATE');
+
+-- CreateTable
+CREATE TABLE "DocumentAdditionalData" (
+    "id" TEXT NOT NULL,
+    "type" "DocumentDataType" NOT NULL,
+    "data" TEXT NOT NULL,
+    "documentId" INTEGER NOT NULL,
+    "contentType" "AdditionalDataType" NOT NULL,
+
+    CONSTRAINT "DocumentAdditionalData_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentAdditionalData_documentId_contentType_key" ON "DocumentAdditionalData"("documentId", "contentType");
+
+-- AddForeignKey
+ALTER TABLE "DocumentAdditionalData" ADD CONSTRAINT "DocumentAdditionalData_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -241,7 +241,8 @@ model Document {
   teamId         Int?
   team           Team?               @relation(fields: [teamId], references: [id])
 
-  auditLogs DocumentAuditLog[]
+  auditLogs      DocumentAuditLog[]
+  additionalData DocumentAdditionalData[]
 
   @@unique([documentDataId])
   @@index([userId])
@@ -278,6 +279,23 @@ model DocumentData {
   initialData String
   Document    Document?
   Template    Template?
+}
+
+enum AdditionalDataType {
+  LOGS
+  CERTIFICATE
+}
+
+model DocumentAdditionalData {
+  id           String           @id @default(cuid())
+  type         DocumentDataType
+  data         String
+  documentId   Int
+  contentType  AdditionalDataType
+
+  Document     Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@unique([documentId, contentType])
 }
 
 model DocumentMeta {

--- a/packages/prisma/types/document.ts
+++ b/packages/prisma/types/document.ts
@@ -1,4 +1,4 @@
-import { Document, Recipient } from '@documenso/prisma/client';
+import type { Document, Prisma, Recipient } from '@documenso/prisma/client';
 
 export type DocumentWithRecipientAndSender = Omit<Document, 'document'> & {
   recipient: Recipient;
@@ -10,3 +10,23 @@ export type DocumentWithRecipientAndSender = Omit<Document, 'document'> & {
   subject: string;
   description: string;
 };
+
+export type DocumentFromDocumentById = Prisma.DocumentGetPayload<{
+  include: {
+    documentData: true;
+    documentMeta: true;
+    User: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    team: {
+      select: {
+        id: true;
+        url: true;
+      };
+    };
+  };
+}>;

--- a/packages/ui/components/document/document-additional-data-download-button.tsx
+++ b/packages/ui/components/document/document-additional-data-download-button.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { HTMLAttributes } from 'react';
+import { useState } from 'react';
+
+import { Download } from 'lucide-react';
+
+import { downloadPDF } from '@documenso/lib/client-only/download-pdf';
+import type { DocumentAdditionalData } from '@documenso/prisma/client';
+import { useToast } from '@documenso/ui/primitives/use-toast';
+
+import { Button } from '../../primitives/button';
+
+export type AdditionalDataDownloadButtonProps = HTMLAttributes<HTMLButtonElement> & {
+  disabled?: boolean;
+  docTitle: string;
+  documentData: DocumentAdditionalData;
+};
+
+export const DocumentAdditionalDataDownloadButton = ({
+  className,
+  docTitle,
+  documentData,
+  disabled,
+  children,
+  ...props
+}: AdditionalDataDownloadButtonProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
+
+  const onDownloadClick = async () => {
+    try {
+      setIsLoading(true);
+
+      if (!documentData) {
+        setIsLoading(false);
+        return;
+      }
+
+      const originalName = docTitle.replace(/\.pdf$/i, '');
+      const docType = documentData.contentType.toLowerCase();
+      const fileName = `${originalName}_${docType}.pdf`;
+
+      await downloadPDF({ documentData, fileName }).then(() => {
+        setIsLoading(false);
+      });
+    } catch (err) {
+      setIsLoading(false);
+
+      toast({
+        title: 'Something went wrong',
+        description: 'An error occurred while downloading your document.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      className={className}
+      disabled={disabled || !documentData}
+      onClick={onDownloadClick}
+      loading={isLoading}
+      {...props}
+    >
+      <Download className="mr-2 h-5 w-5" />
+      {children}
+    </Button>
+  );
+};


### PR DESCRIPTION
In order to be CFR P11 compliant, document logs file should be created and stored within Documenso's servers.

This branch is using a similar strategy from the documents themselves to store "additional data", namely, logs and signature certificates (for the time being).

A new table has been created: `DocumentAdditionalData`, which is similar to `DocumentData`, thanks to this similarity, I was able to re-use some of the functions implemented to store and read files from the configured storage.

Regarding the PDF creation, `@react-pdf/renderer` was used to easily shape the document using their provided components. here's a sample of the resulting pdf document.

[demo-logs.pdf](https://github.com/documenso/documenso/files/14464750/demo-logs.pdf)
