### PR TITLE
fix: update docker documentation and include cert env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,16 @@ E2E_TEST_AUTHENTICATE_USERNAME="Test User"
 E2E_TEST_AUTHENTICATE_USER_EMAIL="testuser@mail.com"
 E2E_TEST_AUTHENTICATE_USER_PASSWORD="test_Password123"
 
+# [[SIGNING]]
+# OPTIONAL: Defines the signing transport to use. Available options: local (default)
+NEXT_PRIVATE_SIGNING_TRANSPORT="local"
+# OPTIONAL: Defines the passphrase for the signing certificate.
+NEXT_PRIVATE_SIGNING_PASSPHRASE=
+# OPTIONAL: Defines the file contents for the signing certificate as a base64 encoded string.
+NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS=
+# OPTIONAL: Defines the file path for the signing certificate. defaults to ./example/cert.p12
+NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=
+
 # [[STORAGE]]
 # OPTIONAL: Defines the storage transport to use. Available options: database (default) | s3
 NEXT_PUBLIC_UPLOAD_TRANSPORT="database"

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -36,7 +36,7 @@
     "react-hook-form": "^7.43.9",
     "react-icons": "^4.11.0",
     "recharts": "^2.7.2",
-    "sharp": "0.33.1",
+    "sharp": "^0.33.1",
     "typescript": "5.2.2",
     "zod": "^3.22.4"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,7 +43,7 @@
     "react-icons": "^4.11.0",
     "react-rnd": "^10.4.1",
     "remeda": "^1.27.1",
-    "sharp": "0.33.1",
+    "sharp": "^0.33.1",
     "ts-pattern": "^5.0.5",
     "ua-parser-js": "^1.0.37",
     "uqr": "^0.1.2",

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,16 @@ NEXT_PRIVATE_SMTP_USERNAME="<your-username>"
 NEXT_PRIVATE_SMTP_PASSWORD="<your-password>"
 ```
 
-4. Run the following command to start the containers:
+4. Update the volume binding for the cert file in the `compose.yml` file to point to your own key file:
+
+Since the `cert.p12` file is required for signing and encrypting documents, you will need to provide your own key file. Update the volume binding in the `compose.yml` file to point to your key file:
+
+```yaml
+volumes:
+  - /path/to/your/keyfile.p12:/opt/documenso/cert.p12
+```
+
+1. Run the following command to start the containers:
 
 ```
 docker-compose --env-file ./.env -d up
@@ -70,6 +79,7 @@ docker run -d \
   -e NEXT_PRIVATE_SMTP_TRANSPORT="<your-next-private-smtp-transport>"
   -e NEXT_PRIVATE_SMTP_FROM_NAME="<your-next-private-smtp-from-name>"
   -e NEXT_PRIVATE_SMTP_FROM_ADDRESS="<your-next-private-smtp-from-address>"
+  -v /path/to/your/keyfile.p12:/opt/documenso/cert.p12
   documenso/documenso
 ```
 
@@ -99,6 +109,10 @@ Here's a markdown table documenting all the provided environment variables:
 | `NEXT_PUBLIC_WEBAPP_URL`                     | The URL for the web application.                                                                    |
 | `NEXT_PRIVATE_DATABASE_URL`                  | The URL for the primary database connection (with connection pooling).                              |
 | `NEXT_PRIVATE_DIRECT_DATABASE_URL`           | The URL for the direct database connection (without connection pooling).                            |
+| `NEXT_PRIVATE_SIGNING_TRANSPORT`             | The signing transport to use. Available options: local (default)                                    |
+| `NEXT_PRIVATE_SIGNING_PASSPHRASE`            | The passphrase for the key file.                                                                    |
+| `NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS`   | The base64-encoded contents of the key file, will be used instead of file path.                     |
+| `NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH`       | The path to the key file, default `/opt/documenso/cert.p12`.                                        |
 | `NEXT_PUBLIC_UPLOAD_TRANSPORT`               | The transport to use for file uploads (database or s3).                                             |
 | `NEXT_PRIVATE_UPLOAD_ENDPOINT`               | The endpoint for the S3 storage transport (for third-party S3-compatible providers).                |
 | `NEXT_PRIVATE_UPLOAD_REGION`                 | The region for the S3 storage transport (defaults to us-east-1).                                    |

--- a/docker/production/compose.yml
+++ b/docker/production/compose.yml
@@ -57,8 +57,11 @@ services:
       - NEXT_PUBLIC_DOCUMENT_SIZE_UPLOAD_LIMIT=${NEXT_PUBLIC_DOCUMENT_SIZE_UPLOAD_LIMIT}
       - NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
       - NEXT_PUBLIC_DISABLE_SIGNUP=${NEXT_PUBLIC_DISABLE_SIGNUP}
+      - NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=${NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH?:-/opt/documenso/cert.p12}
     ports:
       - ${PORT:-3000}:${PORT:-3000}
+    volumes:
+      - /opt/documenso/cert.p12:/opt/documenso/cert.p12
 
 volumes:
   database:

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -47,6 +47,7 @@ services:
       - NEXT_PRIVATE_SMTP_PASSWORD=password
       - NEXT_PRIVATE_SMTP_FROM_NAME="No Reply @ Documenso"
       - NEXT_PRIVATE_SMTP_FROM_ADDRESS=noreply@documenso.com
+      - NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=/opt/documenso/cert.p12
     ports:
       - 3000:3000
     volumes:

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -49,3 +49,5 @@ services:
       - NEXT_PRIVATE_SMTP_FROM_ADDRESS=noreply@documenso.com
     ports:
       - 3000:3000
+    volumes:
+      - ../../apps/web/example/cert.p12:/opt/documenso/cert.p12

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "react-hook-form": "^7.43.9",
         "react-icons": "^4.11.0",
         "recharts": "^2.7.2",
-        "sharp": "0.33.1",
+        "sharp": "^0.33.1",
         "typescript": "5.2.2",
         "zod": "^3.22.4"
       },
@@ -73,45 +73,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.0.tgz",
       "integrity": "sha512-O+z53uwx64xY7D6roOi4+jApDGFg0qn6WHcxe5QeqjMaTezBO/mxdfFXIVAVVyNWKx84OmPB3L8kbVYOTeN34A==",
       "dev": true
-    },
-    "apps/marketing/node_modules/sharp": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.1.tgz",
-      "integrity": "sha512-iAYUnOdTqqZDb3QjMneBKINTllCJDZ3em6WaWy7NPECM4aHncvqHRm0v0bN9nqJxMiwamv5KIdauJ6lUzKDpTQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "libvips": ">=8.15.0",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.1",
-        "@img/sharp-darwin-x64": "0.33.1",
-        "@img/sharp-libvips-darwin-arm64": "1.0.0",
-        "@img/sharp-libvips-darwin-x64": "1.0.0",
-        "@img/sharp-libvips-linux-arm": "1.0.0",
-        "@img/sharp-libvips-linux-arm64": "1.0.0",
-        "@img/sharp-libvips-linux-s390x": "1.0.0",
-        "@img/sharp-libvips-linux-x64": "1.0.0",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.0",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.0",
-        "@img/sharp-linux-arm": "0.33.1",
-        "@img/sharp-linux-arm64": "0.33.1",
-        "@img/sharp-linux-s390x": "0.33.1",
-        "@img/sharp-linux-x64": "0.33.1",
-        "@img/sharp-linuxmusl-arm64": "0.33.1",
-        "@img/sharp-linuxmusl-x64": "0.33.1",
-        "@img/sharp-wasm32": "0.33.1",
-        "@img/sharp-win32-ia32": "0.33.1",
-        "@img/sharp-win32-x64": "0.33.1"
-      }
     },
     "apps/marketing/node_modules/typescript": {
       "version": "5.2.2",
@@ -159,7 +120,7 @@
         "react-icons": "^4.11.0",
         "react-rnd": "^10.4.1",
         "remeda": "^1.27.1",
-        "sharp": "0.33.1",
+        "sharp": "^0.33.1",
         "ts-pattern": "^5.0.5",
         "ua-parser-js": "^1.0.37",
         "uqr": "^0.1.2",
@@ -181,45 +142,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.0.tgz",
       "integrity": "sha512-O+z53uwx64xY7D6roOi4+jApDGFg0qn6WHcxe5QeqjMaTezBO/mxdfFXIVAVVyNWKx84OmPB3L8kbVYOTeN34A==",
       "dev": true
-    },
-    "apps/web/node_modules/sharp": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.1.tgz",
-      "integrity": "sha512-iAYUnOdTqqZDb3QjMneBKINTllCJDZ3em6WaWy7NPECM4aHncvqHRm0v0bN9nqJxMiwamv5KIdauJ6lUzKDpTQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "libvips": ">=8.15.0",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.1",
-        "@img/sharp-darwin-x64": "0.33.1",
-        "@img/sharp-libvips-darwin-arm64": "1.0.0",
-        "@img/sharp-libvips-darwin-x64": "1.0.0",
-        "@img/sharp-libvips-linux-arm": "1.0.0",
-        "@img/sharp-libvips-linux-arm64": "1.0.0",
-        "@img/sharp-libvips-linux-s390x": "1.0.0",
-        "@img/sharp-libvips-linux-x64": "1.0.0",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.0",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.0",
-        "@img/sharp-linux-arm": "0.33.1",
-        "@img/sharp-linux-arm64": "0.33.1",
-        "@img/sharp-linux-s390x": "0.33.1",
-        "@img/sharp-linux-x64": "0.33.1",
-        "@img/sharp-linuxmusl-arm64": "0.33.1",
-        "@img/sharp-linuxmusl-x64": "0.33.1",
-        "@img/sharp-wasm32": "0.33.1",
-        "@img/sharp-win32-ia32": "0.33.1",
-        "@img/sharp-win32-x64": "0.33.1"
-      }
     },
     "apps/web/node_modules/typescript": {
       "version": "5.2.2",
@@ -18558,6 +18480,45 @@
       },
       "bin": {
         "sha.js": "bin.js"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.1.tgz",
+      "integrity": "sha512-iAYUnOdTqqZDb3QjMneBKINTllCJDZ3em6WaWy7NPECM4aHncvqHRm0v0bN9nqJxMiwamv5KIdauJ6lUzKDpTQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "libvips": ">=8.15.0",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.1",
+        "@img/sharp-darwin-x64": "0.33.1",
+        "@img/sharp-libvips-darwin-arm64": "1.0.0",
+        "@img/sharp-libvips-darwin-x64": "1.0.0",
+        "@img/sharp-libvips-linux-arm": "1.0.0",
+        "@img/sharp-libvips-linux-arm64": "1.0.0",
+        "@img/sharp-libvips-linux-s390x": "1.0.0",
+        "@img/sharp-libvips-linux-x64": "1.0.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.0",
+        "@img/sharp-linux-arm": "0.33.1",
+        "@img/sharp-linux-arm64": "0.33.1",
+        "@img/sharp-linux-s390x": "0.33.1",
+        "@img/sharp-linux-x64": "0.33.1",
+        "@img/sharp-linuxmusl-arm64": "0.33.1",
+        "@img/sharp-linuxmusl-x64": "0.33.1",
+        "@img/sharp-wasm32": "0.33.1",
+        "@img/sharp-win32-ia32": "0.33.1",
+        "@img/sharp-win32-x64": "0.33.1"
       }
     },
     "node_modules/shebang-command": {


### PR DESCRIPTION
## Description

Updates the docker documentation and compose files to include key file related configuration for self hosters. This was missed as the key file environment variables weren't documented in the `.env.example` file which was used for creating the docker documentation.

## Related Issue

#1012

## Changes Made

- Updated the docker configuration to include key file environment variables
- Updated the .env.example to include key file env vars
- Updated the compose images to use volumes for key files

## Testing Performed

- I have used the containers with the updated values and confirmed that they work as expected

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

N/A