### PR TITLE
fix: document audit log field security migration

### DIFF
--- a/packages/lib/types/document-audit-logs.ts
+++ b/packages/lib/types/document-audit-logs.ts
@@ -236,11 +236,29 @@ export const ZDocumentAuditLogEventDocumentFieldInsertedSchema = z.object({
         data: z.string(),
       }),
     ]),
-    fieldSecurity: z
-      .object({
-        type: ZRecipientActionAuthTypesSchema,
-      })
-      .optional(),
+    fieldSecurity: z.preprocess(
+      (input) => {
+        const legacyNoneSecurityType = JSON.stringify({
+          type: 'NONE',
+        });
+
+        // Replace legacy 'NONE' field security type with undefined.
+        if (
+          typeof input === 'object' &&
+          input !== null &&
+          JSON.stringify(input) === legacyNoneSecurityType
+        ) {
+          return undefined;
+        }
+
+        return input;
+      },
+      z
+        .object({
+          type: ZRecipientActionAuthTypesSchema,
+        })
+        .optional(),
+    ),
   }),
 });
 


### PR DESCRIPTION
## Description

When document audit logs were first introduced, we by default set the `fieldSecurity` to `NONE`

Now that document auth has been added, this is causing issues since we do not use `NONE` to define field that has no migrations required, but rather have the `fieldSecurity` field itself be undefined.

To keeps things consistent, this migration replaces `NONE` with undefined. 

There are a few ways to approach this:
- Run a prisma migration on the JSON
- Modify the data before we pass the data to the schema in `parseDocumentAuditLogData`
- Use `NONE` instead of undefined

If anyone thinks there's a better way to do this, please drop a comment 🙇 