### PR TITLE
fix: eslint config file parseOptions.project path is updated

### DIFF
--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -20,7 +20,7 @@ module.exports = {
 
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['../../apps/*/tsconfig.json', '../../packages/*/tsconfig.json'],
+    project: ['../../tsconfig.eslint.json'],
     ecmaVersion: 2022,
     ecmaFeatures: {
       jsx: true,

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./packages/tsconfig/base.json",
+  "include": ["packages/**/*", "apps/**/*"]
+}


### PR DESCRIPTION
I found out that the problem of slow down is the use of parseOption.project with multiple tsconfig files which increases usage of memory consumption quite a lot.

Here is the reference I found to resolve this issue:

[reference link](https://github.com/typescript-eslint/typescript-eslint/issues/1192)
[Doc link](https://typescript-eslint.io/getting-started/typed-linting/monorepos/)

Based on this reference  I created the solution and tested out locally it does reduce the eslint time.

#1002 
