### PR TITLE
fix: use correct date format

### DIFF
--- a/packages/lib/constants/date-formats.ts
+++ b/packages/lib/constants/date-formats.ts
@@ -13,7 +13,7 @@ export const DATE_FORMATS = [
   {
     key: 'YYYYMMDD',
     label: 'YYYY-MM-DD',
-    value: 'YYYY-MM-DD',
+    value: 'yyyy-MM-dd',
   },
   {
     key: 'DDMMYYYY',


### PR DESCRIPTION
### Before
![CleanShot 2024-03-21 at 17 23 09@2x](https://github.com/documenso/documenso/assets/55143799/d1cd22ca-399b-4ba2-bb82-b4dc869605c8)

### After
![CleanShot 2024-03-21 at 17 23 17@2x](https://github.com/documenso/documenso/assets/55143799/cdb814ea-01be-4bcb-9bad-df41030f320a)
