### PR TITLE
fix: refactor use template

### DIFF
--- a/apps/web/src/app/(dashboard)/templates/use-template-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/templates/use-template-dialog.tsx
@@ -98,8 +98,8 @@ export function UseTemplateDialog({
       sendDocument: false,
       recipients: recipients.map((recipient) => ({
         id: recipient.id,
-        name: recipient.name,
-        email: recipient.email,
+        name: '',
+        email: '',
       })),
     },
   });
@@ -156,15 +156,16 @@ export function UseTemplateDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Create document from template</DialogTitle>
-          <DialogDescription>Add the recipients to create the document with</DialogDescription>
+          <DialogDescription>
+            {recipients.length === 0
+              ? 'A draft document will be created'
+              : 'Add the recipients to create the document with'}
+          </DialogDescription>
         </DialogHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)}>
-            <fieldset
-              className="flex h-full flex-col space-y-4"
-              disabled={form.formState.isSubmitting}
-            >
+            <fieldset className="flex h-full flex-col" disabled={form.formState.isSubmitting}>
               <div className="custom-scrollbar -m-1 max-h-[60vh] space-y-4 overflow-y-auto p-1">
                 {formRecipients.map((recipient, index) => (
                   <div className="flex w-full flex-row space-x-4" key={recipient.id}>
@@ -201,46 +202,48 @@ export function UseTemplateDialog({
                 ))}
               </div>
 
-              <div className="mt-4 flex flex-row items-center">
-                <FormField
-                  control={form.control}
-                  name="sendDocument"
-                  render={({ field }) => (
-                    <FormItem>
-                      <div className="flex flex-row items-center">
-                        <Checkbox
-                          id="sendDocument"
-                          className="h-5 w-5"
-                          checkClassName="dark:text-white text-primary"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
+              {recipients.length > 0 && (
+                <div className="mt-4 flex flex-row items-center">
+                  <FormField
+                    control={form.control}
+                    name="sendDocument"
+                    render={({ field }) => (
+                      <FormItem>
+                        <div className="flex flex-row items-center">
+                          <Checkbox
+                            id="sendDocument"
+                            className="h-5 w-5"
+                            checkClassName="dark:text-white text-primary"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
 
-                        <label
-                          className="text-muted-foreground ml-2 flex items-center text-sm"
-                          htmlFor="sendDocument"
-                        >
-                          Send document
-                          <Tooltip>
-                            <TooltipTrigger type="button">
-                              <InfoIcon className="mx-1 h-4 w-4" />
-                            </TooltipTrigger>
+                          <label
+                            className="text-muted-foreground ml-2 flex items-center text-sm"
+                            htmlFor="sendDocument"
+                          >
+                            Send document
+                            <Tooltip>
+                              <TooltipTrigger type="button">
+                                <InfoIcon className="mx-1 h-4 w-4" />
+                              </TooltipTrigger>
 
-                            <TooltipContent className="text-muted-foreground z-[99999] max-w-md space-y-2 p-4">
-                              <p>
-                                The document will be immediately sent to recipients if this is
-                                checked.
-                              </p>
+                              <TooltipContent className="text-muted-foreground z-[99999] max-w-md space-y-2 p-4">
+                                <p>
+                                  The document will be immediately sent to recipients if this is
+                                  checked.
+                                </p>
 
-                              <p>Otherwise, the document will be created as a draft.</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </label>
-                      </div>
-                    </FormItem>
-                  )}
-                />
-              </div>
+                                <p>Otherwise, the document will be created as a draft.</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </label>
+                        </div>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              )}
 
               <DialogFooter>
                 <DialogClose asChild>
@@ -250,7 +253,11 @@ export function UseTemplateDialog({
                 </DialogClose>
 
                 <Button type="submit" loading={form.formState.isSubmitting}>
-                  {form.getValues('sendDocument') ? 'Send' : 'Review'}
+                  {recipients.length === 0
+                    ? 'Create'
+                    : form.getValues('sendDocument')
+                    ? 'Send'
+                    : 'Review'}
                 </Button>
               </DialogFooter>
             </fieldset>

--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -100,13 +100,21 @@ export type TCreateDocumentMutationResponseSchema = z.infer<
 
 export const ZCreateDocumentFromTemplateMutationSchema = z.object({
   title: z.string().min(1),
-  recipients: z.array(
-    z.object({
-      name: z.string().min(1),
-      email: z.string().email().min(1),
-      role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
-    }),
-  ),
+  recipients: z.union([
+    z.array(
+      z.object({
+        id: z.number(),
+        name: z.string().min(1),
+        email: z.string().email().min(1),
+      }),
+    ),
+    z.array(
+      z.object({
+        name: z.string().min(1),
+        email: z.string().email().min(1),
+      }),
+    ),
+  ]),
   meta: z
     .object({
       subject: z.string(),

--- a/packages/app-tests/e2e/templates/manage-templates.spec.ts
+++ b/packages/app-tests/e2e/templates/manage-templates.spec.ts
@@ -196,7 +196,7 @@ test('[TEMPLATES]: use template', async ({ page }) => {
   await page.getByPlaceholder('Recipient 1').click();
   await page.getByPlaceholder('Recipient 1').fill('name');
 
-  await page.getByRole('button', { name: 'Review' }).click();
+  await page.getByRole('button', { name: 'Create as draft' }).click();
   await page.waitForURL(/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
   await page.waitForURL('/documents');
@@ -214,7 +214,7 @@ test('[TEMPLATES]: use template', async ({ page }) => {
   await page.getByPlaceholder('Recipient 1').click();
   await page.getByPlaceholder('Recipient 1').fill('name');
 
-  await page.getByRole('button', { name: 'Review' }).click();
+  await page.getByRole('button', { name: 'Create as draft' }).click();
   await page.waitForURL(/\/t\/.+\/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
   await page.waitForURL(`/t/${team.url}/documents`);

--- a/packages/app-tests/e2e/templates/manage-templates.spec.ts
+++ b/packages/app-tests/e2e/templates/manage-templates.spec.ts
@@ -189,6 +189,13 @@ test('[TEMPLATES]: use template', async ({ page }) => {
 
   // Use personal template.
   await page.getByRole('button', { name: 'Use Template' }).click();
+
+  // Enter template values.
+  await page.getByPlaceholder('recipient.1@documenso.com').click();
+  await page.getByPlaceholder('recipient.1@documenso.com').fill(teamMemberUser.email);
+  await page.getByPlaceholder('Recipient 1').click();
+  await page.getByPlaceholder('Recipient 1').fill('name');
+
   await page.getByRole('button', { name: 'Review' }).click();
   await page.waitForURL(/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
@@ -200,6 +207,13 @@ test('[TEMPLATES]: use template', async ({ page }) => {
 
   // Use team template.
   await page.getByRole('button', { name: 'Use Template' }).click();
+
+  // Enter template values.
+  await page.getByPlaceholder('recipient.1@documenso.com').click();
+  await page.getByPlaceholder('recipient.1@documenso.com').fill(teamMemberUser.email);
+  await page.getByPlaceholder('Recipient 1').click();
+  await page.getByPlaceholder('Recipient 1').fill('name');
+
   await page.getByRole('button', { name: 'Review' }).click();
   await page.waitForURL(/\/t\/.+\/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();

--- a/packages/app-tests/e2e/templates/manage-templates.spec.ts
+++ b/packages/app-tests/e2e/templates/manage-templates.spec.ts
@@ -189,7 +189,7 @@ test('[TEMPLATES]: use template', async ({ page }) => {
 
   // Use personal template.
   await page.getByRole('button', { name: 'Use Template' }).click();
-  await page.getByRole('button', { name: 'Create Document' }).click();
+  await page.getByRole('button', { name: 'Review' }).click();
   await page.waitForURL(/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
   await page.waitForURL('/documents');
@@ -200,7 +200,7 @@ test('[TEMPLATES]: use template', async ({ page }) => {
 
   // Use team template.
   await page.getByRole('button', { name: 'Use Template' }).click();
-  await page.getByRole('button', { name: 'Create Document' }).click();
+  await page.getByRole('button', { name: 'Review' }).click();
   await page.waitForURL(/\/t\/.+\/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
   await page.waitForURL(`/t/${team.url}/documents`);

--- a/packages/lib/constants/template.ts
+++ b/packages/lib/constants/template.ts
@@ -1,0 +1,1 @@
+export const TEMPLATE_RECIPIENT_PLACEHOLDER_REGEX = /recipient\.\d+@documenso\.com/i;

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -1,15 +1,14 @@
 import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
-import type { RecipientRole } from '@documenso/prisma/client';
 
 export type CreateDocumentFromTemplateOptions = {
   templateId: number;
   userId: number;
   teamId?: number;
-  recipients?: {
+  recipients: {
+    id: number;
     name?: string;
     email: string;
-    role?: RecipientRole;
   }[];
 };
 
@@ -49,6 +48,20 @@ export const createDocumentFromTemplate = async ({
     throw new Error('Template not found.');
   }
 
+  const finalRecipients = template.Recipient.map((templateRecipient) => {
+    const foundRecipient = recipients.find((recipient) => recipient.id === templateRecipient.id);
+
+    if (!foundRecipient) {
+      throw new Error('Recipient not found.');
+    }
+
+    return {
+      name: foundRecipient.name,
+      email: foundRecipient.email,
+      role: templateRecipient.role,
+    };
+  });
+
   const documentData = await prisma.documentData.create({
     data: {
       type: template.templateDocumentData.type,
@@ -57,81 +70,55 @@ export const createDocumentFromTemplate = async ({
     },
   });
 
-  const document = await prisma.document.create({
-    data: {
-      userId,
-      teamId: template.teamId,
-      title: template.title,
-      documentDataId: documentData.id,
-      Recipient: {
-        create: template.Recipient.map((recipient) => ({
-          email: recipient.email,
-          name: recipient.name,
-          role: recipient.role,
-          token: nanoid(),
-        })),
-      },
-    },
-
-    include: {
-      Recipient: {
-        orderBy: {
-          id: 'asc',
-        },
-      },
-      documentData: true,
-    },
-  });
-
-  await prisma.field.createMany({
-    data: template.Field.map((field) => {
-      const recipient = template.Recipient.find((recipient) => recipient.id === field.recipientId);
-
-      const documentRecipient = document.Recipient.find((doc) => doc.email === recipient?.email);
-
-      return {
-        type: field.type,
-        page: field.page,
-        positionX: field.positionX,
-        positionY: field.positionY,
-        width: field.width,
-        height: field.height,
-        customText: field.customText,
-        inserted: field.inserted,
-        documentId: document.id,
-        recipientId: documentRecipient?.id || null,
-      };
-    }),
-  });
-
-  if (recipients && recipients.length > 0) {
-    document.Recipient = await Promise.all(
-      recipients.map(async (recipient, index) => {
-        const existingRecipient = document.Recipient.at(index);
-
-        return await prisma.recipient.upsert({
-          where: {
-            documentId_email: {
-              documentId: document.id,
-              email: existingRecipient?.email ?? recipient.email,
-            },
-          },
-          update: {
-            name: recipient.name,
-            email: recipient.email,
-            role: recipient.role,
-          },
-          create: {
-            documentId: document.id,
+  return await prisma.$transaction(async (tx) => {
+    const document = await tx.document.create({
+      data: {
+        userId,
+        teamId: template.teamId,
+        title: template.title,
+        documentDataId: documentData.id,
+        Recipient: {
+          create: finalRecipients.map((recipient) => ({
             email: recipient.email,
             name: recipient.name,
             role: recipient.role,
             token: nanoid(),
+          })),
+        },
+      },
+      include: {
+        Recipient: {
+          orderBy: {
+            id: 'asc',
           },
-        });
-      }),
-    );
-  }
+        },
+        documentData: true,
+      },
+    });
 
-  return document;
+    await tx.field.createMany({
+      data: template.Field.map((field) => {
+        const recipient = template.Recipient.find(
+          (recipient) => recipient.id === field.recipientId,
+        );
+
+        const documentRecipient = document.Recipient.find((doc) => doc.email === recipient?.email);
+
+        return {
+          type: field.type,
+          page: field.page,
+          positionX: field.positionX,
+          positionY: field.positionY,
+          width: field.width,
+          height: field.height,
+          customText: field.customText,
+          inserted: field.inserted,
+          documentId: document.id,
+          recipientId: documentRecipient?.id || null,
+        };
+      }),
+    });
+
+    return document;
+  });
 };

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -47,7 +47,11 @@ export const createDocumentFromTemplate = async ({
     },
     include: {
       Recipient: true,
-      Field: true,
+      Field: {
+        include: {
+          Recipient: true,
+        },
+      },
       templateDocumentData: true,
     },
   });
@@ -125,11 +129,9 @@ export const createDocumentFromTemplate = async ({
 
     await tx.field.createMany({
       data: template.Field.map((field) => {
-        const recipient = template.Recipient.find(
-          (recipient) => recipient.id === field.recipientId,
+        const documentRecipient = document.Recipient.find(
+          (recipient) => recipient.email === field.Recipient.email,
         );
-
-        const documentRecipient = document.Recipient.find((doc) => doc.email === recipient?.email);
 
         if (!documentRecipient) {
           throw new Error('Recipient not found.');

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -1,11 +1,22 @@
 import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
-import type { Recipient } from '@documenso/prisma/client';
+import type { Field } from '@documenso/prisma/client';
+import { type Recipient, WebhookTriggerEvents } from '@documenso/prisma/client';
+
+import { DOCUMENT_AUDIT_LOG_TYPE } from '../../types/document-audit-logs';
+import type { RequestMetadata } from '../../universal/extract-request-metadata';
+import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
+import { triggerWebhook } from '../webhooks/trigger/trigger-webhook';
 
 type RecipientWithId = {
   id: number;
   name?: string;
   email: string;
+};
+
+type FinalRecipient = Pick<Recipient, 'name' | 'email' | 'role'> & {
+  templateRecipientId: number;
+  fields: Field[];
 };
 
 export type CreateDocumentFromTemplateOptions = {
@@ -18,6 +29,7 @@ export type CreateDocumentFromTemplateOptions = {
         name?: string;
         email: string;
       }[];
+  requestMetadata?: RequestMetadata;
 };
 
 export const createDocumentFromTemplate = async ({
@@ -25,7 +37,14 @@ export const createDocumentFromTemplate = async ({
   userId,
   teamId,
   recipients,
+  requestMetadata,
 }: CreateDocumentFromTemplateOptions) => {
+  const user = await prisma.user.findFirstOrThrow({
+    where: {
+      id: userId,
+    },
+  });
+
   const template = await prisma.template.findUnique({
     where: {
       id: templateId,
@@ -46,10 +65,9 @@ export const createDocumentFromTemplate = async ({
           }),
     },
     include: {
-      Recipient: true,
-      Field: {
+      Recipient: {
         include: {
-          Recipient: true,
+          Field: true,
         },
       },
       templateDocumentData: true,
@@ -64,7 +82,7 @@ export const createDocumentFromTemplate = async ({
     throw new Error('Invalid number of recipients.');
   }
 
-  let finalRecipients: Pick<Recipient, 'name' | 'email' | 'role'>[] = [];
+  let finalRecipients: FinalRecipient[] = [];
 
   if (recipients.length > 0 && Object.prototype.hasOwnProperty.call(recipients[0], 'id')) {
     finalRecipients = template.Recipient.map((templateRecipient) => {
@@ -78,6 +96,8 @@ export const createDocumentFromTemplate = async ({
       }
 
       return {
+        templateRecipientId: templateRecipient.id,
+        fields: templateRecipient.Field,
         name: foundRecipient.name ?? '',
         email: foundRecipient.email,
         role: templateRecipient.role,
@@ -87,6 +107,8 @@ export const createDocumentFromTemplate = async ({
     // Backwards compatible logic for /v1/ API where we use the index to associate
     // the provided recipient with the template recipient.
     finalRecipients = recipients.map((recipient, index) => ({
+      templateRecipientId: template.Recipient[index].id,
+      fields: template.Recipient[index].Field,
       name: recipient.name ?? '',
       email: recipient.email,
       role: template.Recipient[index].role,
@@ -109,12 +131,14 @@ export const createDocumentFromTemplate = async ({
         title: template.title,
         documentDataId: documentData.id,
         Recipient: {
-          create: finalRecipients.map((recipient) => ({
-            email: recipient.email,
-            name: recipient.name,
-            role: recipient.role,
-            token: nanoid(),
-          })),
+          createMany: {
+            data: finalRecipients.map((recipient) => ({
+              email: recipient.email,
+              name: recipient.name,
+              role: recipient.role,
+              token: nanoid(),
+            })),
+          },
         },
       },
       include: {
@@ -127,29 +151,52 @@ export const createDocumentFromTemplate = async ({
       },
     });
 
-    await tx.field.createMany({
-      data: template.Field.map((field) => {
-        const documentRecipient = document.Recipient.find(
-          (recipient) => recipient.email === field.Recipient.email,
-        );
+    let fieldsToCreate: Omit<Field, 'id' | 'secondaryId' | 'templateId'>[] = [];
 
-        if (!documentRecipient) {
-          throw new Error('Recipient not found.');
-        }
+    Object.values(finalRecipients).forEach(({ email, fields }) => {
+      const recipient = document.Recipient.find((recipient) => recipient.email === email);
 
-        return {
+      if (!recipient) {
+        throw new Error('Recipient not found.');
+      }
+
+      fieldsToCreate = fieldsToCreate.concat(
+        fields.map((field) => ({
+          documentId: document.id,
+          recipientId: recipient.id,
           type: field.type,
           page: field.page,
           positionX: field.positionX,
           positionY: field.positionY,
           width: field.width,
           height: field.height,
-          customText: field.customText,
-          inserted: field.inserted,
-          documentId: document.id,
-          recipientId: documentRecipient.id,
-        };
+          customText: '',
+          inserted: false,
+        })),
+      );
+    });
+
+    await tx.field.createMany({
+      data: fieldsToCreate,
+    });
+
+    await tx.documentAuditLog.create({
+      data: createDocumentAuditLogData({
+        type: DOCUMENT_AUDIT_LOG_TYPE.DOCUMENT_CREATED,
+        documentId: document.id,
+        user,
+        requestMetadata,
+        data: {
+          title: document.title,
+        },
       }),
+    });
+
+    await triggerWebhook({
+      event: WebhookTriggerEvents.DOCUMENT_CREATED,
+      data: document,
+      userId,
+      teamId,
     });
 
     return document;

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -1,15 +1,23 @@
 import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
+import type { Recipient } from '@documenso/prisma/client';
+
+type RecipientWithId = {
+  id: number;
+  name?: string;
+  email: string;
+};
 
 export type CreateDocumentFromTemplateOptions = {
   templateId: number;
   userId: number;
   teamId?: number;
-  recipients: {
-    id: number;
-    name?: string;
-    email: string;
-  }[];
+  recipients:
+    | RecipientWithId[]
+    | {
+        name?: string;
+        email: string;
+      }[];
 };
 
 export const createDocumentFromTemplate = async ({
@@ -48,19 +56,38 @@ export const createDocumentFromTemplate = async ({
     throw new Error('Template not found.');
   }
 
-  const finalRecipients = template.Recipient.map((templateRecipient) => {
-    const foundRecipient = recipients.find((recipient) => recipient.id === templateRecipient.id);
+  if (recipients.length === 0 || recipients.length !== template.Recipient.length) {
+    throw new Error('Invalid number of recipients.');
+  }
 
-    if (!foundRecipient) {
-      throw new Error('Recipient not found.');
-    }
+  let finalRecipients: Pick<Recipient, 'name' | 'email' | 'role'>[] = [];
 
-    return {
-      name: foundRecipient.name,
-      email: foundRecipient.email,
-      role: templateRecipient.role,
-    };
-  });
+  if (Object.prototype.hasOwnProperty.call(recipients[0], 'id')) {
+    finalRecipients = template.Recipient.map((templateRecipient) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const foundRecipient = (recipients as RecipientWithId[]).find(
+        (recipient) => recipient.id === templateRecipient.id,
+      );
+
+      if (!foundRecipient) {
+        throw new Error('Recipient not found.');
+      }
+
+      return {
+        name: foundRecipient.name ?? '',
+        email: foundRecipient.email,
+        role: templateRecipient.role,
+      };
+    });
+  } else {
+    // Backwards compatible logic for /v1/ API where we use the index to associate
+    // the provided recipient with the template recipient.
+    finalRecipients = recipients.map((recipient, index) => ({
+      name: recipient.name ?? '',
+      email: recipient.email,
+      role: template.Recipient[index].role,
+    }));
+  }
 
   const documentData = await prisma.documentData.create({
     data: {

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -56,13 +56,13 @@ export const createDocumentFromTemplate = async ({
     throw new Error('Template not found.');
   }
 
-  if (recipients.length === 0 || recipients.length !== template.Recipient.length) {
+  if (recipients.length !== template.Recipient.length) {
     throw new Error('Invalid number of recipients.');
   }
 
   let finalRecipients: Pick<Recipient, 'name' | 'email' | 'role'>[] = [];
 
-  if (Object.prototype.hasOwnProperty.call(recipients[0], 'id')) {
+  if (recipients.length > 0 && Object.prototype.hasOwnProperty.call(recipients[0], 'id')) {
     finalRecipients = template.Recipient.map((templateRecipient) => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const foundRecipient = (recipients as RecipientWithId[]).find(

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -66,7 +66,9 @@ export const templateRouter = router({
             userId: ctx.user.id,
             teamId,
             requestMetadata: extractNextApiRequestMetadata(ctx.req),
-          }).catch(() => {
+          }).catch((err) => {
+            console.error(err);
+
             throw new AppError('DOCUMENT_SEND_FAILED');
           });
         }

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -1,10 +1,14 @@
 import { TRPCError } from '@trpc/server';
 
 import { getServerLimits } from '@documenso/ee/server-only/limits/server';
+import { AppError } from '@documenso/lib/errors/app-error';
+import { sendDocument } from '@documenso/lib/server-only/document/send-document';
 import { createDocumentFromTemplate } from '@documenso/lib/server-only/template/create-document-from-template';
 import { createTemplate } from '@documenso/lib/server-only/template/create-template';
 import { deleteTemplate } from '@documenso/lib/server-only/template/delete-template';
 import { duplicateTemplate } from '@documenso/lib/server-only/template/duplicate-template';
+import { extractNextApiRequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
+import type { Document } from '@documenso/prisma/client';
 
 import { authenticatedProcedure, router } from '../trpc';
 import {
@@ -49,19 +53,29 @@ export const templateRouter = router({
           throw new Error('You have reached your document limit.');
         }
 
-        return await createDocumentFromTemplate({
+        let document: Document = await createDocumentFromTemplate({
           templateId,
           teamId,
           userId: ctx.user.id,
           recipients: input.recipients,
         });
+
+        if (input.sendDocument) {
+          document = await sendDocument({
+            documentId: document.id,
+            userId: ctx.user.id,
+            teamId,
+            requestMetadata: extractNextApiRequestMetadata(ctx.req),
+          }).catch(() => {
+            throw new AppError('DOCUMENT_SEND_FAILED');
+          });
+        }
+
+        return document;
       } catch (err) {
         console.error(err);
 
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'We were unable to create this document. Please try again later.',
-        });
+        throw AppError.parseErrorToTRPCError(err);
       }
     }),
 

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -53,11 +53,14 @@ export const templateRouter = router({
           throw new Error('You have reached your document limit.');
         }
 
+        const requestMetadata = extractNextApiRequestMetadata(ctx.req);
+
         let document: Document = await createDocumentFromTemplate({
           templateId,
           teamId,
           userId: ctx.user.id,
           recipients: input.recipients,
+          requestMetadata,
         });
 
         if (input.sendDocument) {
@@ -65,7 +68,7 @@ export const templateRouter = router({
             documentId: document.id,
             userId: ctx.user.id,
             teamId,
-            requestMetadata: extractNextApiRequestMetadata(ctx.req),
+            requestMetadata,
           }).catch((err) => {
             console.error(err);
 

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import { RecipientRole } from '@documenso/prisma/client';
-
 export const ZCreateTemplateMutationSchema = z.object({
   title: z.string().min(1).trim(),
   teamId: z.number().optional(),
@@ -11,15 +9,13 @@ export const ZCreateTemplateMutationSchema = z.object({
 export const ZCreateDocumentFromTemplateMutationSchema = z.object({
   templateId: z.number(),
   teamId: z.number().optional(),
-  recipients: z
-    .array(
-      z.object({
-        email: z.string().email(),
-        name: z.string(),
-        role: z.nativeEnum(RecipientRole),
-      }),
-    )
-    .optional(),
+  recipients: z.array(
+    z.object({
+      id: z.number(),
+      email: z.string().email(),
+      name: z.string().optional(),
+    }),
+  ),
 });
 
 export const ZDuplicateTemplateMutationSchema = z.object({

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -16,6 +16,7 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
       name: z.string().optional(),
     }),
   ),
+  sendDocument: z.boolean().optional(),
 });
 
 export const ZDuplicateTemplateMutationSchema = z.object({

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
@@ -103,6 +103,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
     appendSigner({
       formId: nanoid(12),
       name: `Recipient ${placeholderRecipientCount}`,
+      // Update TEMPLATE_RECIPIENT_PLACEHOLDER_REGEX if this is ever changed.
       email: `recipient.${placeholderRecipientCount}@documenso.com`,
       role: RecipientRole.SIGNER,
     });


### PR DESCRIPTION
## Description

Refactor the "use template" flow

These changes include backwards compatible logic for `/api/v1` which makes it a bit messy.

## Changes Made

- Add placeholders for recipients
- Add audit log when document is created
- Trigger DOCUMENT_CREATED webhook when document is created
- Remove role field when using template
- Remove flaky logic when associating template recipients with form recipients
- Refactor to use `Form` 

### Using template when document has no recipients

<img width="529" alt="image" src="https://github.com/documenso/documenso/assets/20962767/a8494ac9-0397-4e3b-a0cf-818c8454a55c">

### Using template with recipients 

<img width="529" alt="image" src="https://github.com/documenso/documenso/assets/20962767/54d949fc-ed6a-4318-bfd6-6a3179896ba9">

### Using template with the send option selected

<img width="529" alt="image" src="https://github.com/documenso/documenso/assets/20962767/541b2664-0540-43e9-83dd-e040a45a44ea">
