### PR TITLE
fix: remove scrollbar gutter

### DIFF
--- a/packages/ui/styles/theme.css
+++ b/packages/ui/styles/theme.css
@@ -91,11 +91,6 @@
     @apply border-border;
   }
 
-  html,
-  body {
-    scrollbar-gutter: stable;
-  }
-
   body {
     @apply bg-background text-foreground;
     font-feature-settings: 'rlig' 1, 'calt' 1;
@@ -130,7 +125,7 @@
   background: rgb(100 116 139 / 0.5);
 }
 
- /* Custom Swagger Dark Theme */
+/* Custom Swagger Dark Theme */
 .swagger-dark-theme .swagger-ui {
   filter: invert(88%) hue-rotate(180deg);
 }


### PR DESCRIPTION
## Description

Currently opening modals, clicking select boxes or using anything from radix that overlays the screen in some way will shift the screen.

This can be easily noticeable when changing the document "Period" selector on the /documents page.

## Changes Made

Undo the gutter change for now. Can find a proper solution another time.


https://github.com/documenso/documenso/assets/20962767/5bcae576-2944-4ae5-a2c3-0589e7f61bdb

