### PR TITLE
fix: normalize and flatten annotations

### DIFF
--- a/packages/lib/server-only/pdf/flatten-annotations.ts
+++ b/packages/lib/server-only/pdf/flatten-annotations.ts
@@ -1,0 +1,63 @@
+import { PDFAnnotation, PDFRef } from 'pdf-lib';
+import {
+  PDFDict,
+  type PDFDocument,
+  PDFName,
+  drawObject,
+  popGraphicsState,
+  pushGraphicsState,
+  rotateInPlace,
+  translate,
+} from 'pdf-lib';
+
+export const flattenAnnotations = (document: PDFDocument) => {
+  const pages = document.getPages();
+
+  for (const page of pages) {
+    const annotations = page.node.Annots()?.asArray() ?? [];
+
+    annotations.forEach((annotation) => {
+      if (!(annotation instanceof PDFRef)) {
+        return;
+      }
+
+      const actualAnnotation = page.node.context.lookup(annotation);
+
+      if (!(actualAnnotation instanceof PDFDict)) {
+        return;
+      }
+
+      const pdfAnnot = PDFAnnotation.fromDict(actualAnnotation);
+
+      const appearance = pdfAnnot.ensureAP();
+
+      // Skip annotations without a normal appearance
+      if (!appearance.has(PDFName.of('N'))) {
+        return;
+      }
+
+      const normalAppearance = pdfAnnot.getNormalAppearance();
+      const rectangle = pdfAnnot.getRectangle();
+
+      if (!(normalAppearance instanceof PDFRef)) {
+        // Not sure how to get the reference to the normal appearance yet
+        // so we should skip this annotation for now
+        return;
+      }
+
+      const xobj = page.node.newXObject('FlatAnnot', normalAppearance);
+
+      const operators = [
+        pushGraphicsState(),
+        translate(rectangle.x, rectangle.y),
+        ...rotateInPlace({ ...rectangle, rotation: 0 }),
+        drawObject(xobj),
+        popGraphicsState(),
+      ].filter((op) => !!op);
+
+      page.pushOperators(...operators);
+
+      page.node.removeAnnot(annotation);
+    });
+  }
+};

--- a/packages/lib/server-only/pdf/normalize-signature-appearances.ts
+++ b/packages/lib/server-only/pdf/normalize-signature-appearances.ts
@@ -1,0 +1,26 @@
+import type { PDFDocument } from 'pdf-lib';
+import { PDFSignature, rectangle } from 'pdf-lib';
+
+export const normalizeSignatureAppearances = (document: PDFDocument) => {
+  const form = document.getForm();
+
+  for (const field of form.getFields()) {
+    if (field instanceof PDFSignature) {
+      field.acroField.getWidgets().forEach((widget) => {
+        widget.ensureAP();
+
+        try {
+          widget.getNormalAppearance();
+        } catch {
+          const { context } = widget.dict;
+
+          const xobj = context.formXObject([rectangle(0, 0, 0, 0)]);
+
+          const streamRef = context.register(xobj);
+
+          widget.setNormalAppearance(streamRef);
+        }
+      });
+    }
+  }
+};


### PR DESCRIPTION
This change flattens and normalizes annotation and widget layers within the PDF document removing items that can be accidentally modified after signing which would void the signature attached to the document.

Initially this change was just to assign to an ArcoForm object in the document catalog if it existed but quickly turned into the above. 

When annotations aren't flattened Adobe PDF will say that the signature needs to be validated and upon doing so will become invalid due to the annotation layers being touched.

To resolve this I set out to flatten and remove the annotations by pulling out their normal appearances if they are present, converting them into xobjects and then drawing those using the drawObject operator.

This resolves a critical issue the users experienced during the signing flow when they had marked up a document using annotations in pdf editors.