### PR TITLE
feat: add extra info for recipient roles

### DIFF
--- a/packages/ui/primitives/document-flow/add-signers.tsx
+++ b/packages/ui/primitives/document-flow/add-signers.tsx
@@ -342,6 +342,15 @@ export const AddSignersFormPartial = ({
                                 <div className="flex items-center">
                                   <span className="mr-2">{ROLE_ICONS[RecipientRole.SIGNER]}</span>
                                   Signer
+                                  <Tooltip>
+                                    <TooltipTrigger className="-mr-1 ml-auto">
+                                      <InfoIcon className="mx-2 h-4 w-4" />
+                                    </TooltipTrigger>
+
+                                    <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+                                      <p>The recipient is required to sign the document.</p>
+                                    </TooltipContent>
+                                  </Tooltip>
                                 </div>
                               </SelectItem>
 
@@ -349,6 +358,18 @@ export const AddSignersFormPartial = ({
                                 <div className="flex items-center">
                                   <span className="mr-2">{ROLE_ICONS[RecipientRole.CC]}</span>
                                   Receives copy
+                                  <Tooltip>
+                                    <TooltipTrigger className="-mr-1 ml-auto">
+                                      <InfoIcon className="mx-2 h-4 w-4" />
+                                    </TooltipTrigger>
+
+                                    <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+                                      <p>
+                                        The recipient is not required to take any action and
+                                        receives a copy of the document.
+                                      </p>
+                                    </TooltipContent>
+                                  </Tooltip>
                                 </div>
                               </SelectItem>
 
@@ -356,6 +377,15 @@ export const AddSignersFormPartial = ({
                                 <div className="flex items-center">
                                   <span className="mr-2">{ROLE_ICONS[RecipientRole.APPROVER]}</span>
                                   Approver
+                                  <Tooltip>
+                                    <TooltipTrigger className="-mr-1 ml-auto">
+                                      <InfoIcon className="mx-2 h-4 w-4" />
+                                    </TooltipTrigger>
+
+                                    <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+                                      <p>The recipient is required to approve the document.</p>
+                                    </TooltipContent>
+                                  </Tooltip>
                                 </div>
                               </SelectItem>
 
@@ -363,6 +393,15 @@ export const AddSignersFormPartial = ({
                                 <div className="flex items-center">
                                   <span className="mr-2">{ROLE_ICONS[RecipientRole.VIEWER]}</span>
                                   Viewer
+                                  <Tooltip>
+                                    <TooltipTrigger className="-mr-1 ml-auto">
+                                      <InfoIcon className="mx-2 h-4 w-4" />
+                                    </TooltipTrigger>
+
+                                    <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+                                      <p>The recipient is required to view the document.</p>
+                                    </TooltipContent>
+                                  </Tooltip>
                                 </div>
                               </SelectItem>
                             </SelectContent>


### PR DESCRIPTION

## Description

Add additional information for each role to help document owners understand what each role involves.

## Changes Made

![CleanShot 2024-04-16 at 10 24 19](https://github.com/documenso/documenso/assets/25515812/bac6cd7d-fbe2-4987-ac17-de08db882eda)
![CleanShot 2024-04-16 at 10 24 27](https://github.com/documenso/documenso/assets/25515812/1bd23021-e971-451a-8e36-df5db57687f7)
![CleanShot 2024-04-16 at 10 24 35](https://github.com/documenso/documenso/assets/25515812/e658e86e-7fa1-4a40-9ed9-317964388e61)

## Testing Performed

Tested the changes locally.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
