### PR TITLE
fix: delete pending documents

### DIFF
--- a/packages/lib/server-only/document/delete-document.ts
+++ b/packages/lib/server-only/document/delete-document.ts
@@ -75,7 +75,7 @@ export const deleteDocument = async ({
   }
 
   // Continue to hide the document from the user if they are a recipient.
-  if (userRecipient?.documentDeletedAt === null) {
+  if (userRecipient?.documentDeletedAt === null && document.status === DocumentStatus.COMPLETED) {
     await prisma.recipient.update({
       where: {
         documentId_email: {

--- a/packages/lib/server-only/document/delete-document.ts
+++ b/packages/lib/server-only/document/delete-document.ts
@@ -75,18 +75,20 @@ export const deleteDocument = async ({
   }
 
   // Continue to hide the document from the user if they are a recipient.
-  if (userRecipient?.documentDeletedAt === null && document.status === DocumentStatus.COMPLETED) {
-    await prisma.recipient.update({
-      where: {
-        documentId_email: {
-          documentId: document.id,
-          email: user.email,
+  // Dirty way of doing this but it's faster than refetching the document.
+  if (userRecipient?.documentDeletedAt === null) {
+    await prisma.recipient
+      .update({
+        where: {
+          id: userRecipient.id,
         },
-      },
-      data: {
-        documentDeletedAt: new Date().toISOString(),
-      },
-    });
+        data: {
+          documentDeletedAt: new Date().toISOString(),
+        },
+      })
+      .catch(() => {
+        // Do nothing.
+      });
   }
 
   // Return partial document for API v1 response.


### PR DESCRIPTION
## Description

Currently deleting a pending document where you are a recipient off will delete the document, but will also throw an error.

This is due to the recipient being updated after the document deleted, which is only supposed to happen for completed documents.

_Preference is to not merge until playwright is resolved since there's a lot of document deleting E2E tests._

