### PR TITLE
feat: update emails for self-signer

### DIFF
--- a/packages/email/template-components/template-document-invite.tsx
+++ b/packages/email/template-components/template-document-invite.tsx
@@ -5,20 +5,18 @@ import { Button, Section, Text } from '../components';
 import { TemplateDocumentImage } from './template-document-image';
 
 export interface TemplateDocumentInviteProps {
-  inviterName: string;
-  inviterEmail: string;
   documentName: string;
   signDocumentLink: string;
   assetBaseUrl: string;
   role: RecipientRole;
+  headerContent: React.ReactNode;
 }
 
 export const TemplateDocumentInvite = ({
-  inviterName,
-  documentName,
   signDocumentLink,
   assetBaseUrl,
   role,
+  headerContent,
 }: TemplateDocumentInviteProps) => {
   const { actionVerb, progressiveVerb } = RECIPIENT_ROLES_DESCRIPTION[role];
 
@@ -28,8 +26,7 @@ export const TemplateDocumentInvite = ({
 
       <Section>
         <Text className="text-primary mx-auto mb-0 max-w-[80%] text-center text-lg font-semibold">
-          {inviterName} has invited you to {actionVerb.toLowerCase()}
-          <br />"{documentName}"
+          {headerContent}
         </Text>
 
         <Text className="my-1 text-center text-base text-slate-400">

--- a/packages/email/template-components/template-document-invite.tsx
+++ b/packages/email/template-components/template-document-invite.tsx
@@ -5,20 +5,37 @@ import { Button, Section, Text } from '../components';
 import { TemplateDocumentImage } from './template-document-image';
 
 export interface TemplateDocumentInviteProps {
+  inviterName: string;
+  inviterEmail: string;
   documentName: string;
   signDocumentLink: string;
   assetBaseUrl: string;
   role: RecipientRole;
-  headerContent: React.ReactNode;
+  selfSigner: boolean;
 }
 
 export const TemplateDocumentInvite = ({
+  inviterName,
+  documentName,
   signDocumentLink,
   assetBaseUrl,
   role,
-  headerContent,
+  selfSigner,
 }: TemplateDocumentInviteProps) => {
   const { actionVerb, progressiveVerb } = RECIPIENT_ROLES_DESCRIPTION[role];
+  const headerContent = selfSigner ? (
+    <>
+      {`Please ${actionVerb.toLowerCase()} your document`}
+      <br />
+      {`"${documentName}"`}
+    </>
+  ) : (
+    <>
+      {`${inviterName} has invited you to ${actionVerb.toLowerCase()}`}
+      <br />
+      {`"${documentName}"`}
+    </>
+  );
 
   return (
     <>

--- a/packages/email/template-components/template-document-invite.tsx
+++ b/packages/email/template-components/template-document-invite.tsx
@@ -23,19 +23,6 @@ export const TemplateDocumentInvite = ({
   selfSigner,
 }: TemplateDocumentInviteProps) => {
   const { actionVerb, progressiveVerb } = RECIPIENT_ROLES_DESCRIPTION[role];
-  const headerContent = selfSigner ? (
-    <>
-      {`Please ${actionVerb.toLowerCase()} your document`}
-      <br />
-      {`"${documentName}"`}
-    </>
-  ) : (
-    <>
-      {`${inviterName} has invited you to ${actionVerb.toLowerCase()}`}
-      <br />
-      {`"${documentName}"`}
-    </>
-  );
 
   return (
     <>
@@ -43,7 +30,19 @@ export const TemplateDocumentInvite = ({
 
       <Section>
         <Text className="text-primary mx-auto mb-0 max-w-[80%] text-center text-lg font-semibold">
-          {headerContent}
+          {selfSigner ? (
+            <>
+              {`Please ${actionVerb.toLowerCase()} your document`}
+              <br />
+              {`"${documentName}"`}
+            </>
+          ) : (
+            <>
+              {`${inviterName} has invited you to ${actionVerb.toLowerCase()}`}
+              <br />
+              {`"${documentName}"`}
+            </>
+          )}
         </Text>
 
         <Text className="my-1 text-center text-base text-slate-400">

--- a/packages/email/templates/document-invite.tsx
+++ b/packages/email/templates/document-invite.tsx
@@ -20,8 +20,11 @@ import { TemplateDocumentInvite } from '../template-components/template-document
 import { TemplateFooter } from '../template-components/template-footer';
 
 export type DocumentInviteEmailTemplateProps = Partial<TemplateDocumentInviteProps> & {
+  inviterName?: string;
+  inviterEmail: string;
   customBody?: string;
   role: RecipientRole;
+  selfSigner?: boolean;
 };
 
 export const DocumentInviteEmailTemplate = ({
@@ -32,10 +35,26 @@ export const DocumentInviteEmailTemplate = ({
   assetBaseUrl = 'http://localhost:3002',
   customBody,
   role,
+  selfSigner = false,
 }: DocumentInviteEmailTemplateProps) => {
   const action = RECIPIENT_ROLES_DESCRIPTION[role].actionVerb.toLowerCase();
+  const headerContent = selfSigner ? (
+    <>
+      {`Please ${action} your document`}
+      <br />
+      {`"${documentName}"`}
+    </>
+  ) : (
+    <>
+      {`${inviterName} has invited you to ${action}`}
+      <br />
+      {`"${documentName}"`}
+    </>
+  );
 
-  const previewText = `${inviterName} has invited you to ${action} ${documentName}`;
+  const previewText = selfSigner
+    ? `Please ${action} your document ${documentName}`
+    : `${inviterName} has invited you to ${action} ${documentName}`;
 
   const getAssetUrl = (path: string) => {
     return new URL(path, assetBaseUrl).toString();
@@ -65,12 +84,11 @@ export const DocumentInviteEmailTemplate = ({
                 />
 
                 <TemplateDocumentInvite
-                  inviterName={inviterName}
-                  inviterEmail={inviterEmail}
                   documentName={documentName}
                   signDocumentLink={signDocumentLink}
                   assetBaseUrl={assetBaseUrl}
                   role={role}
+                  headerContent={headerContent}
                 />
               </Section>
             </Container>

--- a/packages/email/templates/document-invite.tsx
+++ b/packages/email/templates/document-invite.tsx
@@ -20,8 +20,6 @@ import { TemplateDocumentInvite } from '../template-components/template-document
 import { TemplateFooter } from '../template-components/template-footer';
 
 export type DocumentInviteEmailTemplateProps = Partial<TemplateDocumentInviteProps> & {
-  inviterName?: string;
-  inviterEmail: string;
   customBody?: string;
   role: RecipientRole;
   selfSigner?: boolean;
@@ -38,19 +36,6 @@ export const DocumentInviteEmailTemplate = ({
   selfSigner = false,
 }: DocumentInviteEmailTemplateProps) => {
   const action = RECIPIENT_ROLES_DESCRIPTION[role].actionVerb.toLowerCase();
-  const headerContent = selfSigner ? (
-    <>
-      {`Please ${action} your document`}
-      <br />
-      {`"${documentName}"`}
-    </>
-  ) : (
-    <>
-      {`${inviterName} has invited you to ${action}`}
-      <br />
-      {`"${documentName}"`}
-    </>
-  );
 
   const previewText = selfSigner
     ? `Please ${action} your document ${documentName}`
@@ -84,11 +69,13 @@ export const DocumentInviteEmailTemplate = ({
                 />
 
                 <TemplateDocumentInvite
+                  inviterName={inviterName}
+                  inviterEmail={inviterEmail}
                   documentName={documentName}
                   signDocumentLink={signDocumentLink}
                   assetBaseUrl={assetBaseUrl}
                   role={role}
-                  headerContent={headerContent}
+                  selfSigner={selfSigner}
                 />
               </Section>
             </Container>

--- a/packages/lib/server-only/document/resend-document.tsx
+++ b/packages/lib/server-only/document/resend-document.tsx
@@ -88,6 +88,11 @@ export const resendDocument = async ({
       const recipientEmailType = RECIPIENT_ROLE_TO_EMAIL_TYPE[recipient.role];
 
       const { email, name } = recipient;
+      const selfSigner = email === user.email;
+
+      const selfSignerCustomEmail = `You have initiated the document ${`"${document.title}"`} that requires you to ${RECIPIENT_ROLES_DESCRIPTION[
+        recipient.role
+      ].actionVerb.toLowerCase()} it.`;
 
       const customEmailTemplate = {
         'signer.name': name,
@@ -104,11 +109,19 @@ export const resendDocument = async ({
         inviterEmail: user.email,
         assetBaseUrl,
         signDocumentLink,
-        customBody: renderCustomEmailTemplate(customEmail?.message || '', customEmailTemplate),
+        customBody: renderCustomEmailTemplate(
+          selfSigner ? selfSignerCustomEmail : customEmail?.message || '',
+          customEmailTemplate,
+        ),
         role: recipient.role,
+        selfSigner,
       });
 
       const { actionVerb } = RECIPIENT_ROLES_DESCRIPTION[recipient.role];
+
+      const emailSubject = selfSigner
+        ? `Please ${actionVerb.toLowerCase()} your document`
+        : `Please ${actionVerb.toLowerCase()} this document`;
 
       await prisma.$transaction(
         async (tx) => {
@@ -123,7 +136,7 @@ export const resendDocument = async ({
             },
             subject: customEmail?.subject
               ? renderCustomEmailTemplate(customEmail.subject, customEmailTemplate)
-              : `Please ${actionVerb.toLowerCase()} this document`,
+              : emailSubject,
             html: render(template),
             text: render(template, { plainText: true }),
           });

--- a/packages/lib/server-only/document/resend-document.tsx
+++ b/packages/lib/server-only/document/resend-document.tsx
@@ -120,8 +120,8 @@ export const resendDocument = async ({
       const { actionVerb } = RECIPIENT_ROLES_DESCRIPTION[recipient.role];
 
       const emailSubject = selfSigner
-        ? `Please ${actionVerb.toLowerCase()} your document`
-        : `Please ${actionVerb.toLowerCase()} this document`;
+        ? `Reminder: Please ${actionVerb.toLowerCase()} your document`
+        : `Reminder: Please ${actionVerb.toLowerCase()} this document`;
 
       await prisma.$transaction(
         async (tx) => {

--- a/packages/lib/server-only/document/send-document.tsx
+++ b/packages/lib/server-only/document/send-document.tsx
@@ -127,6 +127,11 @@ export const sendDocument = async ({
       const recipientEmailType = RECIPIENT_ROLE_TO_EMAIL_TYPE[recipient.role];
 
       const { email, name } = recipient;
+      const selfSigner = email === user.email;
+
+      const selfSignerCustomEmail = `You have initiated the document ${`"${document.title}"`} that requires you to ${RECIPIENT_ROLES_DESCRIPTION[
+        recipient.role
+      ].actionVerb.toLowerCase()} it.`;
 
       const customEmailTemplate = {
         'signer.name': name,
@@ -143,11 +148,19 @@ export const sendDocument = async ({
         inviterEmail: user.email,
         assetBaseUrl,
         signDocumentLink,
-        customBody: renderCustomEmailTemplate(customEmail?.message || '', customEmailTemplate),
+        customBody: renderCustomEmailTemplate(
+          selfSigner ? selfSignerCustomEmail : customEmail?.message || '',
+          customEmailTemplate,
+        ),
         role: recipient.role,
+        selfSigner,
       });
 
       const { actionVerb } = RECIPIENT_ROLES_DESCRIPTION[recipient.role];
+
+      const emailSubject = selfSigner
+        ? `Please ${actionVerb.toLowerCase()} your document`
+        : `Please ${actionVerb.toLowerCase()} this document`;
 
       await prisma.$transaction(
         async (tx) => {
@@ -162,7 +175,7 @@ export const sendDocument = async ({
             },
             subject: customEmail?.subject
               ? renderCustomEmailTemplate(customEmail.subject, customEmailTemplate)
-              : `Please ${actionVerb.toLowerCase()} this document`,
+              : emailSubject,
             html: render(template),
             text: render(template, { plainText: true }),
           });


### PR DESCRIPTION
## Description

Updated the email content based on whether the document owner is a recipient or not.

If the document owner is a recipient (self-signer):
* the email subject will be `Please view/sign/approve your document`
* the email header will be `Please view/sign/approve your document "<your-doc-title>"`
* the email content will be `You have initiated the document "<your-doc-title>" that requires you to view/sign/approve it.`

Otherwise:
* the email subject will be `Please view/sign/approve this document`
* the email header will be `<doc-owner> has invited you to view/sign/approve "<doc-title>"`
* the email content will be `<doc-owner> has invited you to view/sign/approve the document "<doc-title>".`


## Related Issue

Related to #1091 

## Testing Performed

Tested the feature with a different number of recipients (including and excluding the document owner - self-signer). Tested both the sending and resending functionality.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## UI Screenshots

![CleanShot 2024-04-18 at 12 26 11@2x](https://github.com/documenso/documenso/assets/25515812/ca80f625-befb-4cbc-a541-f2186379d2e8)
![CleanShot 2024-04-18 at 12 27 40@2x](https://github.com/documenso/documenso/assets/25515812/8bcbb6fc-ba98-4fa1-8538-2d062febd27b)
![CleanShot 2024-04-18 at 12 27 53@2x](https://github.com/documenso/documenso/assets/25515812/25d77d98-b5ec-4270-8ffa-43774fe70526)
![CleanShot 2024-04-18 at 12 30 00@2x](https://github.com/documenso/documenso/assets/25515812/a90bb8e3-3ea8-42ff-9971-559b3e81ae6f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the document invitation components to support scenarios where the recipient is also the sender, providing customized email content and subject lines.
	- Introduced new properties in email templates to improve clarity and relevance based on the user's role in the document signing process.

- **Refactor**
	- Updated components to use a more flexible `headerContent` property for displaying invitation headers, replacing previous individual inviter details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->