### PR TITLE
fix: enforce users to have stripe account

### DIFF
--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import NextAuth from 'next-auth';
 
+import { getStripeCustomerByUser } from '@documenso/ee/server-only/stripe/get-customer';
+import { IS_BILLING_ENABLED } from '@documenso/lib/constants/app';
 import { NEXT_AUTH_OPTIONS } from '@documenso/lib/next-auth/auth-options';
 import { extractNextApiRequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
 import { prisma } from '@documenso/prisma';
@@ -18,15 +20,27 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
       error: '/signin',
     },
     events: {
-      signIn: async ({ user }) => {
-        await prisma.userSecurityAuditLog.create({
-          data: {
-            userId: user.id,
-            ipAddress,
-            userAgent,
-            type: UserSecurityAuditLogType.SIGN_IN,
-          },
-        });
+      signIn: async ({ user: { id: userId } }) => {
+        const [user] = await Promise.all([
+          await prisma.user.findFirstOrThrow({
+            where: {
+              id: userId,
+            },
+          }),
+          await prisma.userSecurityAuditLog.create({
+            data: {
+              userId: userId,
+              ipAddress,
+              userAgent,
+              type: UserSecurityAuditLogType.SIGN_IN,
+            },
+          }),
+        ]);
+
+        // Create the Stripe customer and attach it to the user if it doesn't exist.
+        if (user.customerId === null && IS_BILLING_ENABLED()) {
+          await getStripeCustomerByUser(user);
+        }
       },
       signOut: async ({ token }) => {
         const userId = typeof token.id === 'string' ? parseInt(token.id) : token.id;

--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -29,7 +29,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
           }),
           await prisma.userSecurityAuditLog.create({
             data: {
-              userId: userId,
+              userId,
               ipAddress,
               userAgent,
               type: UserSecurityAuditLogType.SIGN_IN,

--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -39,7 +39,9 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
 
         // Create the Stripe customer and attach it to the user if it doesn't exist.
         if (user.customerId === null && IS_BILLING_ENABLED()) {
-          await getStripeCustomerByUser(user);
+          await getStripeCustomerByUser(user).catch((err) => {
+            console.error(err);
+          });
         }
       },
       signOut: async ({ token }) => {


### PR DESCRIPTION
## Description

Currently users who sign in via Google SSO do not get assigned a Stripe customer account.

This enforces the Stripe customer requirement on sign in.

There might be a better place to put this so it's open to any suggestions.