### PR TITLE
feat: add passkey and 2FA document action auth options

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/security/passkeys/create-passkey-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/settings/security/passkeys/create-passkey-dialog.tsx
@@ -38,6 +38,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export type CreatePasskeyDialogProps = {
   trigger?: React.ReactNode;
+  onSuccess?: () => void;
 } & Omit<DialogPrimitive.DialogProps, 'children'>;
 
 const ZCreatePasskeyFormSchema = z.object({
@@ -48,7 +49,7 @@ type TCreatePasskeyFormSchema = z.infer<typeof ZCreatePasskeyFormSchema>;
 
 const parser = new UAParser();
 
-export const CreatePasskeyDialog = ({ trigger, ...props }: CreatePasskeyDialogProps) => {
+export const CreatePasskeyDialog = ({ trigger, onSuccess, ...props }: CreatePasskeyDialogProps) => {
   const [open, setOpen] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -84,6 +85,7 @@ export const CreatePasskeyDialog = ({ trigger, ...props }: CreatePasskeyDialogPr
         duration: 5000,
       });
 
+      onSuccess?.();
       setOpen(false);
     } catch (err) {
       if (err.name === 'NotAllowedError') {

--- a/apps/web/src/app/(signing)/sign/[token]/document-action-auth-2fa.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/document-action-auth-2fa.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { AppError } from '@documenso/lib/errors/app-error';
+import { DocumentAuth, type TRecipientActionAuth } from '@documenso/lib/types/document-auth';
+import { RecipientRole } from '@documenso/prisma/client';
+import { Alert, AlertDescription, AlertTitle } from '@documenso/ui/primitives/alert';
+import { Button } from '@documenso/ui/primitives/button';
+import { DialogFooter } from '@documenso/ui/primitives/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@documenso/ui/primitives/form/form';
+import { Input } from '@documenso/ui/primitives/input';
+
+import { EnableAuthenticatorAppDialog } from '~/components/forms/2fa/enable-authenticator-app-dialog';
+
+import { useRequiredDocumentAuthContext } from './document-auth-provider';
+
+export type DocumentActionAuth2FAProps = {
+  actionTarget?: 'FIELD' | 'DOCUMENT';
+  actionVerb?: string;
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  onReauthFormSubmit: (values?: TRecipientActionAuth) => Promise<void> | void;
+};
+
+const Z2FAAuthFormSchema = z.object({
+  token: z
+    .string()
+    .min(4, { message: 'Token must at least 4 characters long' })
+    .max(10, { message: 'Token must be at most 10 characters long' }),
+});
+
+type T2FAAuthFormSchema = z.infer<typeof Z2FAAuthFormSchema>;
+
+export const DocumentActionAuth2FA = ({
+  actionTarget = 'FIELD',
+  actionVerb = 'sign',
+  onReauthFormSubmit,
+  open,
+  onOpenChange,
+}: DocumentActionAuth2FAProps) => {
+  const { recipient, user, isCurrentlyAuthenticating, setIsCurrentlyAuthenticating } =
+    useRequiredDocumentAuthContext();
+
+  const form = useForm<T2FAAuthFormSchema>({
+    resolver: zodResolver(Z2FAAuthFormSchema),
+    defaultValues: {
+      token: '',
+    },
+  });
+
+  const [is2FASetupSuccessful, setIs2FASetupSuccessful] = useState(false);
+  const [formErrorCode, setFormErrorCode] = useState<string | null>(null);
+
+  const onFormSubmit = async ({ token }: T2FAAuthFormSchema) => {
+    try {
+      setIsCurrentlyAuthenticating(true);
+
+      await onReauthFormSubmit({
+        type: DocumentAuth.TWO_FACTOR_AUTH,
+        token,
+      });
+
+      setIsCurrentlyAuthenticating(false);
+
+      onOpenChange(false);
+    } catch (err) {
+      setIsCurrentlyAuthenticating(false);
+
+      const error = AppError.parseError(err);
+      setFormErrorCode(error.code);
+
+      // Todo: Alert.
+    }
+  };
+
+  useEffect(() => {
+    form.reset({
+      token: '',
+    });
+
+    setIs2FASetupSuccessful(false);
+    setFormErrorCode(null);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!user?.twoFactorEnabled && !is2FASetupSuccessful) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="warning">
+          <AlertDescription>
+            <p>
+              {recipient.role === RecipientRole.VIEWER && actionTarget === 'DOCUMENT'
+                ? 'You need to setup 2FA to mark this document as viewed.'
+                : `You need to setup 2FA to ${actionVerb.toLowerCase()} this ${actionTarget.toLowerCase()}.`}
+            </p>
+
+            {user?.identityProvider === 'DOCUMENSO' && (
+              <p className="mt-2">
+                By enabling 2FA, you will be required to enter a code from your authenticator app
+                every time you sign in.
+              </p>
+            )}
+          </AlertDescription>
+        </Alert>
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+
+          <EnableAuthenticatorAppDialog onSuccess={() => setIs2FASetupSuccessful(true)} />
+        </DialogFooter>
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onFormSubmit)}>
+        <fieldset disabled={isCurrentlyAuthenticating}>
+          <div className="space-y-4">
+            <FormField
+              control={form.control}
+              name="token"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>2FA token</FormLabel>
+
+                  <FormControl>
+                    <Input {...field} placeholder="Token" />
+                  </FormControl>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {formErrorCode && (
+              <Alert variant="destructive">
+                <AlertTitle>Unauthorized</AlertTitle>
+                <AlertDescription>
+                  We were unable to verify your details. Please try again or contact support
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <DialogFooter>
+              <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+
+              <Button type="submit" loading={isCurrentlyAuthenticating}>
+                Sign
+              </Button>
+            </DialogFooter>
+          </div>
+        </fieldset>
+      </form>
+    </Form>
+  );
+};

--- a/apps/web/src/app/(signing)/sign/[token]/document-action-auth-account.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/document-action-auth-account.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+import { DateTime } from 'luxon';
+import { signOut } from 'next-auth/react';
+
+import { RecipientRole } from '@documenso/prisma/client';
+import { trpc } from '@documenso/trpc/react';
+import { Alert, AlertDescription } from '@documenso/ui/primitives/alert';
+import { Button } from '@documenso/ui/primitives/button';
+import { DialogFooter } from '@documenso/ui/primitives/dialog';
+
+import { useRequiredDocumentAuthContext } from './document-auth-provider';
+
+export type DocumentActionAuthAccountProps = {
+  actionTarget?: 'FIELD' | 'DOCUMENT';
+  actionVerb?: string;
+  onOpenChange: (value: boolean) => void;
+};
+
+export const DocumentActionAuthAccount = ({
+  actionTarget = 'FIELD',
+  actionVerb = 'sign',
+  onOpenChange,
+}: DocumentActionAuthAccountProps) => {
+  const { recipient } = useRequiredDocumentAuthContext();
+
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const { mutateAsync: encryptSecondaryData } = trpc.crypto.encryptSecondaryData.useMutation();
+
+  const handleChangeAccount = async (email: string) => {
+    try {
+      setIsSigningOut(true);
+
+      const encryptedEmail = await encryptSecondaryData({
+        data: email,
+        expiresAt: DateTime.now().plus({ days: 1 }).toMillis(),
+      });
+
+      await signOut({
+        callbackUrl: `/signin?email=${encodeURIComponent(encryptedEmail)}`,
+      });
+    } catch {
+      setIsSigningOut(false);
+
+      // Todo: Alert.
+    }
+  };
+
+  return (
+    <fieldset disabled={isSigningOut} className="space-y-4">
+      <Alert variant="warning">
+        <AlertDescription>
+          {actionTarget === 'DOCUMENT' && recipient.role === RecipientRole.VIEWER ? (
+            <span>
+              To mark this document as viewed, you need to be logged in as{' '}
+              <strong>{recipient.email}</strong>
+            </span>
+          ) : (
+            <span>
+              To {actionVerb.toLowerCase()} this {actionTarget.toLowerCase()}, you need to be logged
+              in as <strong>{recipient.email}</strong>
+            </span>
+          )}
+        </AlertDescription>
+      </Alert>
+
+      <DialogFooter>
+        <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+
+        <Button onClick={async () => handleChangeAccount(recipient.email)} loading={isSigningOut}>
+          Login
+        </Button>
+      </DialogFooter>
+    </fieldset>
+  );
+};

--- a/apps/web/src/app/(signing)/sign/[token]/document-action-auth-dialog.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/document-action-auth-dialog.tsx
@@ -1,13 +1,4 @@
-/**
- * Note: This file has some commented out stuff for password auth which is no longer possible.
- *
- * Leaving it here until after we add passkeys and 2FA since it can be reused.
- */
-import { useState } from 'react';
-
-import { DateTime } from 'luxon';
-import { signOut } from 'next-auth/react';
-import { match } from 'ts-pattern';
+import { P, match } from 'ts-pattern';
 
 import {
   DocumentAuth,
@@ -15,18 +6,17 @@ import {
   type TRecipientActionAuthTypes,
 } from '@documenso/lib/types/document-auth';
 import type { FieldType } from '@documenso/prisma/client';
-import { trpc } from '@documenso/trpc/react';
-import { Alert, AlertDescription } from '@documenso/ui/primitives/alert';
-import { Button } from '@documenso/ui/primitives/button';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@documenso/ui/primitives/dialog';
 
+import { DocumentActionAuth2FA } from './document-action-auth-2fa';
+import { DocumentActionAuthAccount } from './document-action-auth-account';
+import { DocumentActionAuthPasskey } from './document-action-auth-passkey';
 import { useRequiredDocumentAuthContext } from './document-auth-provider';
 
 export type DocumentActionAuthDialogProps = {
@@ -34,7 +24,6 @@ export type DocumentActionAuthDialogProps = {
   documentAuthType: TRecipientActionAuthTypes;
   description?: string;
   actionTarget: FieldType | 'DOCUMENT';
-  isSubmitting?: boolean;
   open: boolean;
   onOpenChange: (value: boolean) => void;
 
@@ -44,95 +33,23 @@ export type DocumentActionAuthDialogProps = {
   onReauthFormSubmit: (values?: TRecipientActionAuth) => Promise<void> | void;
 };
 
-// const ZReauthFormSchema = z.object({
-//   password: ZCurrentPasswordSchema,
-// });
-// type TReauthFormSchema = z.infer<typeof ZReauthFormSchema>;
-
 export const DocumentActionAuthDialog = ({
   title,
   description,
   documentAuthType,
-  // onReauthFormSubmit,
-  isSubmitting,
   open,
   onOpenChange,
+  onReauthFormSubmit,
 }: DocumentActionAuthDialogProps) => {
-  const { recipient } = useRequiredDocumentAuthContext();
-
-  // const form = useForm({
-  //   resolver: zodResolver(ZReauthFormSchema),
-  //   defaultValues: {
-  //     password: '',
-  //   },
-  // });
-
-  const [isSigningOut, setIsSigningOut] = useState(false);
-
-  const isLoading = isSigningOut || isSubmitting; // || form.formState.isSubmitting;
-
-  const { mutateAsync: encryptSecondaryData } = trpc.crypto.encryptSecondaryData.useMutation();
-
-  // const [formErrorCode, setFormErrorCode] = useState<string | null>(null);
-  // const onFormSubmit = async (_values: TReauthFormSchema) => {
-  //   const documentAuthValue: TRecipientActionAuth = match(documentAuthType)
-  //     // Todo: Add passkey.
-  //     // .with(DocumentAuthType.PASSKEY, (type) => ({
-  //     //   type,
-  //     //   value,
-  //     // }))
-  //     .otherwise((type) => ({
-  //       type,
-  //     }));
-
-  //   try {
-  //     await onReauthFormSubmit(documentAuthValue);
-
-  //     onOpenChange(false);
-  //   } catch (e) {
-  //     const error = AppError.parseError(e);
-  //     setFormErrorCode(error.code);
-
-  //     // Suppress unauthorized errors since it's handled in this component.
-  //     if (error.code === AppErrorCode.UNAUTHORIZED) {
-  //       return;
-  //     }
-
-  //     throw error;
-  //   }
-  // };
-
-  const handleChangeAccount = async (email: string) => {
-    try {
-      setIsSigningOut(true);
-
-      const encryptedEmail = await encryptSecondaryData({
-        data: email,
-        expiresAt: DateTime.now().plus({ days: 1 }).toMillis(),
-      });
-
-      await signOut({
-        callbackUrl: `/signin?email=${encodeURIComponent(encryptedEmail)}`,
-      });
-    } catch {
-      setIsSigningOut(false);
-
-      // Todo: Alert.
-    }
-  };
+  const { recipient, user, isCurrentlyAuthenticating } = useRequiredDocumentAuthContext();
 
   const handleOnOpenChange = (value: boolean) => {
-    if (isLoading) {
+    if (isCurrentlyAuthenticating) {
       return;
     }
 
     onOpenChange(value);
   };
-
-  // useEffect(() => {
-  //   form.reset();
-  //   setFormErrorCode(null);
-  // }, [open, form]);
 
   return (
     <Dialog open={open} onOpenChange={handleOnOpenChange}>
@@ -141,100 +58,32 @@ export const DocumentActionAuthDialog = ({
           <DialogTitle>{title || 'Sign field'}</DialogTitle>
 
           <DialogDescription>
-            {description || `Reauthentication is required to sign the field`}
+            {description || 'Reauthentication is required to sign this field'}
           </DialogDescription>
         </DialogHeader>
 
-        {match(documentAuthType)
-          .with(DocumentAuth.ACCOUNT, () => (
-            <fieldset disabled={isSigningOut} className="space-y-4">
-              <Alert>
-                <AlertDescription>
-                  To sign this field, you need to be logged in as <strong>{recipient.email}</strong>
-                </AlertDescription>
-              </Alert>
-
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-
-                <Button
-                  type="submit"
-                  onClick={async () => handleChangeAccount(recipient.email)}
-                  loading={isSigningOut}
-                >
-                  Login
-                </Button>
-              </DialogFooter>
-            </fieldset>
+        {match({ documentAuthType, user })
+          .with(
+            { documentAuthType: DocumentAuth.ACCOUNT },
+            { user: P.when((user) => !user || user.email !== recipient.email) }, // Assume all current auth methods requires them to be logged in.
+            () => <DocumentActionAuthAccount onOpenChange={onOpenChange} />,
+          )
+          .with({ documentAuthType: DocumentAuth.PASSKEY }, () => (
+            <DocumentActionAuthPasskey
+              open={open}
+              onOpenChange={onOpenChange}
+              onReauthFormSubmit={onReauthFormSubmit}
+            />
           ))
-          .with(DocumentAuth.EXPLICIT_NONE, () => null)
+          .with({ documentAuthType: DocumentAuth.TWO_FACTOR_AUTH }, () => (
+            <DocumentActionAuth2FA
+              open={open}
+              onOpenChange={onOpenChange}
+              onReauthFormSubmit={onReauthFormSubmit}
+            />
+          ))
+          .with({ documentAuthType: DocumentAuth.EXPLICIT_NONE }, () => null)
           .exhaustive()}
-
-        {/* <Form {...form}>
-            <form onSubmit={form.handleSubmit(onFormSubmit)}>
-              <fieldset className="flex h-full flex-col space-y-4" disabled={isLoading}>
-                <FormItem>
-                  <FormLabel required>Email</FormLabel>
-
-                  <FormControl>
-                    <Input className="bg-background" value={recipient.email} disabled />
-                  </FormControl>
-                </FormItem>
-
-                <FormField
-                  control={form.control}
-                  name="password"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel required>Password</FormLabel>
-
-                      <FormControl>
-                        <PasswordInput className="bg-background" {...field} />
-                      </FormControl>
-
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {formErrorCode && (
-                  <Alert variant="destructive">
-                    {match(formErrorCode)
-                      .with(AppErrorCode.UNAUTHORIZED, () => (
-                        <>
-                          <AlertTitle>Unauthorized</AlertTitle>
-                          <AlertDescription>
-                            We were unable to verify your details. Please ensure the details are
-                            correct
-                          </AlertDescription>
-                        </>
-                      ))
-                      .otherwise(() => (
-                        <>
-                          <AlertTitle>Something went wrong</AlertTitle>
-                          <AlertDescription>
-                            We were unable to sign this field at this time. Please try again or
-                            contact support.
-                          </AlertDescription>
-                        </>
-                      ))}
-                  </Alert>
-                )}
-
-                <DialogFooter>
-                  <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
-                    Cancel
-                  </Button>
-
-                  <Button type="submit" loading={isLoading}>
-                    Sign field
-                  </Button>
-                </DialogFooter>
-              </fieldset>
-            </form>
-          </Form> */}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/app/(signing)/sign/[token]/document-action-auth-passkey.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/document-action-auth-passkey.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { browserSupportsWebAuthn, startAuthentication } from '@simplewebauthn/browser';
+import { Loader } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { AppError } from '@documenso/lib/errors/app-error';
+import { DocumentAuth, type TRecipientActionAuth } from '@documenso/lib/types/document-auth';
+import { RecipientRole } from '@documenso/prisma/client';
+import { trpc } from '@documenso/trpc/react';
+import { Alert, AlertDescription, AlertTitle } from '@documenso/ui/primitives/alert';
+import { Button } from '@documenso/ui/primitives/button';
+import { DialogFooter } from '@documenso/ui/primitives/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@documenso/ui/primitives/form/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@documenso/ui/primitives/select';
+
+import { CreatePasskeyDialog } from '~/app/(dashboard)/settings/security/passkeys/create-passkey-dialog';
+
+import { useRequiredDocumentAuthContext } from './document-auth-provider';
+
+export type DocumentActionAuthPasskeyProps = {
+  actionTarget?: 'FIELD' | 'DOCUMENT';
+  actionVerb?: string;
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  onReauthFormSubmit: (values?: TRecipientActionAuth) => Promise<void> | void;
+};
+
+const ZPasskeyAuthFormSchema = z.object({
+  passkeyId: z.string(),
+});
+
+type TPasskeyAuthFormSchema = z.infer<typeof ZPasskeyAuthFormSchema>;
+
+export const DocumentActionAuthPasskey = ({
+  actionTarget = 'FIELD',
+  actionVerb = 'sign',
+  onReauthFormSubmit,
+  open,
+  onOpenChange,
+}: DocumentActionAuthPasskeyProps) => {
+  const {
+    recipient,
+    passkeyData,
+    preferredPasskeyId,
+    setPreferredPasskeyId,
+    isCurrentlyAuthenticating,
+    setIsCurrentlyAuthenticating,
+    refetchPasskeys,
+  } = useRequiredDocumentAuthContext();
+
+  const form = useForm<TPasskeyAuthFormSchema>({
+    resolver: zodResolver(ZPasskeyAuthFormSchema),
+    defaultValues: {
+      passkeyId: preferredPasskeyId || '',
+    },
+  });
+
+  const { mutateAsync: createPasskeyAuthenticationOptions } =
+    trpc.auth.createPasskeyAuthenticationOptions.useMutation();
+
+  const [formErrorCode, setFormErrorCode] = useState<string | null>(null);
+
+  const onFormSubmit = async ({ passkeyId }: TPasskeyAuthFormSchema) => {
+    try {
+      setPreferredPasskeyId(passkeyId);
+      setIsCurrentlyAuthenticating(true);
+
+      const { options, tokenReference } = await createPasskeyAuthenticationOptions({
+        preferredPasskeyId: passkeyId,
+      });
+
+      const authenticationResponse = await startAuthentication(options);
+
+      await onReauthFormSubmit({
+        type: DocumentAuth.PASSKEY,
+        authenticationResponse,
+        tokenReference,
+      });
+
+      setIsCurrentlyAuthenticating(false);
+
+      onOpenChange(false);
+    } catch (err) {
+      setIsCurrentlyAuthenticating(false);
+
+      if (err.name === 'NotAllowedError') {
+        return;
+      }
+
+      const error = AppError.parseError(err);
+      setFormErrorCode(error.code);
+
+      // Todo: Alert.
+    }
+  };
+
+  useEffect(() => {
+    form.reset({
+      passkeyId: preferredPasskeyId || '',
+    });
+
+    setFormErrorCode(null);
+  }, [open, form, preferredPasskeyId]);
+
+  if (!browserSupportsWebAuthn()) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="warning">
+          <AlertDescription>
+            Your browser does not support passkeys, which is required to {actionVerb.toLowerCase()}{' '}
+            this {actionTarget.toLowerCase()}.
+          </AlertDescription>
+        </Alert>
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </div>
+    );
+  }
+
+  if (passkeyData.isInitialLoading || (passkeyData.isError && passkeyData.passkeys.length === 0)) {
+    return (
+      <div className="flex h-28 items-center justify-center">
+        <Loader className="text-muted-foreground h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  if (passkeyData.isError) {
+    return (
+      <div className="h-28 space-y-4">
+        <Alert variant="destructive">
+          <AlertDescription>Something went wrong while loading your passkeys.</AlertDescription>
+        </Alert>
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+
+          <Button type="button" onClick={() => void refetchPasskeys()}>
+            Retry
+          </Button>
+        </DialogFooter>
+      </div>
+    );
+  }
+
+  if (passkeyData.passkeys.length === 0) {
+    return (
+      <div className="space-y-4">
+        <Alert variant="warning">
+          <AlertDescription>
+            {recipient.role === RecipientRole.VIEWER && actionTarget === 'DOCUMENT'
+              ? 'You need to setup a passkey to mark this document as viewed.'
+              : `You need to setup a passkey to ${actionVerb.toLowerCase()} this ${actionTarget.toLowerCase()}.`}
+          </AlertDescription>
+        </Alert>
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+
+          <CreatePasskeyDialog
+            onSuccess={async () => refetchPasskeys()}
+            trigger={<Button>Setup</Button>}
+          />
+        </DialogFooter>
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onFormSubmit)}>
+        <fieldset disabled={isCurrentlyAuthenticating}>
+          <div className="space-y-4">
+            <FormField
+              control={form.control}
+              name="passkeyId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>Passkey</FormLabel>
+
+                  <FormControl>
+                    <Select {...field} onValueChange={field.onChange}>
+                      <SelectTrigger className="bg-background text-muted-foreground">
+                        <SelectValue
+                          data-testid="documentAccessSelectValue"
+                          placeholder="Select passkey"
+                        />
+                      </SelectTrigger>
+
+                      <SelectContent position="popper">
+                        {passkeyData.passkeys.map((passkey) => (
+                          <SelectItem key={passkey.id} value={passkey.id}>
+                            {passkey.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {formErrorCode && (
+              <Alert variant="destructive">
+                <AlertTitle>Unauthorized</AlertTitle>
+                <AlertDescription>
+                  We were unable to verify your details. Please try again or contact support
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <DialogFooter>
+              <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+
+              <Button type="submit" loading={isCurrentlyAuthenticating}>
+                Sign
+              </Button>
+            </DialogFooter>
+          </div>
+        </fieldset>
+      </form>
+    </Form>
+  );
+};

--- a/apps/web/src/app/(signing)/sign/[token]/form.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/form.tsx
@@ -42,10 +42,10 @@ export const SigningForm = ({ document, recipient, fields, redirectUrl }: Signin
   const { mutateAsync: completeDocumentWithToken } =
     trpc.recipient.completeDocumentWithToken.useMutation();
 
-  const {
-    handleSubmit,
-    formState: { isSubmitting },
-  } = useForm();
+  const { handleSubmit, formState } = useForm();
+
+  // Keep the loading state going if successful since the redirect may take some time.
+  const isSubmitting = formState.isSubmitting || formState.isSubmitSuccessful;
 
   const uninsertedFields = useMemo(() => {
     return sortFieldsByPosition(fields.filter((field) => !field.inserted));

--- a/apps/web/src/components/forms/2fa/enable-authenticator-app-dialog.tsx
+++ b/apps/web/src/components/forms/2fa/enable-authenticator-app-dialog.tsx
@@ -41,8 +41,13 @@ export const ZEnable2FAForm = z.object({
 
 export type TEnable2FAForm = z.infer<typeof ZEnable2FAForm>;
 
-export const EnableAuthenticatorAppDialog = () => {
+export type EnableAuthenticatorAppDialogProps = {
+  onSuccess?: () => void;
+};
+
+export const EnableAuthenticatorAppDialog = ({ onSuccess }: EnableAuthenticatorAppDialogProps) => {
   const { toast } = useToast();
+
   const router = useRouter();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -79,6 +84,7 @@ export const EnableAuthenticatorAppDialog = () => {
       const data = await enable2FA({ code: token });
 
       setRecoveryCodes(data.recoveryCodes);
+      onSuccess?.();
 
       toast({
         title: 'Two-factor authentication enabled',
@@ -89,7 +95,7 @@ export const EnableAuthenticatorAppDialog = () => {
       toast({
         title: 'Unable to setup two-factor authentication',
         description:
-          'We were unable to setup two-factor authentication for your account. Please ensure that you have entered your password correctly and try again.',
+          'We were unable to setup two-factor authentication for your account. Please ensure that you have entered your code correctly and try again.',
         variant: 'destructive',
       });
     }

--- a/apps/web/src/components/forms/signin.tsx
+++ b/apps/web/src/components/forms/signin.tsx
@@ -124,7 +124,7 @@ export const SignInForm = ({ className, initialEmail, isGoogleSSOEnabled }: Sign
   };
 
   const onSignInWithPasskey = async () => {
-    if (!browserSupportsWebAuthn) {
+    if (!browserSupportsWebAuthn()) {
       toast({
         title: 'Not supported',
         description: 'Passkeys are not supported on this browser',

--- a/packages/app-tests/e2e/document-auth/action-auth.spec.ts
+++ b/packages/app-tests/e2e/document-auth/action-auth.spec.ts
@@ -191,7 +191,7 @@ test('[DOCUMENT_AUTH]: should deny signing fields when required for global auth'
 
       await page.locator(`#field-${field.id}`).getByRole('button').click();
       await expect(page.getByRole('paragraph')).toContainText(
-        'Reauthentication is required to sign the field',
+        'Reauthentication is required to sign this field',
       );
       await page.getByRole('button', { name: 'Cancel' }).click();
     }
@@ -260,7 +260,7 @@ test('[DOCUMENT_AUTH]: should allow field signing when required for recipient au
 
         await page.locator(`#field-${field.id}`).getByRole('button').click();
         await expect(page.getByRole('paragraph')).toContainText(
-          'Reauthentication is required to sign the field',
+          'Reauthentication is required to sign this field',
         );
         await page.getByRole('button', { name: 'Cancel' }).click();
       }
@@ -371,7 +371,7 @@ test('[DOCUMENT_AUTH]: should allow field signing when required for recipient an
 
         await page.locator(`#field-${field.id}`).getByRole('button').click();
         await expect(page.getByRole('paragraph')).toContainText(
-          'Reauthentication is required to sign the field',
+          'Reauthentication is required to sign this field',
         );
         await page.getByRole('button', { name: 'Cancel' }).click();
       }

--- a/packages/app-tests/e2e/pr-718-add-stepper-component.spec.ts
+++ b/packages/app-tests/e2e/pr-718-add-stepper-component.spec.ts
@@ -1,12 +1,24 @@
 import { expect, test } from '@playwright/test';
 import path from 'node:path';
 
-import { getDocumentByToken } from '@documenso/lib/server-only/document/get-document-by-token';
 import { getRecipientByEmail } from '@documenso/lib/server-only/recipient/get-recipient-by-email';
+import { prisma } from '@documenso/prisma';
 import { DocumentStatus } from '@documenso/prisma/client';
 import { seedUser } from '@documenso/prisma/seed/users';
 
 import { apiSignin } from './fixtures/authentication';
+
+const getDocumentByToken = async (token: string) => {
+  return await prisma.document.findFirstOrThrow({
+    where: {
+      Recipient: {
+        some: {
+          token,
+        },
+      },
+    },
+  });
+};
 
 test(`[PR-718]: should be able to create a document`, async ({ page }) => {
   await page.goto('/signin');

--- a/packages/app-tests/e2e/pr-718-add-stepper-component.spec.ts
+++ b/packages/app-tests/e2e/pr-718-add-stepper-component.spec.ts
@@ -258,7 +258,7 @@ test('should be able to create, send and sign a document', async ({ page }) => {
   await page.waitForURL(`/sign/${token}`);
 
   // Check if document has been viewed
-  const { status } = await getDocumentByToken({ token });
+  const { status } = await getDocumentByToken(token);
   expect(status).toBe(DocumentStatus.PENDING);
 
   await page.getByRole('button', { name: 'Complete' }).click();
@@ -269,7 +269,7 @@ test('should be able to create, send and sign a document', async ({ page }) => {
   await expect(page.getByText('You have signed')).toBeVisible();
 
   // Check if document has been signed
-  const { status: completedStatus } = await getDocumentByToken({ token });
+  const { status: completedStatus } = await getDocumentByToken(token);
   expect(completedStatus).toBe(DocumentStatus.COMPLETED);
 });
 
@@ -343,7 +343,7 @@ test('should be able to create, send with redirect url, sign a document and redi
   await page.waitForURL(`/sign/${token}`);
 
   // Check if document has been viewed
-  const { status } = await getDocumentByToken({ token });
+  const { status } = await getDocumentByToken(token);
   expect(status).toBe(DocumentStatus.PENDING);
 
   await page.getByRole('button', { name: 'Complete' }).click();
@@ -353,6 +353,6 @@ test('should be able to create, send with redirect url, sign a document and redi
   await page.waitForURL('https://documenso.com');
 
   // Check if document has been signed
-  const { status: completedStatus } = await getDocumentByToken({ token });
+  const { status: completedStatus } = await getDocumentByToken(token);
   expect(completedStatus).toBe(DocumentStatus.COMPLETED);
 });

--- a/packages/lib/constants/document-auth.ts
+++ b/packages/lib/constants/document-auth.ts
@@ -4,26 +4,21 @@ import { DocumentAuth } from '../types/document-auth';
 type DocumentAuthTypeData = {
   key: TDocumentAuth;
   value: string;
-
-  /**
-   * Whether this authentication event will require the user to halt and
-   * redirect.
-   *
-   * Defaults to false.
-   */
-  isAuthRedirectRequired?: boolean;
 };
 
 export const DOCUMENT_AUTH_TYPES: Record<string, DocumentAuthTypeData> = {
   [DocumentAuth.ACCOUNT]: {
     key: DocumentAuth.ACCOUNT,
     value: 'Require account',
-    isAuthRedirectRequired: true,
   },
-  // [DocumentAuthType.PASSKEY]: {
-  //   key: DocumentAuthType.PASSKEY,
-  //   value: 'Require passkey',
-  // },
+  [DocumentAuth.PASSKEY]: {
+    key: DocumentAuth.PASSKEY,
+    value: 'Require passkey',
+  },
+  [DocumentAuth.TWO_FACTOR_AUTH]: {
+    key: DocumentAuth.TWO_FACTOR_AUTH,
+    value: 'Require 2FA',
+  },
   [DocumentAuth.EXPLICIT_NONE]: {
     key: DocumentAuth.EXPLICIT_NONE,
     value: 'None (Overrides global settings)',

--- a/packages/lib/next-auth/auth-options.ts
+++ b/packages/lib/next-auth/auth-options.ts
@@ -22,7 +22,7 @@ import { sendConfirmationToken } from '../server-only/user/send-confirmation-tok
 import type { TAuthenticationResponseJSONSchema } from '../types/webauthn';
 import { ZAuthenticationResponseJSONSchema } from '../types/webauthn';
 import { extractNextAuthRequestMetadata } from '../universal/extract-request-metadata';
-import { getAuthenticatorRegistrationOptions } from '../utils/authenticator';
+import { getAuthenticatorOptions } from '../utils/authenticator';
 import { ErrorCode } from './error-codes';
 
 export const NEXT_AUTH_OPTIONS: AuthOptions = {
@@ -196,7 +196,7 @@ export const NEXT_AUTH_OPTIONS: AuthOptions = {
 
         const user = passkey.User;
 
-        const { rpId, origin } = getAuthenticatorRegistrationOptions();
+        const { rpId, origin } = getAuthenticatorOptions();
 
         const verification = await verifyAuthenticationResponse({
           response: requestBodyCrediential,

--- a/packages/lib/server-only/auth/create-passkey-authentication-options.ts
+++ b/packages/lib/server-only/auth/create-passkey-authentication-options.ts
@@ -1,0 +1,76 @@
+import { generateAuthenticationOptions } from '@simplewebauthn/server';
+import type { AuthenticatorTransportFuture } from '@simplewebauthn/types';
+import { DateTime } from 'luxon';
+
+import { prisma } from '@documenso/prisma';
+import type { Passkey } from '@documenso/prisma/client';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import { getAuthenticatorOptions } from '../../utils/authenticator';
+
+type CreatePasskeyAuthenticationOptions = {
+  userId: number;
+
+  /**
+   * The ID of the passkey to request authentication for.
+   *
+   * If not set, we allow the browser client to handle choosing.
+   */
+  preferredPasskeyId?: string;
+};
+
+export const createPasskeyAuthenticationOptions = async ({
+  userId,
+  preferredPasskeyId,
+}: CreatePasskeyAuthenticationOptions) => {
+  const { rpId, timeout } = getAuthenticatorOptions();
+
+  let preferredPasskey: Pick<Passkey, 'credentialId' | 'transports'> | null = null;
+
+  if (preferredPasskeyId) {
+    preferredPasskey = await prisma.passkey.findFirst({
+      where: {
+        userId,
+        id: preferredPasskeyId,
+      },
+      select: {
+        credentialId: true,
+        transports: true,
+      },
+    });
+
+    if (!preferredPasskey) {
+      throw new AppError(AppErrorCode.NOT_FOUND, 'Requested passkey not found');
+    }
+  }
+
+  const options = await generateAuthenticationOptions({
+    rpID: rpId,
+    userVerification: 'preferred',
+    timeout,
+    allowCredentials: preferredPasskey
+      ? [
+          {
+            id: preferredPasskey.credentialId,
+            type: 'public-key',
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            transports: preferredPasskey.transports as AuthenticatorTransportFuture[],
+          },
+        ]
+      : undefined,
+  });
+
+  const { secondaryId } = await prisma.verificationToken.create({
+    data: {
+      userId,
+      token: options.challenge,
+      expires: DateTime.now().plus({ minutes: 2 }).toJSDate(),
+      identifier: 'PASSKEY_CHALLENGE',
+    },
+  });
+
+  return {
+    tokenReference: secondaryId,
+    options,
+  };
+};

--- a/packages/lib/server-only/auth/create-passkey-registration-options.ts
+++ b/packages/lib/server-only/auth/create-passkey-registration-options.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import { prisma } from '@documenso/prisma';
 
 import { PASSKEY_TIMEOUT } from '../../constants/auth';
-import { getAuthenticatorRegistrationOptions } from '../../utils/authenticator';
+import { getAuthenticatorOptions } from '../../utils/authenticator';
 
 type CreatePasskeyRegistrationOptions = {
   userId: number;
@@ -27,7 +27,7 @@ export const createPasskeyRegistrationOptions = async ({
 
   const { passkeys } = user;
 
-  const { rpName, rpId: rpID } = getAuthenticatorRegistrationOptions();
+  const { rpName, rpId: rpID } = getAuthenticatorOptions();
 
   const options = await generateRegistrationOptions({
     rpName,

--- a/packages/lib/server-only/auth/create-passkey-signin-options.ts
+++ b/packages/lib/server-only/auth/create-passkey-signin-options.ts
@@ -3,14 +3,14 @@ import { DateTime } from 'luxon';
 
 import { prisma } from '@documenso/prisma';
 
-import { getAuthenticatorRegistrationOptions } from '../../utils/authenticator';
+import { getAuthenticatorOptions } from '../../utils/authenticator';
 
 type CreatePasskeySigninOptions = {
   sessionId: string;
 };
 
 export const createPasskeySigninOptions = async ({ sessionId }: CreatePasskeySigninOptions) => {
-  const { rpId, timeout } = getAuthenticatorRegistrationOptions();
+  const { rpId, timeout } = getAuthenticatorOptions();
 
   const options = await generateAuthenticationOptions({
     rpID: rpId,

--- a/packages/lib/server-only/auth/create-passkey.ts
+++ b/packages/lib/server-only/auth/create-passkey.ts
@@ -7,7 +7,7 @@ import { UserSecurityAuditLogType } from '@documenso/prisma/client';
 import { MAXIMUM_PASSKEYS } from '../../constants/auth';
 import { AppError, AppErrorCode } from '../../errors/app-error';
 import type { RequestMetadata } from '../../universal/extract-request-metadata';
-import { getAuthenticatorRegistrationOptions } from '../../utils/authenticator';
+import { getAuthenticatorOptions } from '../../utils/authenticator';
 
 type CreatePasskeyOptions = {
   userId: number;
@@ -64,7 +64,7 @@ export const createPasskey = async ({
     throw new AppError(AppErrorCode.EXPIRED_CODE, 'Challenge token expired');
   }
 
-  const { rpId: expectedRPID, origin: expectedOrigin } = getAuthenticatorRegistrationOptions();
+  const { rpId: expectedRPID, origin: expectedOrigin } = getAuthenticatorOptions();
 
   const verification = await verifyRegistrationResponse({
     response: verificationResponse,

--- a/packages/lib/server-only/auth/find-passkeys.ts
+++ b/packages/lib/server-only/auth/find-passkeys.ts
@@ -11,6 +11,7 @@ export interface FindPasskeysOptions {
   orderBy?: {
     column: keyof Passkey;
     direction: 'asc' | 'desc';
+    nulls?: Prisma.NullsOrder;
   };
 }
 
@@ -21,8 +22,9 @@ export const findPasskeys = async ({
   perPage = 10,
   orderBy,
 }: FindPasskeysOptions) => {
-  const orderByColumn = orderBy?.column ?? 'name';
+  const orderByColumn = orderBy?.column ?? 'lastUsedAt';
   const orderByDirection = orderBy?.direction ?? 'desc';
+  const orderByNulls: Prisma.NullsOrder | undefined = orderBy?.nulls ?? 'last';
 
   const whereClause: Prisma.PasskeyWhereInput = {
     userId,
@@ -41,7 +43,10 @@ export const findPasskeys = async ({
       skip: Math.max(page - 1, 0) * perPage,
       take: perPage,
       orderBy: {
-        [orderByColumn]: orderByDirection,
+        [orderByColumn]: {
+          sort: orderByDirection,
+          nulls: orderByNulls,
+        },
       },
       select: {
         id: true,

--- a/packages/lib/server-only/document/is-recipient-authorized.ts
+++ b/packages/lib/server-only/document/is-recipient-authorized.ts
@@ -1,10 +1,15 @@
+import { verifyAuthenticationResponse } from '@simplewebauthn/server';
 import { match } from 'ts-pattern';
 
 import { prisma } from '@documenso/prisma';
 import type { Document, Recipient } from '@documenso/prisma/client';
 
+import { verifyTwoFactorAuthenticationToken } from '../2fa/verify-2fa-token';
+import { AppError, AppErrorCode } from '../../errors/app-error';
 import type { TDocumentAuth, TDocumentAuthMethods } from '../../types/document-auth';
 import { DocumentAuth } from '../../types/document-auth';
+import type { TAuthenticationResponseJSONSchema } from '../../types/webauthn';
+import { getAuthenticatorOptions } from '../../utils/authenticator';
 import { extractDocumentAuthMethods } from '../../utils/document-auth';
 
 type IsRecipientAuthorizedOptions = {
@@ -63,17 +68,20 @@ export const isRecipientAuthorized = async ({
     return true;
   }
 
+  // Create auth options when none are passed for account.
+  if (!authOptions && authMethod === DocumentAuth.ACCOUNT) {
+    authOptions = {
+      type: DocumentAuth.ACCOUNT,
+    };
+  }
+
   // Authentication required does not match provided method.
-  if (authOptions && authOptions.type !== authMethod) {
+  if (!authOptions || authOptions.type !== authMethod || !userId) {
     return false;
   }
 
-  return await match(authMethod)
-    .with(DocumentAuth.ACCOUNT, async () => {
-      if (userId === undefined) {
-        return false;
-      }
-
+  return await match(authOptions)
+    .with({ type: DocumentAuth.ACCOUNT }, async () => {
       const recipientUser = await getUserByEmail(recipient.email);
 
       if (!recipientUser) {
@@ -82,5 +90,124 @@ export const isRecipientAuthorized = async ({
 
       return recipientUser.id === userId;
     })
+    .with({ type: DocumentAuth.PASSKEY }, async ({ authenticationResponse, tokenReference }) => {
+      return await isPasskeyAuthValid({
+        userId,
+        authenticationResponse,
+        tokenReference,
+      });
+    })
+    .with({ type: DocumentAuth.TWO_FACTOR_AUTH }, async ({ token }) => {
+      const user = await prisma.user.findFirst({
+        where: {
+          id: userId,
+        },
+      });
+
+      // Should not be possible.
+      if (!user) {
+        throw new AppError(AppErrorCode.NOT_FOUND, 'User not found');
+      }
+
+      return await verifyTwoFactorAuthenticationToken({
+        user,
+        totpCode: token,
+      });
+    })
     .exhaustive();
+};
+
+type VerifyPasskeyOptions = {
+  /**
+   * The ID of the user who initiated the request.
+   */
+  userId: number;
+
+  /**
+   * The secondary ID of the verification token.
+   */
+  tokenReference: string;
+
+  /**
+   * The response from the passkey authenticator.
+   */
+  authenticationResponse: TAuthenticationResponseJSONSchema;
+};
+
+/**
+ * Whether the provided passkey authenticator response is valid and the user is
+ * authenticated.
+ */
+const isPasskeyAuthValid = async (options: VerifyPasskeyOptions): Promise<boolean> => {
+  return verifyPasskey(options)
+    .then(() => true)
+    .catch(() => false);
+};
+
+/**
+ * Verifies whether the provided passkey authenticator is valid and the user is
+ * authenticated.
+ *
+ * Will throw an error if the user should not be authenticated.
+ */
+const verifyPasskey = async ({
+  userId,
+  tokenReference,
+  authenticationResponse,
+}: VerifyPasskeyOptions): Promise<void> => {
+  const passkey = await prisma.passkey.findFirst({
+    where: {
+      credentialId: Buffer.from(authenticationResponse.id, 'base64'),
+      userId,
+    },
+  });
+
+  if (!passkey) {
+    throw new AppError(AppErrorCode.NOT_FOUND, 'Passkey not found');
+  }
+
+  const verificationToken = await prisma.verificationToken
+    .delete({
+      where: {
+        userId,
+        secondaryId: tokenReference,
+      },
+    })
+    .catch(() => null);
+
+  if (!verificationToken) {
+    throw new AppError(AppErrorCode.NOT_FOUND, 'Token not found');
+  }
+
+  if (verificationToken.expires < new Date()) {
+    throw new AppError(AppErrorCode.EXPIRED_CODE, 'Token expired');
+  }
+
+  const { rpId, origin } = getAuthenticatorOptions();
+
+  const verification = await verifyAuthenticationResponse({
+    response: authenticationResponse,
+    expectedChallenge: verificationToken.token,
+    expectedOrigin: origin,
+    expectedRPID: rpId,
+    authenticator: {
+      credentialID: new Uint8Array(Array.from(passkey.credentialId)),
+      credentialPublicKey: new Uint8Array(passkey.credentialPublicKey),
+      counter: Number(passkey.counter),
+    },
+  }).catch(() => null); // May want to log this for insights.
+
+  if (verification?.verified !== true) {
+    throw new AppError(AppErrorCode.UNAUTHORIZED, 'User is not authorized');
+  }
+
+  await prisma.passkey.update({
+    where: {
+      id: passkey.id,
+    },
+    data: {
+      lastUsedAt: new Date(),
+      counter: verification.authenticationInfo.newCounter,
+    },
+  });
 };

--- a/packages/lib/types/document-auth.ts
+++ b/packages/lib/types/document-auth.ts
@@ -1,9 +1,16 @@
 import { z } from 'zod';
 
+import { ZAuthenticationResponseJSONSchema } from './webauthn';
+
 /**
  * All the available types of document authentication options for both access and action.
  */
-export const ZDocumentAuthTypesSchema = z.enum(['ACCOUNT', 'EXPLICIT_NONE']);
+export const ZDocumentAuthTypesSchema = z.enum([
+  'ACCOUNT',
+  'PASSKEY',
+  'TWO_FACTOR_AUTH',
+  'EXPLICIT_NONE',
+]);
 export const DocumentAuth = ZDocumentAuthTypesSchema.Enum;
 
 const ZDocumentAuthAccountSchema = z.object({
@@ -14,12 +21,25 @@ const ZDocumentAuthExplicitNoneSchema = z.object({
   type: z.literal(DocumentAuth.EXPLICIT_NONE),
 });
 
+const ZDocumentAuthPasskeySchema = z.object({
+  type: z.literal(DocumentAuth.PASSKEY),
+  authenticationResponse: ZAuthenticationResponseJSONSchema,
+  tokenReference: z.string().min(1),
+});
+
+const ZDocumentAuth2FASchema = z.object({
+  type: z.literal(DocumentAuth.TWO_FACTOR_AUTH),
+  token: z.string().min(4).max(10),
+});
+
 /**
  * All the document auth methods for both accessing and actioning.
  */
 export const ZDocumentAuthMethodsSchema = z.discriminatedUnion('type', [
   ZDocumentAuthAccountSchema,
   ZDocumentAuthExplicitNoneSchema,
+  ZDocumentAuthPasskeySchema,
+  ZDocumentAuth2FASchema,
 ]);
 
 /**
@@ -35,8 +55,16 @@ export const ZDocumentAccessAuthTypesSchema = z.enum([DocumentAuth.ACCOUNT]);
  *
  * Must keep these two in sync.
  */
-export const ZDocumentActionAuthSchema = z.discriminatedUnion('type', [ZDocumentAuthAccountSchema]); // Todo: Add passkeys here.
-export const ZDocumentActionAuthTypesSchema = z.enum([DocumentAuth.ACCOUNT]);
+export const ZDocumentActionAuthSchema = z.discriminatedUnion('type', [
+  ZDocumentAuthAccountSchema,
+  ZDocumentAuthPasskeySchema,
+  ZDocumentAuth2FASchema,
+]);
+export const ZDocumentActionAuthTypesSchema = z.enum([
+  DocumentAuth.ACCOUNT,
+  DocumentAuth.PASSKEY,
+  DocumentAuth.TWO_FACTOR_AUTH,
+]);
 
 /**
  * The recipient access auth methods.
@@ -54,11 +82,15 @@ export const ZRecipientAccessAuthTypesSchema = z.enum([DocumentAuth.ACCOUNT]);
  * Must keep these two in sync.
  */
 export const ZRecipientActionAuthSchema = z.discriminatedUnion('type', [
-  ZDocumentAuthAccountSchema, // Todo: Add passkeys here.
+  ZDocumentAuthAccountSchema,
+  ZDocumentAuthPasskeySchema,
+  ZDocumentAuth2FASchema,
   ZDocumentAuthExplicitNoneSchema,
 ]);
 export const ZRecipientActionAuthTypesSchema = z.enum([
   DocumentAuth.ACCOUNT,
+  DocumentAuth.PASSKEY,
+  DocumentAuth.TWO_FACTOR_AUTH,
   DocumentAuth.EXPLICIT_NONE,
 ]);
 

--- a/packages/lib/utils/authenticator.ts
+++ b/packages/lib/utils/authenticator.ts
@@ -4,7 +4,7 @@ import { PASSKEY_TIMEOUT } from '../constants/auth';
 /**
  * Extracts common fields to identify the RP (relying party)
  */
-export const getAuthenticatorRegistrationOptions = () => {
+export const getAuthenticatorOptions = () => {
   const webAppBaseUrl = new URL(WEBAPP_BASE_URL);
   const rpId = webAppBaseUrl.hostname;
 

--- a/packages/prisma/migrations/20240327074701_add_secondary_verification_id/migration.sql
+++ b/packages/prisma/migrations/20240327074701_add_secondary_verification_id/migration.sql
@@ -6,7 +6,13 @@
 
 */
 -- AlterTable
-ALTER TABLE "VerificationToken" ADD COLUMN     "secondaryId" TEXT NOT NULL;
+ALTER TABLE "VerificationToken" ADD COLUMN     "secondaryId" TEXT;
+
+-- Set all null secondaryId fields to a uuid
+UPDATE "VerificationToken" SET "secondaryId" = gen_random_uuid()::text WHERE "secondaryId" IS NULL;
+
+-- Restrict the VerificationToken to required
+ALTER TABLE "VerificationToken" ALTER COLUMN "secondaryId" SET NOT NULL;
 
 -- CreateIndex
 CREATE UNIQUE INDEX "VerificationToken_secondaryId_key" ON "VerificationToken"("secondaryId");

--- a/packages/prisma/migrations/20240327074701_add_secondary_verification_id/migration.sql
+++ b/packages/prisma/migrations/20240327074701_add_secondary_verification_id/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[secondaryId]` on the table `VerificationToken` will be added. If there are existing duplicate values, this will fail.
+  - The required column `secondaryId` was added to the `VerificationToken` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- AlterTable
+ALTER TABLE "VerificationToken" ADD COLUMN     "secondaryId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_secondaryId_key" ON "VerificationToken"("secondaryId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -126,13 +126,14 @@ model AnonymousVerificationToken {
 }
 
 model VerificationToken {
-  id         Int      @id @default(autoincrement())
-  identifier String
-  token      String   @unique
-  expires    DateTime
-  createdAt  DateTime @default(now())
-  userId     Int
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id          Int      @id @default(autoincrement())
+  secondaryId String   @unique @default(cuid())
+  identifier  String
+  token       String   @unique
+  expires     DateTime
+  createdAt   DateTime @default(now())
+  userId      Int
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 enum WebhookTriggerEvents {

--- a/packages/trpc/server/auth-router/router.ts
+++ b/packages/trpc/server/auth-router/router.ts
@@ -7,6 +7,7 @@ import { IS_BILLING_ENABLED } from '@documenso/lib/constants/app';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import { ErrorCode } from '@documenso/lib/next-auth/error-codes';
 import { createPasskey } from '@documenso/lib/server-only/auth/create-passkey';
+import { createPasskeyAuthenticationOptions } from '@documenso/lib/server-only/auth/create-passkey-authentication-options';
 import { createPasskeyRegistrationOptions } from '@documenso/lib/server-only/auth/create-passkey-registration-options';
 import { createPasskeySigninOptions } from '@documenso/lib/server-only/auth/create-passkey-signin-options';
 import { deletePasskey } from '@documenso/lib/server-only/auth/delete-passkey';
@@ -19,6 +20,7 @@ import { extractNextApiRequestMetadata } from '@documenso/lib/universal/extract-
 
 import { authenticatedProcedure, procedure, router } from '../trpc';
 import {
+  ZCreatePasskeyAuthenticationOptionsMutationSchema,
   ZCreatePasskeyMutationSchema,
   ZDeletePasskeyMutationSchema,
   ZFindPasskeysQuerySchema,
@@ -112,6 +114,25 @@ export const authRouter = router({
         console.error(err);
 
         throw AppError.parseErrorToTRPCError(err);
+      }
+    }),
+
+  createPasskeyAuthenticationOptions: authenticatedProcedure
+    .input(ZCreatePasskeyAuthenticationOptionsMutationSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await createPasskeyAuthenticationOptions({
+          userId: ctx.user.id,
+          preferredPasskeyId: input?.preferredPasskeyId,
+        });
+      } catch (err) {
+        console.error(err);
+
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'We were unable to create the authentication options for the passkey. Please try again later.',
+        });
       }
     }),
 

--- a/packages/trpc/server/auth-router/schema.ts
+++ b/packages/trpc/server/auth-router/schema.ts
@@ -40,6 +40,12 @@ export const ZCreatePasskeyMutationSchema = z.object({
   verificationResponse: ZRegistrationResponseJSONSchema,
 });
 
+export const ZCreatePasskeyAuthenticationOptionsMutationSchema = z
+  .object({
+    preferredPasskeyId: z.string().optional(),
+  })
+  .optional();
+
 export const ZDeletePasskeyMutationSchema = z.object({
   passkeyId: z.string().trim().min(1),
 });

--- a/packages/ui/primitives/document-flow/add-settings.tsx
+++ b/packages/ui/primitives/document-flow/add-settings.tsx
@@ -220,6 +220,10 @@ export const AddSettingsFormPartial = ({
                               <strong>Require account</strong> - The recipient must be signed in
                             </li>
                             <li>
+                              <strong>Require passkey</strong> - The recipient must have an account
+                              and passkey configured via their settings
+                            </li>
+                            <li>
                               <strong>None</strong> - No authentication required
                             </li>
                           </ul>

--- a/packages/ui/primitives/document-flow/add-signers.tsx
+++ b/packages/ui/primitives/document-flow/add-signers.tsx
@@ -288,6 +288,10 @@ export const AddSignersFormPartial = ({
                                         signed in
                                       </li>
                                       <li>
+                                        <strong>Require passkey</strong> - The recipient must have
+                                        an account and passkey configured via their settings
+                                      </li>
+                                      <li>
                                         <strong>None</strong> - No authentication required
                                       </li>
                                     </ul>


### PR DESCRIPTION
## Description

Add the following document action auth options:
- 2FA
- Passkey

If the user does not have the required auth setup, we onboard them directly.

## Changes made

Note: Added secondaryId to the VerificationToken schema

## Testing Performed

Tested locally, pending preview tests

## Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have followed the project's coding style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced components for 2FA, account, and passkey authentication during document signing.
	- Added "Require passkey" option to document settings and signer authentication settings.
	- Enhanced form submission and loading states for improved user experience.
- **Refactor**
	- Optimized authentication components to efficiently support multiple authentication methods.
- **Chores**
	- Updated and renamed functions and components for clarity and consistency across the authentication system.
	- Refined sorting options and database schema to support new authentication features.
- **Bug Fixes**
	- Adjusted SignInForm to verify browser support for WebAuthn before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->