### PR TITLE
feat: add general template enhancements

### DIFF
--- a/apps/web/src/app/(dashboard)/templates/[id]/template-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/templates/[id]/template-page-view.tsx
@@ -58,7 +58,7 @@ export const TemplatePageView = async ({ params, team }: TemplatePageViewProps) 
   ]);
 
   return (
-    <div className="mx-auto max-w-screen-xl px-4 md:px-8">
+    <div className="mx-auto -mt-4 max-w-screen-xl px-4 md:px-8">
       <Link href="/templates" className="flex items-center text-[#7AC455] hover:opacity-80">
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
         Templates

--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -19,7 +19,7 @@ import { getRecipientById } from '@documenso/lib/server-only/recipient/get-recip
 import { getRecipientsForDocument } from '@documenso/lib/server-only/recipient/get-recipients-for-document';
 import { setRecipientsForDocument } from '@documenso/lib/server-only/recipient/set-recipients-for-document';
 import { updateRecipient } from '@documenso/lib/server-only/recipient/update-recipient';
-import { createDocumentFromTemplate } from '@documenso/lib/server-only/template/create-document-from-template';
+import { createDocumentFromTemplateLegacy } from '@documenso/lib/server-only/template/create-document-from-template-legacy';
 import { extractNextApiRequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
 import { getFile } from '@documenso/lib/universal/upload/get-file';
 import { putPdfFile } from '@documenso/lib/universal/upload/put-file';
@@ -286,7 +286,7 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
     const fileName = body.title.endsWith('.pdf') ? body.title : `${body.title}.pdf`;
 
-    const document = await createDocumentFromTemplate({
+    const document = await createDocumentFromTemplateLegacy({
       templateId,
       userId: user.id,
       teamId: team?.id,

--- a/packages/app-tests/e2e/templates/manage-templates.spec.ts
+++ b/packages/app-tests/e2e/templates/manage-templates.spec.ts
@@ -189,7 +189,14 @@ test('[TEMPLATES]: use template', async ({ page }) => {
 
   // Use personal template.
   await page.getByRole('button', { name: 'Use Template' }).click();
-  await page.getByRole('button', { name: 'Create Document' }).click();
+
+  // Enter template values.
+  await page.getByPlaceholder('recipient.1@documenso.com').click();
+  await page.getByPlaceholder('recipient.1@documenso.com').fill(teamMemberUser.email);
+  await page.getByPlaceholder('Recipient 1').click();
+  await page.getByPlaceholder('Recipient 1').fill('name');
+
+  await page.getByRole('button', { name: 'Create as draft' }).click();
   await page.waitForURL(/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
   await page.waitForURL('/documents');
@@ -200,7 +207,14 @@ test('[TEMPLATES]: use template', async ({ page }) => {
 
   // Use team template.
   await page.getByRole('button', { name: 'Use Template' }).click();
-  await page.getByRole('button', { name: 'Create Document' }).click();
+
+  // Enter template values.
+  await page.getByPlaceholder('recipient.1@documenso.com').click();
+  await page.getByPlaceholder('recipient.1@documenso.com').fill(teamMemberUser.email);
+  await page.getByPlaceholder('Recipient 1').click();
+  await page.getByPlaceholder('Recipient 1').fill('name');
+
+  await page.getByRole('button', { name: 'Create as draft' }).click();
   await page.waitForURL(/\/t\/.+\/documents/);
   await page.getByRole('main').getByRole('link', { name: 'Documents' }).click();
   await page.waitForURL(`/t/${team.url}/documents`);

--- a/packages/lib/constants/template.ts
+++ b/packages/lib/constants/template.ts
@@ -1,0 +1,1 @@
+export const TEMPLATE_RECIPIENT_PLACEHOLDER_REGEX = /recipient\.\d+@documenso\.com/i;

--- a/packages/lib/errors/app-error.ts
+++ b/packages/lib/errors/app-error.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server';
+import { match } from 'ts-pattern';
 import { z } from 'zod';
 
 import { TRPCClientError } from '@documenso/trpc/client';
@@ -148,5 +149,25 @@ export class AppError extends Error {
     } catch {
       return null;
     }
+  }
+
+  static toRestAPIError(err: unknown): {
+    status: 400 | 401 | 404 | 500;
+    body: { message: string };
+  } {
+    const error = AppError.parseError(err);
+
+    const status = match(error.code)
+      .with(AppErrorCode.INVALID_BODY, AppErrorCode.INVALID_REQUEST, () => 400 as const)
+      .with(AppErrorCode.UNAUTHORIZED, () => 401 as const)
+      .with(AppErrorCode.NOT_FOUND, () => 404 as const)
+      .otherwise(() => 500 as const);
+
+    return {
+      status,
+      body: {
+        message: status !== 500 ? error.message : 'Something went wrong',
+      },
+    };
   }
 }

--- a/packages/lib/server-only/template/create-document-from-template-legacy.ts
+++ b/packages/lib/server-only/template/create-document-from-template-legacy.ts
@@ -1,0 +1,144 @@
+import { nanoid } from '@documenso/lib/universal/id';
+import { prisma } from '@documenso/prisma';
+import type { RecipientRole } from '@documenso/prisma/client';
+
+export type CreateDocumentFromTemplateLegacyOptions = {
+  templateId: number;
+  userId: number;
+  teamId?: number;
+  recipients?: {
+    name?: string;
+    email: string;
+    role?: RecipientRole;
+  }[];
+};
+
+/**
+ * Legacy server function for /api/v1
+ */
+export const createDocumentFromTemplateLegacy = async ({
+  templateId,
+  userId,
+  teamId,
+  recipients,
+}: CreateDocumentFromTemplateLegacyOptions) => {
+  const template = await prisma.template.findUnique({
+    where: {
+      id: templateId,
+      ...(teamId
+        ? {
+            team: {
+              id: teamId,
+              members: {
+                some: {
+                  userId,
+                },
+              },
+            },
+          }
+        : {
+            userId,
+            teamId: null,
+          }),
+    },
+    include: {
+      Recipient: true,
+      Field: true,
+      templateDocumentData: true,
+    },
+  });
+
+  if (!template) {
+    throw new Error('Template not found.');
+  }
+
+  const documentData = await prisma.documentData.create({
+    data: {
+      type: template.templateDocumentData.type,
+      data: template.templateDocumentData.data,
+      initialData: template.templateDocumentData.initialData,
+    },
+  });
+
+  const document = await prisma.document.create({
+    data: {
+      userId,
+      teamId: template.teamId,
+      title: template.title,
+      documentDataId: documentData.id,
+      Recipient: {
+        create: template.Recipient.map((recipient) => ({
+          email: recipient.email,
+          name: recipient.name,
+          role: recipient.role,
+          token: nanoid(),
+        })),
+      },
+    },
+
+    include: {
+      Recipient: {
+        orderBy: {
+          id: 'asc',
+        },
+      },
+      documentData: true,
+    },
+  });
+
+  await prisma.field.createMany({
+    data: template.Field.map((field) => {
+      const recipient = template.Recipient.find((recipient) => recipient.id === field.recipientId);
+
+      const documentRecipient = document.Recipient.find((doc) => doc.email === recipient?.email);
+
+      if (!documentRecipient) {
+        throw new Error('Recipient not found.');
+      }
+
+      return {
+        type: field.type,
+        page: field.page,
+        positionX: field.positionX,
+        positionY: field.positionY,
+        width: field.width,
+        height: field.height,
+        customText: field.customText,
+        inserted: field.inserted,
+        documentId: document.id,
+        recipientId: documentRecipient.id,
+      };
+    }),
+  });
+
+  if (recipients && recipients.length > 0) {
+    document.Recipient = await Promise.all(
+      recipients.map(async (recipient, index) => {
+        const existingRecipient = document.Recipient.at(index);
+
+        return await prisma.recipient.upsert({
+          where: {
+            documentId_email: {
+              documentId: document.id,
+              email: existingRecipient?.email ?? recipient.email,
+            },
+          },
+          update: {
+            name: recipient.name,
+            email: recipient.email,
+            role: recipient.role,
+          },
+          create: {
+            documentId: document.id,
+            email: recipient.email,
+            name: recipient.name,
+            role: recipient.role,
+            token: nanoid(),
+          },
+        });
+      }),
+    );
+  }
+
+  return document;
+};

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -1,16 +1,29 @@
 import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
-import type { RecipientRole } from '@documenso/prisma/client';
+import type { Field } from '@documenso/prisma/client';
+import { type Recipient, WebhookTriggerEvents } from '@documenso/prisma/client';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import { DOCUMENT_AUDIT_LOG_TYPE } from '../../types/document-audit-logs';
+import type { RequestMetadata } from '../../universal/extract-request-metadata';
+import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
+import { triggerWebhook } from '../webhooks/trigger/trigger-webhook';
+
+type FinalRecipient = Pick<Recipient, 'name' | 'email' | 'role'> & {
+  templateRecipientId: number;
+  fields: Field[];
+};
 
 export type CreateDocumentFromTemplateOptions = {
   templateId: number;
   userId: number;
   teamId?: number;
-  recipients?: {
+  recipients: {
+    id: number;
     name?: string;
     email: string;
-    role?: RecipientRole;
   }[];
+  requestMetadata?: RequestMetadata;
 };
 
 export const createDocumentFromTemplate = async ({
@@ -18,7 +31,14 @@ export const createDocumentFromTemplate = async ({
   userId,
   teamId,
   recipients,
+  requestMetadata,
 }: CreateDocumentFromTemplateOptions) => {
+  const user = await prisma.user.findFirstOrThrow({
+    where: {
+      id: userId,
+    },
+  });
+
   const template = await prisma.template.findUnique({
     where: {
       id: templateId,
@@ -39,15 +59,41 @@ export const createDocumentFromTemplate = async ({
           }),
     },
     include: {
-      Recipient: true,
-      Field: true,
+      Recipient: {
+        include: {
+          Field: true,
+        },
+      },
       templateDocumentData: true,
     },
   });
 
   if (!template) {
-    throw new Error('Template not found.');
+    throw new AppError(AppErrorCode.NOT_FOUND, 'Template not found');
   }
+
+  if (recipients.length !== template.Recipient.length) {
+    throw new AppError(AppErrorCode.INVALID_BODY, 'Invalid number of recipients.');
+  }
+
+  const finalRecipients: FinalRecipient[] = template.Recipient.map((templateRecipient) => {
+    const foundRecipient = recipients.find((recipient) => recipient.id === templateRecipient.id);
+
+    if (!foundRecipient) {
+      throw new AppError(
+        AppErrorCode.INVALID_BODY,
+        `Missing template recipient with ID ${templateRecipient.id}`,
+      );
+    }
+
+    return {
+      templateRecipientId: templateRecipient.id,
+      fields: templateRecipient.Field,
+      name: foundRecipient.name ?? '',
+      email: foundRecipient.email,
+      role: templateRecipient.role,
+    };
+  });
 
   const documentData = await prisma.documentData.create({
     data: {
@@ -57,85 +103,82 @@ export const createDocumentFromTemplate = async ({
     },
   });
 
-  const document = await prisma.document.create({
-    data: {
-      userId,
-      teamId: template.teamId,
-      title: template.title,
-      documentDataId: documentData.id,
-      Recipient: {
-        create: template.Recipient.map((recipient) => ({
-          email: recipient.email,
-          name: recipient.name,
-          role: recipient.role,
-          token: nanoid(),
-        })),
-      },
-    },
-
-    include: {
-      Recipient: {
-        orderBy: {
-          id: 'asc',
+  return await prisma.$transaction(async (tx) => {
+    const document = await tx.document.create({
+      data: {
+        userId,
+        teamId: template.teamId,
+        title: template.title,
+        documentDataId: documentData.id,
+        Recipient: {
+          createMany: {
+            data: finalRecipients.map((recipient) => ({
+              email: recipient.email,
+              name: recipient.name,
+              role: recipient.role,
+              token: nanoid(),
+            })),
+          },
         },
       },
-      documentData: true,
-    },
-  });
+      include: {
+        Recipient: {
+          orderBy: {
+            id: 'asc',
+          },
+        },
+        documentData: true,
+      },
+    });
 
-  await prisma.field.createMany({
-    data: template.Field.map((field) => {
-      const recipient = template.Recipient.find((recipient) => recipient.id === field.recipientId);
+    let fieldsToCreate: Omit<Field, 'id' | 'secondaryId' | 'templateId'>[] = [];
 
-      const documentRecipient = document.Recipient.find((doc) => doc.email === recipient?.email);
+    Object.values(finalRecipients).forEach(({ email, fields }) => {
+      const recipient = document.Recipient.find((recipient) => recipient.email === email);
 
-      if (!documentRecipient) {
+      if (!recipient) {
         throw new Error('Recipient not found.');
       }
 
-      return {
-        type: field.type,
-        page: field.page,
-        positionX: field.positionX,
-        positionY: field.positionY,
-        width: field.width,
-        height: field.height,
-        customText: field.customText,
-        inserted: field.inserted,
+      fieldsToCreate = fieldsToCreate.concat(
+        fields.map((field) => ({
+          documentId: document.id,
+          recipientId: recipient.id,
+          type: field.type,
+          page: field.page,
+          positionX: field.positionX,
+          positionY: field.positionY,
+          width: field.width,
+          height: field.height,
+          customText: '',
+          inserted: false,
+        })),
+      );
+    });
+
+    await tx.field.createMany({
+      data: fieldsToCreate,
+    });
+
+    await tx.documentAuditLog.create({
+      data: createDocumentAuditLogData({
+        type: DOCUMENT_AUDIT_LOG_TYPE.DOCUMENT_CREATED,
         documentId: document.id,
-        recipientId: documentRecipient.id,
-      };
-    }),
-  });
-
-  if (recipients && recipients.length > 0) {
-    document.Recipient = await Promise.all(
-      recipients.map(async (recipient, index) => {
-        const existingRecipient = document.Recipient.at(index);
-
-        return await prisma.recipient.upsert({
-          where: {
-            documentId_email: {
-              documentId: document.id,
-              email: existingRecipient?.email ?? recipient.email,
-            },
-          },
-          update: {
-            name: recipient.name,
-            email: recipient.email,
-            role: recipient.role,
-          },
-          create: {
-            documentId: document.id,
-            email: recipient.email,
-            name: recipient.name,
-            role: recipient.role,
-            token: nanoid(),
-          },
-        });
+        user,
+        requestMetadata,
+        data: {
+          title: document.title,
+        },
       }),
-    );
-  }
+    });
 
-  return document;
+    await triggerWebhook({
+      event: WebhookTriggerEvents.DOCUMENT_CREATED,
+      data: document,
+      userId,
+      teamId,
+    });
+
+    return document;
+  });
 };

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import { RecipientRole } from '@documenso/prisma/client';
-
 export const ZCreateTemplateMutationSchema = z.object({
   title: z.string().min(1).trim(),
   teamId: z.number().optional(),
@@ -14,12 +12,16 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
   recipients: z
     .array(
       z.object({
+        id: z.number(),
         email: z.string().email(),
-        name: z.string(),
-        role: z.nativeEnum(RecipientRole),
+        name: z.string().optional(),
       }),
     )
-    .optional(),
+    .refine((recipients) => {
+      const emails = recipients.map((signer) => signer.email);
+      return new Set(emails).size === emails.length;
+    }, 'Recipients must have unique emails'),
+  sendDocument: z.boolean().optional(),
 });
 
 export const ZDuplicateTemplateMutationSchema = z.object({

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
@@ -103,6 +103,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
     appendSigner({
       formId: nanoid(12),
       name: `Recipient ${placeholderRecipientCount}`,
+      // Update TEMPLATE_RECIPIENT_PLACEHOLDER_REGEX if this is ever changed.
       email: `recipient.${placeholderRecipientCount}@documenso.com`,
       role: RecipientRole.SIGNER,
     });


### PR DESCRIPTION
## Description

Refactor the "use template" flow

## Changes Made

- Add placeholders for recipients
- Add audit log when document is created
- Trigger DOCUMENT_CREATED webhook when document is created
- Remove role field when using template
- Remove flaky logic when associating template recipients with form recipients
- Refactor to use `Form` 

### Using template when document has no recipients

<img width="529" alt="image" src="https://github.com/documenso/documenso/assets/20962767/a8494ac9-0397-4e3b-a0cf-818c8454a55c">

### Using template with recipients 

<img width="529" alt="image" src="https://github.com/documenso/documenso/assets/20962767/54d949fc-ed6a-4318-bfd6-6a3179896ba9">

### Using template with the send option selected

<img width="529" alt="image" src="https://github.com/documenso/documenso/assets/20962767/541b2664-0540-43e9-83dd-e040a45a44ea">
