### PR TITLE
fix: increase trpc max duration

### DIFF
--- a/apps/web/src/pages/api/trpc/[trpc].ts
+++ b/apps/web/src/pages/api/trpc/[trpc].ts
@@ -3,7 +3,7 @@ import { createTrpcContext } from '@documenso/trpc/server/context';
 import { appRouter } from '@documenso/trpc/server/router';
 
 export const config = {
-  maxDuration: 60,
+  maxDuration: 90,
   api: {
     bodyParser: {
       sizeLimit: '50mb',

--- a/apps/web/src/pages/api/trpc/[trpc].ts
+++ b/apps/web/src/pages/api/trpc/[trpc].ts
@@ -3,7 +3,7 @@ import { createTrpcContext } from '@documenso/trpc/server/context';
 import { appRouter } from '@documenso/trpc/server/router';
 
 export const config = {
-  maxDuration: 90,
+  maxDuration: 120,
   api: {
     bodyParser: {
       sizeLimit: '50mb',


### PR DESCRIPTION
## Description

Increase the max duration of the TRPC API endpoint to 120 seconds.
