### PR TITLE
build: force devcontainer to run x86

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:bullseye

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "Documenso",
-  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "packages/*"
   ],
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "next-runtime-env": "^3.2.0"
   },
   "overrides": {


### PR DESCRIPTION
Fixes Bcrypt failing on ARM-based Mac's (requires rosetta)