### PR TITLE
fix: hide team webhooks from users

### DIFF
--- a/packages/lib/server-only/webhooks/get-webhooks-by-user-id.ts
+++ b/packages/lib/server-only/webhooks/get-webhooks-by-user-id.ts
@@ -4,6 +4,7 @@ export const getWebhooksByUserId = async (userId: number) => {
   return await prisma.webhook.findMany({
     where: {
       userId,
+      teamId: null,
     },
     orderBy: {
       createdAt: 'desc',


### PR DESCRIPTION
## Description

Currently if you create a team webhook, you can see it in your personal webhooks.

However, interacting with them will throw errors because there is server side logic preventing any interaction with them since they are outside of the correct context.

So the solution is to either:
- Allow the user to edit the team webhooks that they created on their personal webhooks page
- Hide team webhooks for personal webhooks pages

This PR goes with the second option, but is open to suggestions.