### PR TITLE
fix: enforce 2FA for email password SSO linked accounts

### DIFF
--- a/packages/app-tests/e2e/pr-718-add-stepper-component.spec.ts
+++ b/packages/app-tests/e2e/pr-718-add-stepper-component.spec.ts
@@ -262,7 +262,7 @@ test('should be able to create, send and sign a document', async ({ page }) => {
   expect(status).toBe(DocumentStatus.PENDING);
 
   await page.getByRole('button', { name: 'Complete' }).click();
-  await expect(page.getByRole('dialog').getByText('Sign Document')).toBeVisible();
+  await expect(page.getByRole('dialog').getByText('Complete Signing').first()).toBeVisible();
   await page.getByRole('button', { name: 'Sign' }).click();
 
   await page.waitForURL(`/sign/${token}/complete`);
@@ -347,7 +347,7 @@ test('should be able to create, send with redirect url, sign a document and redi
   expect(status).toBe(DocumentStatus.PENDING);
 
   await page.getByRole('button', { name: 'Complete' }).click();
-  await expect(page.getByRole('dialog').getByText('Sign Document')).toBeVisible();
+  await expect(page.getByRole('dialog').getByText('Complete Signing').first()).toBeVisible();
   await page.getByRole('button', { name: 'Sign' }).click();
 
   await page.waitForURL('https://documenso.com');

--- a/packages/app-tests/e2e/test-auth-flow.spec.ts
+++ b/packages/app-tests/e2e/test-auth-flow.spec.ts
@@ -30,7 +30,7 @@ test('user can sign up with email and password', async ({ page }: { page: Page }
   }
 
   await page.getByRole('button', { name: 'Next', exact: true }).click();
-  await page.getByLabel('Public profile username').fill('username-123');
+  await page.getByLabel('Public profile username').fill(Date.now().toString());
 
   await page.getByRole('button', { name: 'Complete', exact: true }).click();
 

--- a/packages/lib/server-only/2fa/is-2fa-availble.ts
+++ b/packages/lib/server-only/2fa/is-2fa-availble.ts
@@ -1,4 +1,4 @@
-import { User } from '@documenso/prisma/client';
+import type { User } from '@documenso/prisma/client';
 
 import { DOCUMENSO_ENCRYPTION_KEY } from '../../constants/crypto';
 
@@ -9,9 +9,5 @@ type IsTwoFactorAuthenticationEnabledOptions = {
 export const isTwoFactorAuthenticationEnabled = ({
   user,
 }: IsTwoFactorAuthenticationEnabledOptions) => {
-  return (
-    user.twoFactorEnabled &&
-    user.identityProvider === 'DOCUMENSO' &&
-    typeof DOCUMENSO_ENCRYPTION_KEY === 'string'
-  );
+  return user.twoFactorEnabled && typeof DOCUMENSO_ENCRYPTION_KEY === 'string';
 };


### PR DESCRIPTION
## Description

Fixed issue where accounts that were initially created via email/password, then linked to an SSO account, can bypass the 2FA during login if they use their email password.

## Testing Performed

Tested locally, and 2FA is now required for linked SSO accounts