### PR TITLE
fix: fix blog post date

### DIFF
--- a/apps/marketing/content/blog/removing-server-actions.mdx
+++ b/apps/marketing/content/blog/removing-server-actions.mdx
@@ -4,7 +4,7 @@ description: 'This article talks about the need for the public API and the proce
 authorName: 'Lucas Smith'
 authorImage: '/blog/blog-author-lucas.png'
 authorRole: 'Co-Founder'
-date: 2024-07-23
+date: 2024-03-07
 tags:
   - Development
 ---


### PR DESCRIPTION
Fixing the blog date for https://documenso.com/blog/removing-server-actions
(I assume it was meant to be March 7th)

![image](https://github.com/documenso/documenso/assets/64188227/a7b96168-b094-46c0-877a-da26c9d140d4)
