### PR TITLE
fix: downloaded files should have _signed

### DIFF
--- a/packages/lib/client-only/download-pdf.ts
+++ b/packages/lib/client-only/download-pdf.ts
@@ -18,7 +18,7 @@ export const downloadPDF = async ({ documentData, fileName }: DownloadPDFProps) 
   const baseTitle = (fileName ?? 'document').replace(/\.pdf$/, '');
 
   downloadFile({
-    filename: `${baseTitle}.pdf`,
+    filename: `${baseTitle}_signed.pdf`,
     data: blob,
   });
 };


### PR DESCRIPTION

## Description

Modifies the generated filename for the downloaded PDF by appending "_signed" to the base title.

## Related Issue

N/A

## Changes Made

- Update the filename in the downloadFile function call to append "_signed" to the baseTitle variable.

## Testing Performed

Tested the `downloadPDF` function locally to ensure that the downloaded PDF file has the correct filename with "_signed" appended.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

