### PR TITLE
chore: remove duplicate env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,16 +40,6 @@ NEXT_PRIVATE_SIGNING_GCLOUD_HSM_PUBLIC_CRT_FILE_CONTENTS=
 # OPTIONAL: The path to the Google Cloud Credentials file to use for the gcloud-hsm signing transport.
 NEXT_PRIVATE_SIGNING_GCLOUD_APPLICATION_CREDENTIALS_CONTENTS=
 
-# [[SIGNING]]
-# OPTIONAL: Defines the signing transport to use. Available options: local (default)
-NEXT_PRIVATE_SIGNING_TRANSPORT="local"
-# OPTIONAL: Defines the passphrase for the signing certificate.
-NEXT_PRIVATE_SIGNING_PASSPHRASE=
-# OPTIONAL: Defines the file contents for the signing certificate as a base64 encoded string.
-NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS=
-# OPTIONAL: Defines the file path for the signing certificate. defaults to ./example/cert.p12
-NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=
-
 # [[STORAGE]]
 # OPTIONAL: Defines the storage transport to use. Available options: database (default) | s3
 NEXT_PUBLIC_UPLOAD_TRANSPORT="database"


### PR DESCRIPTION
**Description:**

The `.env.example` had duplicate keys so removed them in this PR