### PR TITLE
chore: fix text padding

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/complete/page.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/complete/page.tsx
@@ -131,7 +131,7 @@ export default async function CompletedSigningPage({
               </div>
             ))
             .with({ deletedAt: null }, () => (
-              <div className="flex items-center text-center text-blue-600">
+              <div className="flex items-center mt-4 text-center text-blue-600">
                 <Clock8 className="mr-2 h-5 w-5" />
                 <span className="text-sm">Waiting for others to sign</span>
               </div>


### PR DESCRIPTION
**Description:**

This PR fixes the text padding 

**Before:**

<img width="639" alt="Screenshot 2024-04-17 at 4 10 51 AM" src="https://github.com/documenso/documenso/assets/23498248/a46fdb12-4ec6-4084-af3a-ae794e535e6f">

**After:**

<img width="680" alt="Screenshot 2024-04-17 at 4 09 44 AM" src="https://github.com/documenso/documenso/assets/23498248/0b9c6e8c-4116-4bde-a19d-f907fb93ad5d">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the layout by adding top margin to the message display on the signing completion page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->