### PR TITLE
feat: add prefilling pdf form fields via api

### DIFF
--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -73,6 +73,7 @@ export const ZCreateDocumentMutationSchema = z.object({
       redirectUrl: z.string(),
     })
     .partial(),
+  formValues: z.record(z.string(), z.union([z.string(), z.boolean(), z.number()])).optional(),
 });
 
 export type TCreateDocumentMutationSchema = z.infer<typeof ZCreateDocumentMutationSchema>;
@@ -112,6 +113,7 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
     })
     .partial()
     .optional(),
+  formValues: z.record(z.string(), z.union([z.string(), z.boolean(), z.number()])).optional(),
 });
 
 export type TCreateDocumentFromTemplateMutationSchema = z.infer<

--- a/packages/lib/server-only/document/create-document.ts
+++ b/packages/lib/server-only/document/create-document.ts
@@ -14,6 +14,7 @@ export type CreateDocumentOptions = {
   userId: number;
   teamId?: number;
   documentDataId: string;
+  formValues?: Record<string, string | number | boolean>;
   requestMetadata?: RequestMetadata;
 };
 
@@ -22,6 +23,7 @@ export const createDocument = async ({
   title,
   documentDataId,
   teamId,
+  formValues,
   requestMetadata,
 }: CreateDocumentOptions) => {
   const user = await prisma.user.findFirstOrThrow({
@@ -51,6 +53,7 @@ export const createDocument = async ({
         documentDataId,
         userId,
         teamId,
+        formValues,
       },
     });
 

--- a/packages/lib/server-only/pdf/insert-form-values-in-pdf.ts
+++ b/packages/lib/server-only/pdf/insert-form-values-in-pdf.ts
@@ -1,0 +1,54 @@
+import { PDFCheckBox, PDFDocument, PDFDropdown, PDFRadioGroup, PDFTextField } from 'pdf-lib';
+
+export type InsertFormValuesInPdfOptions = {
+  pdf: Buffer;
+  formValues: Record<string, string | boolean | number>;
+};
+
+export const insertFormValuesInPdf = async ({ pdf, formValues }: InsertFormValuesInPdfOptions) => {
+  const doc = await PDFDocument.load(pdf);
+
+  const form = doc.getForm();
+
+  if (!form) {
+    return pdf;
+  }
+
+  for (const [key, value] of Object.entries(formValues)) {
+    try {
+      const field = form.getField(key);
+
+      if (!field) {
+        continue;
+      }
+
+      if (typeof value === 'boolean' && field instanceof PDFCheckBox) {
+        if (value) {
+          field.check();
+        } else {
+          field.uncheck();
+        }
+      }
+
+      if (field instanceof PDFTextField) {
+        field.setText(value.toString());
+      }
+
+      if (field instanceof PDFDropdown) {
+        field.select(value.toString());
+      }
+
+      if (field instanceof PDFRadioGroup) {
+        field.select(value.toString());
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error(`Error setting value for field ${key}: ${err.message}`);
+      } else {
+        console.error(`Error setting value for field ${key}`);
+      }
+    }
+  }
+
+  return await doc.save().then((buf) => Buffer.from(buf));
+};

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -79,6 +79,7 @@ export const createDocumentFromTemplate = async ({
           id: 'asc',
         },
       },
+      documentData: true,
     },
   });
 

--- a/packages/prisma/migrations/20240408083413_add_form_values_column/migration.sql
+++ b/packages/prisma/migrations/20240408083413_add_form_values_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Document" ADD COLUMN     "formValues" JSONB;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -257,6 +257,7 @@ model Document {
   userId         Int
   User           User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   authOptions    Json?
+  formValues     Json?
   title          String
   status         DocumentStatus      @default(DRAFT)
   Recipient      Recipient[]


### PR DESCRIPTION
## Description

Adds the ability to prefill native PDF form fields via the API using either normal documents or templates.

Since we won't always know when a document is uploaded and has forms we opt to do this on creation for templates and on sending the document to recipients in all cases. This means that for a created document it can look a little funky since the form fields are missing the data until the document is sent.

This should be improved in a later change but since we've scoped this to an API only workflow for now we are less concerned with the visual issues.

## Related Issue

N/A

## Changes Made

- Added the `formValues` field the document model
- Added a new method for finding and filling form fields based on a `key | value` pair
- Updated the API input shapes to take the new field.

## Testing Performed

- Have created and tested a document using the API both for creation and usage with a template.
- Have verified that the fields display as expected either during creation or sending depending on the document type.