### PR TITLE
fix: return updated doc

### DIFF
--- a/packages/lib/server-only/document/seal-document.ts
+++ b/packages/lib/server-only/document/seal-document.ts
@@ -153,9 +153,19 @@ export const sealDocument = async ({
     await sendCompletedEmail({ documentId, requestMetadata });
   }
 
+  const updatedDocument = await prisma.document.findFirstOrThrow({
+    where: {
+      id: document.id,
+    },
+    include: {
+      documentData: true,
+      Recipient: true,
+    },
+  });
+
   await triggerWebhook({
     event: WebhookTriggerEvents.DOCUMENT_COMPLETED,
-    data: document,
+    data: updatedDocument,
     userId: document.userId,
     teamId: document.teamId ?? undefined,
   });


### PR DESCRIPTION
## Description

Fetch the updated version of the document after sealing it and return it. Previously, the `document.documentData.data` wasn't up to date. Now it is.

## Related Issue

Fixes #1088.

## Testing Performed

* Added console.logs in the code to make sure it returns the proper data
* Set up a webhook and tested that the webhook receives the updated data

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

