### PR TITLE
fix: improve sealing process

### DIFF
--- a/packages/lib/server-only/document/complete-document-with-token.ts
+++ b/packages/lib/server-only/document/complete-document-with-token.ts
@@ -152,15 +152,6 @@ export const completeDocumentWithToken = async ({
     await sealDocument({ documentId: document.id, requestMetadata });
   }
 
-  await prisma.document.update({
-    where: {
-      id: document.id,
-    },
-    data: {
-      completedAt: new Date(),
-    },
-  });
-
   const updatedDocument = await getDocument({ token, documentId });
 
   await triggerWebhook({

--- a/packages/lib/server-only/document/seal-document.ts
+++ b/packages/lib/server-only/document/seal-document.ts
@@ -147,6 +147,7 @@ export const sealDocument = async ({
       },
       data: {
         status: DocumentStatus.COMPLETED,
+        completedAt: new Date(),
       },
     });
 

--- a/packages/lib/server-only/document/seal-document.ts
+++ b/packages/lib/server-only/document/seal-document.ts
@@ -40,6 +40,11 @@ export const sealDocument = async ({
   const document = await prisma.document.findFirstOrThrow({
     where: {
       id: documentId,
+      Recipient: {
+        every: {
+          signingStatus: SigningStatus.SIGNED,
+        },
+      },
     },
     include: {
       documentData: true,
@@ -51,10 +56,6 @@ export const sealDocument = async ({
 
   if (!documentData) {
     throw new Error(`Document ${document.id} has no document data`);
-  }
-
-  if (document.status !== DocumentStatus.COMPLETED) {
-    throw new Error(`Document ${document.id} has not been completed`);
   }
 
   const recipients = await prisma.recipient.findMany({
@@ -92,9 +93,9 @@ export const sealDocument = async ({
   // !: Need to write the fields onto the document as a hard copy
   const pdfData = await getFile(documentData);
 
-  const certificate = await getCertificatePdf({ documentId }).then(async (doc) =>
-    PDFDocument.load(doc),
-  );
+  const certificate = await getCertificatePdf({ documentId })
+    .then(async (doc) => PDFDocument.load(doc))
+    .catch(() => null);
 
   const doc = await PDFDocument.load(pdfData);
 
@@ -103,11 +104,13 @@ export const sealDocument = async ({
   doc.getForm().flatten();
   flattenAnnotations(doc);
 
-  const certificatePages = await doc.copyPages(certificate, certificate.getPageIndices());
+  if (certificate) {
+    const certificatePages = await doc.copyPages(certificate, certificate.getPageIndices());
 
-  certificatePages.forEach((page) => {
-    doc.addPage(page);
-  });
+    certificatePages.forEach((page) => {
+      doc.addPage(page);
+    });
+  }
 
   for (const field of fields) {
     await insertFieldInPDF(doc, field);
@@ -138,6 +141,15 @@ export const sealDocument = async ({
   }
 
   await prisma.$transaction(async (tx) => {
+    await tx.document.update({
+      where: {
+        id: document.id,
+      },
+      data: {
+        status: DocumentStatus.COMPLETED,
+      },
+    });
+
     await tx.documentData.update({
       where: {
         id: documentData.id,

--- a/packages/lib/server-only/htmltopdf/get-certificate-pdf.ts
+++ b/packages/lib/server-only/htmltopdf/get-certificate-pdf.ts
@@ -35,6 +35,7 @@ export const getCertificatePdf = async ({ documentId }: GetCertificatePdfOptions
 
   await page.goto(`${NEXT_PUBLIC_WEBAPP_URL()}/__htmltopdf/certificate?d=${encryptedId}`, {
     waitUntil: 'networkidle',
+    timeout: 10_000,
   });
 
   const result = await page.pdf({


### PR DESCRIPTION
## Description

Improves the sealing process by being strict on how long certificate generation can take, opting to fail generation and continue sealing.

Also changes the ordering of sealing so an error in the process won't also cause a document to be "COMPLETED" since it hasn't been cryptographically sealed yet.

The downside to this change is that documents that fail during sealing will require manual intervention as a signer or owner won't be able to *complete* the document.

## Testing Performed

- Modified code to force specific failure modes to occur and verified that documents were either gracefully sealed without a certificate or not sealed and not completed.
