### PR TITLE
feat: add template enhancements

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/edit-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/edit-document.tsx
@@ -332,6 +332,7 @@ export const EditDocumentForm = ({
               isDocumentPdfLoaded={isDocumentPdfLoaded}
               onSubmit={onAddSettingsFormSubmit}
             />
+
             <AddSignersFormPartial
               key={recipients.length}
               documentFlow={documentFlow.signers}

--- a/apps/web/src/app/(dashboard)/documents/[id]/edit/document-edit-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/edit/document-edit-page-view.tsx
@@ -36,11 +36,6 @@ export const DocumentEditPageView = async ({ params, team }: DocumentEditPageVie
 
   const { user } = await getRequiredServerComponentSession();
 
-  const isDocumentEnterprise = await isUserEnterprise({
-    userId: user.id,
-    teamId: team?.id,
-  });
-
   const document = await getDocumentWithDetailsById({
     id: documentId,
     userId: user.id,
@@ -73,6 +68,11 @@ export const DocumentEditPageView = async ({ params, team }: DocumentEditPageVie
 
     documentMeta.password = securePassword;
   }
+
+  const isDocumentEnterprise = await isUserEnterprise({
+    userId: user.id,
+    teamId: team?.id,
+  });
 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">

--- a/apps/web/src/app/(dashboard)/templates/[id]/edit-template.tsx
+++ b/apps/web/src/app/(dashboard)/templates/[id]/edit-template.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import type { DocumentData, Field, Recipient, Template, User } from '@documenso/prisma/client';
+import {
+  DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
+  SKIP_QUERY_BATCH_META,
+} from '@documenso/lib/constants/trpc';
+import type { TemplateWithDetails } from '@documenso/prisma/types/template';
 import { trpc } from '@documenso/trpc/react';
 import { cn } from '@documenso/ui/lib/utils';
 import { Card, CardContent } from '@documenso/ui/primitives/card';
@@ -19,52 +23,135 @@ import { AddTemplateFieldsFormPartial } from '@documenso/ui/primitives/template-
 import type { TAddTemplateFieldsFormSchema } from '@documenso/ui/primitives/template-flow/add-template-fields.types';
 import { AddTemplatePlaceholderRecipientsFormPartial } from '@documenso/ui/primitives/template-flow/add-template-placeholder-recipients';
 import type { TAddTemplatePlacholderRecipientsFormSchema } from '@documenso/ui/primitives/template-flow/add-template-placeholder-recipients.types';
+import { AddTemplateSettingsFormPartial } from '@documenso/ui/primitives/template-flow/add-template-settings';
+import type { TAddTemplateSettingsFormSchema } from '@documenso/ui/primitives/template-flow/add-template-settings.types';
 import { useToast } from '@documenso/ui/primitives/use-toast';
+
+import { useOptionalCurrentTeam } from '~/providers/team';
 
 export type EditTemplateFormProps = {
   className?: string;
-  user: User;
-  template: Template;
-  recipients: Recipient[];
-  fields: Field[];
-  documentData: DocumentData;
+  initialTemplate: TemplateWithDetails;
+  isEnterprise: boolean;
   templateRootPath: string;
 };
 
-type EditTemplateStep = 'signers' | 'fields';
-const EditTemplateSteps: EditTemplateStep[] = ['signers', 'fields'];
+type EditTemplateStep = 'settings' | 'signers' | 'fields';
+const EditTemplateSteps: EditTemplateStep[] = ['settings', 'signers', 'fields'];
 
 export const EditTemplateForm = ({
+  initialTemplate,
   className,
-  template,
-  recipients,
-  fields,
-  user: _user,
-  documentData,
+  isEnterprise,
   templateRootPath,
 }: EditTemplateFormProps) => {
   const { toast } = useToast();
   const router = useRouter();
 
-  const [step, setStep] = useState<EditTemplateStep>('signers');
+  const team = useOptionalCurrentTeam();
+
+  const [step, setStep] = useState<EditTemplateStep>('settings');
+
+  const [isDocumentPdfLoaded, setIsDocumentPdfLoaded] = useState(false);
+
+  const utils = trpc.useUtils();
+
+  const { data: template, refetch: refetchTemplate } =
+    trpc.template.getTemplateWithDetailsById.useQuery(
+      {
+        id: initialTemplate.id,
+      },
+      {
+        initialData: initialTemplate,
+        ...SKIP_QUERY_BATCH_META,
+      },
+    );
+
+  const { Recipient: recipients, Field: fields, templateDocumentData } = template;
 
   const documentFlow: Record<EditTemplateStep, DocumentFlowStep> = {
+    settings: {
+      title: 'General',
+      description: 'Configure general settings for the template.',
+      stepIndex: 1,
+    },
     signers: {
       title: 'Add Placeholders',
       description: 'Add all relevant placeholders for each recipient.',
-      stepIndex: 1,
+      stepIndex: 2,
     },
     fields: {
       title: 'Add Fields',
       description: 'Add all relevant fields for each recipient.',
-      stepIndex: 2,
+      stepIndex: 3,
     },
   };
 
   const currentDocumentFlow = documentFlow[step];
 
-  const { mutateAsync: addTemplateFields } = trpc.field.addTemplateFields.useMutation();
-  const { mutateAsync: addTemplateSigners } = trpc.recipient.addTemplateSigners.useMutation();
+  const { mutateAsync: updateTemplateSettings } = trpc.template.updateTemplateSettings.useMutation({
+    ...DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
+    onSuccess: (newData) => {
+      utils.template.getTemplateWithDetailsById.setData(
+        {
+          id: initialTemplate.id,
+        },
+        (oldData) => ({ ...(oldData || initialTemplate), ...newData }),
+      );
+    },
+  });
+
+  const { mutateAsync: addTemplateFields } = trpc.field.addTemplateFields.useMutation({
+    ...DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
+    onSuccess: (newData) => {
+      utils.template.getTemplateWithDetailsById.setData(
+        {
+          id: initialTemplate.id,
+        },
+        (oldData) => ({ ...(oldData || initialTemplate), ...newData }),
+      );
+    },
+  });
+
+  const { mutateAsync: addTemplateSigners } = trpc.recipient.addTemplateSigners.useMutation({
+    ...DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
+    onSuccess: (newData) => {
+      utils.template.getTemplateWithDetailsById.setData(
+        {
+          id: initialTemplate.id,
+        },
+        (oldData) => ({ ...(oldData || initialTemplate), ...newData }),
+      );
+    },
+  });
+
+  const onAddSettingsFormSubmit = async (data: TAddTemplateSettingsFormSchema) => {
+    try {
+      await updateTemplateSettings({
+        templateId: template.id,
+        teamId: team?.id,
+        data: {
+          title: data.title,
+          globalAccessAuth: data.globalAccessAuth ?? null,
+          globalActionAuth: data.globalActionAuth ?? null,
+        },
+        meta: data.meta,
+      });
+
+      // Router refresh is here to clear the router cache for when navigating to /documents.
+      router.refresh();
+
+      setStep('signers');
+    } catch (err) {
+      console.error(err);
+
+      toast({
+        title: 'Error',
+        description: 'An error occurred while updating the document settings.',
+        variant: 'destructive',
+      });
+    }
+  };
 
   const onAddTemplatePlaceholderFormSubmit = async (
     data: TAddTemplatePlacholderRecipientsFormSchema,
@@ -72,9 +159,11 @@ export const EditTemplateForm = ({
     try {
       await addTemplateSigners({
         templateId: template.id,
+        teamId: team?.id,
         signers: data.signers,
       });
 
+      // Router refresh is here to clear the router cache for when navigating to /documents.
       router.refresh();
 
       setStep('fields');
@@ -100,6 +189,9 @@ export const EditTemplateForm = ({
         duration: 5000,
       });
 
+      // Router refresh is here to clear the router cache for when navigating to /documents.
+      router.refresh();
+
       router.push(templateRootPath);
     } catch (err) {
       toast({
@@ -110,6 +202,15 @@ export const EditTemplateForm = ({
     }
   };
 
+  /**
+   * Refresh the data in the background when steps change.
+   */
+  useEffect(() => {
+    void refetchTemplate();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step]);
+
   return (
     <div className={cn('grid w-full grid-cols-12 gap-8', className)}>
       <Card
@@ -117,7 +218,11 @@ export const EditTemplateForm = ({
         gradient
       >
         <CardContent className="p-2">
-          <LazyPDFViewer key={documentData.id} documentData={documentData} />
+          <LazyPDFViewer
+            key={templateDocumentData.id}
+            documentData={templateDocumentData}
+            onDocumentLoad={() => setIsDocumentPdfLoaded(true)}
+          />
         </CardContent>
       </Card>
 
@@ -135,14 +240,25 @@ export const EditTemplateForm = ({
             currentStep={currentDocumentFlow.stepIndex}
             setCurrentStep={(step) => setStep(EditTemplateSteps[step - 1])}
           >
+            <AddTemplateSettingsFormPartial
+              key={recipients.length}
+              template={template}
+              documentFlow={documentFlow.settings}
+              recipients={recipients}
+              fields={fields}
+              onSubmit={onAddSettingsFormSubmit}
+              isEnterprise={isEnterprise}
+              isDocumentPdfLoaded={isDocumentPdfLoaded}
+            />
+
             <AddTemplatePlaceholderRecipientsFormPartial
               key={recipients.length}
               documentFlow={documentFlow.signers}
               recipients={recipients}
               fields={fields}
               onSubmit={onAddTemplatePlaceholderFormSubmit}
-              // Todo: Add when we setup template settings.
-              isTemplateOwnerEnterprise={false}
+              isEnterprise={isEnterprise}
+              isDocumentPdfLoaded={isDocumentPdfLoaded}
             />
 
             <AddTemplateFieldsFormPartial

--- a/apps/web/src/app/(dashboard)/templates/new-template-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/templates/new-template-dialog.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { zodResolver } from '@hookform/resolvers/zod';
-import { FilePlus, X } from 'lucide-react';
+import { FilePlus, Loader } from 'lucide-react';
 import { useSession } from 'next-auth/react';
-import { useForm } from 'react-hook-form';
-import * as z from 'zod';
 
 import { createDocumentData } from '@documenso/lib/server-only/document-data/create-document-data';
-import { base64 } from '@documenso/lib/universal/base64';
 import { putPdfFile } from '@documenso/lib/universal/upload/put-file';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
-import { Card, CardContent } from '@documenso/ui/primitives/card';
 import {
   Dialog,
   DialogClose,
@@ -27,23 +22,7 @@ import {
   DialogTrigger,
 } from '@documenso/ui/primitives/dialog';
 import { DocumentDropzone } from '@documenso/ui/primitives/document-dropzone';
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@documenso/ui/primitives/form/form';
-import { Input } from '@documenso/ui/primitives/input';
 import { useToast } from '@documenso/ui/primitives/use-toast';
-
-const ZCreateTemplateFormSchema = z.object({
-  name: z.string(),
-});
-
-type TCreateTemplateFormSchema = z.infer<typeof ZCreateTemplateFormSchema>;
 
 type NewTemplateDialogProps = {
   teamId?: number;
@@ -56,50 +35,20 @@ export const NewTemplateDialog = ({ teamId, templateRootPath }: NewTemplateDialo
   const { data: session } = useSession();
   const { toast } = useToast();
 
-  const form = useForm<TCreateTemplateFormSchema>({
-    defaultValues: {
-      name: '',
-    },
-    resolver: zodResolver(ZCreateTemplateFormSchema),
-  });
-
   const { mutateAsync: createTemplate } = trpc.template.createTemplate.useMutation();
 
   const [showNewTemplateDialog, setShowNewTemplateDialog] = useState(false);
-  const [uploadedFile, setUploadedFile] = useState<{ file: File; fileBase64: string } | null>();
+  const [isUploadingFile, setIsUploadingFile] = useState(false);
 
   const onFileDrop = async (file: File) => {
-    try {
-      const arrayBuffer = await file.arrayBuffer();
-      const base64String = base64.encode(new Uint8Array(arrayBuffer));
-
-      setUploadedFile({
-        file,
-        fileBase64: `data:application/pdf;base64,${base64String}`,
-      });
-
-      if (!form.getValues('name')) {
-        form.setValue('name', file.name);
-      }
-    } catch {
-      toast({
-        title: 'Something went wrong',
-        description: 'Please try again later.',
-        variant: 'destructive',
-      });
-    }
-  };
-
-  const onSubmit = async (values: TCreateTemplateFormSchema) => {
-    if (!uploadedFile) {
+    if (isUploadingFile) {
       return;
     }
 
-    const file: File = uploadedFile.file;
+    setIsUploadingFile(true);
 
     try {
       const { type, data } = await putPdfFile(file);
-
       const { id: templateDocumentDataId } = await createDocumentData({
         type,
         data,
@@ -107,7 +56,7 @@ export const NewTemplateDialog = ({ teamId, templateRootPath }: NewTemplateDialo
 
       const { id } = await createTemplate({
         teamId,
-        title: values.name ? values.name : file.name,
+        title: file.name,
         templateDocumentDataId,
       });
 
@@ -127,26 +76,16 @@ export const NewTemplateDialog = ({ teamId, templateRootPath }: NewTemplateDialo
         description: 'Please try again later.',
         variant: 'destructive',
       });
+
+      setIsUploadingFile(false);
     }
   };
-
-  const resetForm = () => {
-    if (form.getValues('name') === uploadedFile?.file.name) {
-      form.reset();
-    }
-
-    setUploadedFile(null);
-  };
-
-  useEffect(() => {
-    if (!showNewTemplateDialog) {
-      form.reset();
-      setUploadedFile(null);
-    }
-  }, [form, showNewTemplateDialog]);
 
   return (
-    <Dialog open={showNewTemplateDialog} onOpenChange={setShowNewTemplateDialog}>
+    <Dialog
+      open={showNewTemplateDialog}
+      onOpenChange={(value) => !isUploadingFile && setShowNewTemplateDialog(value)}
+    >
       <DialogTrigger asChild>
         <Button className="cursor-pointer" disabled={!session?.user.emailVerified}>
           <FilePlus className="-ml-1 mr-2 h-4 w-4" />
@@ -162,80 +101,23 @@ export const NewTemplateDialog = ({ teamId, templateRootPath }: NewTemplateDialo
           </DialogDescription>
         </DialogHeader>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)}>
-            <fieldset disabled={form.formState.isSubmitting} className="flex flex-col gap-y-4">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Template name</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      <span className="text-muted-foreground text-xs">
-                        Leave this empty if you would like to use your document's name for the
-                        template
-                      </span>
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+        <div className="relative">
+          <DocumentDropzone className="h-[40vh]" onDrop={onFileDrop} type="template" />
 
-              <div className="mt-1.5">
-                {uploadedFile ? (
-                  <Card gradient className="h-[40vh]">
-                    <CardContent className="flex h-full flex-col items-center justify-center p-2">
-                      <button
-                        onClick={() => resetForm()}
-                        title="Remove Template"
-                        className="text-muted-foreground absolute right-2.5 top-2.5 rounded-sm opacity-60 transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none"
-                      >
-                        <X className="h-6 w-6" />
-                        <span className="sr-only">Remove Template</span>
-                      </button>
+          {isUploadingFile && (
+            <div className="bg-background/50 absolute inset-0 flex items-center justify-center rounded-lg">
+              <Loader className="text-muted-foreground h-12 w-12 animate-spin" />
+            </div>
+          )}
+        </div>
 
-                      <div className="border-muted-foreground/20 group-hover:border-documenso/80 dark:bg-muted/80 z-10 flex aspect-[3/4] w-24 flex-col gap-y-1 rounded-lg border bg-white/80 px-2 py-4 backdrop-blur-sm">
-                        <div className="bg-muted-foreground/20 group-hover:bg-documenso h-2 w-full rounded-[2px]" />
-                        <div className="bg-muted-foreground/20 group-hover:bg-documenso h-2 w-5/6 rounded-[2px]" />
-                        <div className="bg-muted-foreground/20 group-hover:bg-documenso h-2 w-full rounded-[2px]" />
-                      </div>
-
-                      <p className="group-hover:text-foreground text-muted-foreground mt-4 font-medium">
-                        Uploaded Document
-                      </p>
-
-                      <span className="text-muted-foreground/80 mt-1 text-sm">
-                        {uploadedFile.file.name}
-                      </span>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  <DocumentDropzone className="h-[40vh]" onDrop={onFileDrop} type="template" />
-                )}
-              </div>
-
-              <DialogFooter>
-                <DialogClose asChild>
-                  <Button type="button" variant="secondary">
-                    Cancel
-                  </Button>
-                </DialogClose>
-
-                <Button
-                  loading={form.formState.isSubmitting}
-                  disabled={!uploadedFile}
-                  type="submit"
-                >
-                  Create template
-                </Button>
-              </DialogFooter>
-            </fieldset>
-          </form>
-        </Form>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="secondary" disabled={isUploadingFile}>
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/packages/api/v1/contract.ts
+++ b/packages/api/v1/contract.ts
@@ -104,7 +104,7 @@ export const ApiContractV1 = c.router(
       },
       summary: 'Create a new document from an existing template',
       description:
-        'Create a new document from an existing template. Passing in values for title and meta will override the original values defined in the template.',
+        'Create a new document from an existing template. Passing in values for title and meta will override the original values defined in the template. If you do not pass in values for recipients, it will use the values defined in the template.',
     },
 
     sendDocument: {

--- a/packages/api/v1/contract.ts
+++ b/packages/api/v1/contract.ts
@@ -12,6 +12,8 @@ import {
   ZDeleteFieldMutationSchema,
   ZDeleteRecipientMutationSchema,
   ZDownloadDocumentSuccessfulSchema,
+  ZGenerateDocumentFromTemplateMutationResponseSchema,
+  ZGenerateDocumentFromTemplateMutationSchema,
   ZGetDocumentsQuerySchema,
   ZSendDocumentForSigningMutationSchema,
   ZSuccessfulDocumentResponseSchema,
@@ -85,6 +87,24 @@ export const ApiContractV1 = c.router(
         404: ZUnsuccessfulResponseSchema,
       },
       summary: 'Create a new document from an existing template',
+      deprecated: true,
+      description: `This has been deprecated in favour of "/api/v1/templates/:templateId/generate-document". You may face unpredictable behavior using this endpoint as it is no longer maintained.`,
+    },
+
+    generateDocumentFromTemplate: {
+      method: 'POST',
+      path: '/api/v1/templates/:templateId/generate-document',
+      body: ZGenerateDocumentFromTemplateMutationSchema,
+      responses: {
+        200: ZGenerateDocumentFromTemplateMutationResponseSchema,
+        400: ZUnsuccessfulResponseSchema,
+        401: ZUnsuccessfulResponseSchema,
+        404: ZUnsuccessfulResponseSchema,
+        500: ZUnsuccessfulResponseSchema,
+      },
+      summary: 'Create a new document from an existing template',
+      description:
+        'Create a new document from an existing template. Passing in values for title and meta will override the original values defined in the template.',
     },
 
     sendDocument: {

--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -1,6 +1,7 @@
 import { createNextRoute } from '@ts-rest/next';
 
 import { getServerLimits } from '@documenso/ee/server-only/limits/server';
+import { AppError } from '@documenso/lib/errors/app-error';
 import { createDocumentData } from '@documenso/lib/server-only/document-data/create-document-data';
 import { upsertDocumentMeta } from '@documenso/lib/server-only/document-meta/upsert-document-meta';
 import { createDocument } from '@documenso/lib/server-only/document/create-document';
@@ -19,6 +20,8 @@ import { getRecipientById } from '@documenso/lib/server-only/recipient/get-recip
 import { getRecipientsForDocument } from '@documenso/lib/server-only/recipient/get-recipients-for-document';
 import { setRecipientsForDocument } from '@documenso/lib/server-only/recipient/set-recipients-for-document';
 import { updateRecipient } from '@documenso/lib/server-only/recipient/update-recipient';
+import type { CreateDocumentFromTemplateResponse } from '@documenso/lib/server-only/template/create-document-from-template';
+import { createDocumentFromTemplate } from '@documenso/lib/server-only/template/create-document-from-template';
 import { createDocumentFromTemplateLegacy } from '@documenso/lib/server-only/template/create-document-from-template-legacy';
 import { extractNextApiRequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
 import { getFile } from '@documenso/lib/universal/upload/get-file';
@@ -333,6 +336,85 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
         userId: user.id,
         ...body.meta,
         requestMetadata: extractNextApiRequestMetadata(args.req),
+      });
+    }
+
+    return {
+      status: 200,
+      body: {
+        documentId: document.id,
+        recipients: document.Recipient.map((recipient) => ({
+          recipientId: recipient.id,
+          name: recipient.name,
+          email: recipient.email,
+          token: recipient.token,
+          role: recipient.role,
+        })),
+      },
+    };
+  }),
+
+  generateDocumentFromTemplate: authenticatedMiddleware(async (args, user, team) => {
+    const { body, params } = args;
+
+    const { remaining } = await getServerLimits({ email: user.email, teamId: team?.id });
+
+    if (remaining.documents <= 0) {
+      return {
+        status: 400,
+        body: {
+          message: 'You have reached the maximum number of documents allowed for this month',
+        },
+      };
+    }
+
+    const templateId = Number(params.templateId);
+
+    let document: CreateDocumentFromTemplateResponse | null = null;
+
+    try {
+      document = await createDocumentFromTemplate({
+        templateId,
+        userId: user.id,
+        teamId: team?.id,
+        recipients: body.recipients,
+        override: {
+          title: body.title,
+          ...body.meta,
+        },
+      });
+    } catch (err) {
+      return AppError.toRestAPIError(err);
+    }
+
+    if (body.formValues) {
+      const fileName = document.title.endsWith('.pdf') ? document.title : `${document.title}.pdf`;
+
+      const pdf = await getFile(document.documentData);
+
+      const prefilled = await insertFormValuesInPdf({
+        pdf: Buffer.from(pdf),
+        formValues: body.formValues,
+      });
+
+      const newDocumentData = await putPdfFile({
+        name: fileName,
+        type: 'application/pdf',
+        arrayBuffer: async () => Promise.resolve(prefilled),
+      });
+
+      await updateDocument({
+        documentId: document.id,
+        userId: user.id,
+        teamId: team?.id,
+        data: {
+          formValues: body.formValues,
+          documentData: {
+            connect: {
+              id: newDocumentData.id,
+            },
+          },
+        },
       });
     }
 

--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { ZUrlSchema } from '@documenso/lib/schemas/common';
 import {
   FieldType,
   ReadStatus,
@@ -139,6 +140,59 @@ export const ZCreateDocumentFromTemplateMutationResponseSchema = z.object({
 
 export type TCreateDocumentFromTemplateMutationResponseSchema = z.infer<
   typeof ZCreateDocumentFromTemplateMutationResponseSchema
+>;
+
+export const ZGenerateDocumentFromTemplateMutationSchema = z.object({
+  title: z.string().optional(),
+  recipients: z
+    .array(
+      z.object({
+        id: z.number(),
+        name: z.string().optional(),
+        email: z.string().email().min(1),
+      }),
+    )
+    .refine(
+      (schema) => {
+        const emails = schema.map((signer) => signer.email.toLowerCase());
+        const ids = schema.map((signer) => signer.id);
+
+        return new Set(emails).size === emails.length && new Set(ids).size === ids.length;
+      },
+      { message: 'Recipient IDs and emails must be unique' },
+    ),
+  meta: z
+    .object({
+      subject: z.string(),
+      message: z.string(),
+      timezone: z.string(),
+      dateFormat: z.string(),
+      redirectUrl: ZUrlSchema,
+    })
+    .partial()
+    .optional(),
+  formValues: z.record(z.string(), z.union([z.string(), z.boolean(), z.number()])).optional(),
+});
+
+export type TGenerateDocumentFromTemplateMutationSchema = z.infer<
+  typeof ZGenerateDocumentFromTemplateMutationSchema
+>;
+
+export const ZGenerateDocumentFromTemplateMutationResponseSchema = z.object({
+  documentId: z.number(),
+  recipients: z.array(
+    z.object({
+      recipientId: z.number(),
+      name: z.string(),
+      email: z.string().email().min(1),
+      token: z.string(),
+      role: z.nativeEnum(RecipientRole),
+    }),
+  ),
+});
+
+export type TGenerateDocumentFromTemplateMutationResponseSchema = z.infer<
+  typeof ZGenerateDocumentFromTemplateMutationResponseSchema
 >;
 
 export const ZCreateRecipientMutationSchema = z.object({

--- a/packages/app-tests/e2e/document-flow/settings-step.spec.ts
+++ b/packages/app-tests/e2e/document-flow/settings-step.spec.ts
@@ -164,9 +164,8 @@ test('[DOCUMENT_FLOW]: add settings', async ({ page }) => {
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
 
-  await expect(page.getByLabel('Title')).toContainText('New Title');
+  await expect(page.getByLabel('Title')).toHaveValue('New Title');
   await expect(page.getByTestId('documentAccessSelectValue')).toContainText('Require account');
-  await expect(page.getByTestId('documentActionSelectValue')).toContainText('Require account');
 
   await unseedUser(user.id);
 });

--- a/packages/app-tests/e2e/document-flow/signers-step.spec.ts
+++ b/packages/app-tests/e2e/document-flow/signers-step.spec.ts
@@ -92,22 +92,5 @@ test('[DOCUMENT_FLOW]: add signers', async ({ page }) => {
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
 
-  // Expect that the advanced settings is unchecked, since no advanced settings were applied.
-  await expect(page.getByLabel('Show advanced settings')).toBeChecked({ checked: false });
-
-  // Add advanced settings for a single recipient.
-  await page.getByLabel('Show advanced settings').check();
-  await page.getByRole('combobox').first().click();
-  await page.getByLabel('Require passkey').click();
-
-  // Navigate to the next step and back.
-  await page.getByRole('button', { name: 'Continue' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
-  await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
-
-  // Expect that the advanced settings is visible, and the checkbox is hidden. Since advanced
-  // settings were applied.
-
   await unseedUser(user.id);
 });

--- a/packages/app-tests/e2e/templates-flow/template-settings-step.spec.ts
+++ b/packages/app-tests/e2e/templates-flow/template-settings-step.spec.ts
@@ -1,12 +1,8 @@
 import { expect, test } from '@playwright/test';
 
-import {
-  seedBlankDocument,
-  seedDraftDocument,
-  seedPendingDocument,
-} from '@documenso/prisma/seed/documents';
 import { seedUserSubscription } from '@documenso/prisma/seed/subscriptions';
 import { seedTeam, unseedTeam } from '@documenso/prisma/seed/teams';
+import { seedBlankTemplate } from '@documenso/prisma/seed/templates';
 import { seedUser, unseedUser } from '@documenso/prisma/seed/users';
 
 import { apiSignin } from '../fixtures/authentication';
@@ -23,7 +19,7 @@ test.describe('[EE_ONLY]', () => {
     );
   });
 
-  test('[DOCUMENT_FLOW] add action auth settings', async ({ page }) => {
+  test('[TEMPLATE_FLOW] add action auth settings', async ({ page }) => {
     const user = await seedUser();
 
     await seedUserSubscription({
@@ -31,12 +27,12 @@ test.describe('[EE_ONLY]', () => {
       priceId: enterprisePriceId,
     });
 
-    const document = await seedBlankDocument(user);
+    const template = await seedBlankTemplate(user);
 
     await apiSignin({
       page,
       email: user.email,
-      redirectPath: `/documents/${document.id}/edit`,
+      redirectPath: `/templates/${template.id}`,
     });
 
     // Set EE action auth.
@@ -46,7 +42,7 @@ test.describe('[EE_ONLY]', () => {
 
     // Save the settings by going to the next step.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add Placeholders' })).toBeVisible();
 
     // Return to the settings step to check that the results are saved correctly.
     await page.getByRole('button', { name: 'Go Back' }).click();
@@ -57,7 +53,7 @@ test.describe('[EE_ONLY]', () => {
     await unseedUser(user.id);
   });
 
-  test('[DOCUMENT_FLOW] enterprise team member can add action auth settings', async ({ page }) => {
+  test('[TEMPLATE_FLOW] enterprise team member can add action auth settings', async ({ page }) => {
     const team = await seedTeam({
       createTeamMembers: 1,
     });
@@ -71,8 +67,8 @@ test.describe('[EE_ONLY]', () => {
       priceId: enterprisePriceId,
     });
 
-    const document = await seedBlankDocument(owner, {
-      createDocumentOptions: {
+    const template = await seedBlankTemplate(owner, {
+      createTemplateOptions: {
         teamId: team.id,
       },
     });
@@ -80,7 +76,7 @@ test.describe('[EE_ONLY]', () => {
     await apiSignin({
       page,
       email: teamMemberUser.email,
-      redirectPath: `/t/${team.url}/documents/${document.id}/edit`,
+      redirectPath: `/t/${team.url}/templates/${template.id}`,
     });
 
     // Set EE action auth.
@@ -90,7 +86,7 @@ test.describe('[EE_ONLY]', () => {
 
     // Save the settings by going to the next step.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add Placeholders' })).toBeVisible();
 
     // Advanced settings should be visible.
     await expect(page.getByLabel('Show advanced settings')).toBeVisible();
@@ -98,7 +94,7 @@ test.describe('[EE_ONLY]', () => {
     await unseedTeam(team.url);
   });
 
-  test('[DOCUMENT_FLOW] enterprise team member should not have access to enterprise on personal account', async ({
+  test('[TEMPLATE_FLOW] enterprise team member should not have access to enterprise on personal account', async ({
     page,
   }) => {
     const team = await seedTeam({
@@ -113,12 +109,12 @@ test.describe('[EE_ONLY]', () => {
       priceId: enterprisePriceId,
     });
 
-    const document = await seedBlankDocument(teamMemberUser);
+    const template = await seedBlankTemplate(teamMemberUser);
 
     await apiSignin({
       page,
       email: teamMemberUser.email,
-      redirectPath: `/documents/${document.id}/edit`,
+      redirectPath: `/templates/${template.id}`,
     });
 
     // Global action auth should not be visible.
@@ -126,7 +122,7 @@ test.describe('[EE_ONLY]', () => {
 
     // Next step.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add Placeholders' })).toBeVisible();
 
     // Advanced settings should not be visible.
     await expect(page.getByLabel('Show advanced settings')).not.toBeVisible();
@@ -135,14 +131,14 @@ test.describe('[EE_ONLY]', () => {
   });
 });
 
-test('[DOCUMENT_FLOW]: add settings', async ({ page }) => {
+test('[TEMPLATE_FLOW]: add settings', async ({ page }) => {
   const user = await seedUser();
-  const document = await seedBlankDocument(user);
+  const template = await seedBlankTemplate(user);
 
   await apiSignin({
     page,
     email: user.email,
-    redirectPath: `/documents/${document.id}/edit`,
+    redirectPath: `/templates/${template.id}`,
   });
 
   // Set title.
@@ -158,37 +154,14 @@ test('[DOCUMENT_FLOW]: add settings', async ({ page }) => {
 
   // Save the settings by going to the next step.
   await page.getByRole('button', { name: 'Continue' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Add Placeholders' })).toBeVisible();
 
   // Return to the settings step to check that the results are saved correctly.
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
 
-  await expect(page.getByLabel('Title')).toContainText('New Title');
+  await expect(page.getByLabel('Title')).toHaveValue('New Title');
   await expect(page.getByTestId('documentAccessSelectValue')).toContainText('Require account');
-  await expect(page.getByTestId('documentActionSelectValue')).toContainText('Require account');
-
-  await unseedUser(user.id);
-});
-
-test('[DOCUMENT_FLOW]: title should be disabled depending on document status', async ({ page }) => {
-  const user = await seedUser();
-
-  const pendingDocument = await seedPendingDocument(user, []);
-  const draftDocument = await seedDraftDocument(user, []);
-
-  await apiSignin({
-    page,
-    email: user.email,
-    redirectPath: `/documents/${pendingDocument.id}/edit`,
-  });
-
-  // Should be disabled for pending documents.
-  await expect(page.getByLabel('Title')).toBeDisabled();
-
-  // Should be enabled for draft documents.
-  await page.goto(`/documents/${draftDocument.id}/edit`);
-  await expect(page.getByLabel('Title')).toBeEnabled();
 
   await unseedUser(user.id);
 });

--- a/packages/app-tests/e2e/templates-flow/template-signers-step.spec.ts
+++ b/packages/app-tests/e2e/templates-flow/template-signers-step.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-import { seedBlankDocument } from '@documenso/prisma/seed/documents';
 import { seedUserSubscription } from '@documenso/prisma/seed/subscriptions';
+import { seedBlankTemplate } from '@documenso/prisma/seed/templates';
 import { seedUser, unseedUser } from '@documenso/prisma/seed/users';
 
 import { apiSignin } from '../fixtures/authentication';
@@ -18,7 +18,7 @@ test.describe('[EE_ONLY]', () => {
     );
   });
 
-  test('[DOCUMENT_FLOW] add EE settings', async ({ page }) => {
+  test('[TEMPLATE_FLOW] add EE settings', async ({ page }) => {
     const user = await seedUser();
 
     await seedUserSubscription({
@@ -26,22 +26,22 @@ test.describe('[EE_ONLY]', () => {
       priceId: enterprisePriceId,
     });
 
-    const document = await seedBlankDocument(user);
+    const template = await seedBlankTemplate(user);
 
     await apiSignin({
       page,
       email: user.email,
-      redirectPath: `/documents/${document.id}/edit`,
+      redirectPath: `/templates/${template.id}`,
     });
 
     // Save the settings by going to the next step.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add Placeholder' })).toBeVisible();
 
     // Add 2 signers.
     await page.getByPlaceholder('Email').fill('recipient1@documenso.com');
     await page.getByPlaceholder('Name').fill('Recipient 1');
-    await page.getByRole('button', { name: 'Add Signer' }).click();
+    await page.getByRole('button', { name: 'Add Placeholder Recipient' }).click();
     await page
       .getByRole('textbox', { name: 'Email', exact: true })
       .fill('recipient2@documenso.com');
@@ -54,60 +54,53 @@ test.describe('[EE_ONLY]', () => {
     await page.getByRole('button', { name: 'Continue' }).click();
     await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
     await page.getByRole('button', { name: 'Go Back' }).click();
-    await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add Placeholder' })).toBeVisible();
 
-    // Todo: Fix stepper component back issue before finishing test.
+    // Expect that the advanced settings is unchecked, since no advanced settings were applied.
+    await expect(page.getByLabel('Show advanced settings')).toBeChecked({ checked: false });
+
+    // Add advanced settings for a single recipient.
+    await page.getByLabel('Show advanced settings').check();
+    await page.getByRole('combobox').first().click();
+    await page.getByLabel('Require passkey').click();
+
+    // Navigate to the next step and back.
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
+    await page.getByRole('button', { name: 'Go Back' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Placeholder' })).toBeVisible();
+
+    // Expect that the advanced settings is visible, and the checkbox is hidden. Since advanced
+    // settings were applied.
+    await expect(page.getByLabel('Show advanced settings')).toBeHidden();
 
     await unseedUser(user.id);
   });
 });
 
-test('[DOCUMENT_FLOW]: add signers', async ({ page }) => {
+test('[TEMPLATE_FLOW]: add placeholder', async ({ page }) => {
   const user = await seedUser();
-  const document = await seedBlankDocument(user);
+  const template = await seedBlankTemplate(user);
 
   await apiSignin({
     page,
     email: user.email,
-    redirectPath: `/documents/${document.id}/edit`,
+    redirectPath: `/templates/${template.id}`,
   });
 
   // Save the settings by going to the next step.
   await page.getByRole('button', { name: 'Continue' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Add Placeholder' })).toBeVisible();
 
   // Add 2 signers.
   await page.getByPlaceholder('Email').fill('recipient1@documenso.com');
   await page.getByPlaceholder('Name').fill('Recipient 1');
-  await page.getByRole('button', { name: 'Add Signer' }).click();
+  await page.getByRole('button', { name: 'Add Placeholder Recipient' }).click();
   await page.getByRole('textbox', { name: 'Email', exact: true }).fill('recipient2@documenso.com');
   await page.getByRole('textbox', { name: 'Name', exact: true }).nth(1).fill('Recipient 2');
 
   // Advanced settings should not be visible for non EE users.
   await expect(page.getByLabel('Show advanced settings')).toBeHidden();
-
-  // Navigate to the next step and back.
-  await page.getByRole('button', { name: 'Continue' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
-  await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
-
-  // Expect that the advanced settings is unchecked, since no advanced settings were applied.
-  await expect(page.getByLabel('Show advanced settings')).toBeChecked({ checked: false });
-
-  // Add advanced settings for a single recipient.
-  await page.getByLabel('Show advanced settings').check();
-  await page.getByRole('combobox').first().click();
-  await page.getByLabel('Require passkey').click();
-
-  // Navigate to the next step and back.
-  await page.getByRole('button', { name: 'Continue' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
-  await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect(page.getByRole('heading', { name: 'Add Signers' })).toBeVisible();
-
-  // Expect that the advanced settings is visible, and the checkbox is hidden. Since advanced
-  // settings were applied.
 
   await unseedUser(user.id);
 });

--- a/packages/app-tests/e2e/templates/create-document-from-template.spec.ts
+++ b/packages/app-tests/e2e/templates/create-document-from-template.spec.ts
@@ -1,0 +1,285 @@
+import { expect, test } from '@playwright/test';
+
+import { extractDocumentAuthMethods } from '@documenso/lib/utils/document-auth';
+import { prisma } from '@documenso/prisma';
+import { seedUserSubscription } from '@documenso/prisma/seed/subscriptions';
+import { seedTeam } from '@documenso/prisma/seed/teams';
+import { seedBlankTemplate } from '@documenso/prisma/seed/templates';
+import { seedUser } from '@documenso/prisma/seed/users';
+
+import { apiSignin } from '../fixtures/authentication';
+
+test.describe.configure({ mode: 'parallel' });
+
+const enterprisePriceId = process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PLAN_MONTHLY_PRICE_ID || '';
+
+/**
+ * 1. Create a template with all settings filled out
+ * 2. Create a document from the template
+ * 3. Ensure all values are correct
+ *
+ * Note: There is a direct copy paste of this test below for teams.
+ *
+ * If you update this test please update that test as well.
+ */
+test('[TEMPLATE]: should create a document from a template', async ({ page }) => {
+  const user = await seedUser();
+  const template = await seedBlankTemplate(user);
+
+  const isBillingEnabled =
+    process.env.NEXT_PUBLIC_FEATURE_BILLING_ENABLED === 'true' && enterprisePriceId;
+
+  await seedUserSubscription({
+    userId: user.id,
+    priceId: enterprisePriceId,
+  });
+
+  await apiSignin({
+    page,
+    email: user.email,
+    redirectPath: `/templates/${template.id}`,
+  });
+
+  // Set template title.
+  await page.getByLabel('Title').fill('TEMPLATE_TITLE');
+
+  // Set template document access.
+  await page.getByTestId('documentAccessSelectValue').click();
+  await page.getByLabel('Require account').getByText('Require account').click();
+  await expect(page.getByTestId('documentAccessSelectValue')).toContainText('Require account');
+
+  // Set EE action auth.
+  if (isBillingEnabled) {
+    await page.getByTestId('documentActionSelectValue').click();
+    await page.getByLabel('Require passkey').getByText('Require passkey').click();
+    await expect(page.getByTestId('documentActionSelectValue')).toContainText('Require passkey');
+  }
+
+  // Set email options.
+  await page.getByRole('button', { name: 'Email Options' }).click();
+  await page.getByLabel('Subject (Optional)').fill('SUBJECT');
+  await page.getByLabel('Message (Optional)').fill('MESSAGE');
+
+  // Set advanced options.
+  await page.getByRole('button', { name: 'Advanced Options' }).click();
+  await page.locator('button').filter({ hasText: 'YYYY-MM-DD HH:mm a' }).click();
+  await page.getByLabel('DD/MM/YYYY').click();
+
+  await page.getByRole('combobox').nth(3).click();
+  await page.getByRole('option', { name: 'Etc/UTC' }).click();
+  await page.getByLabel('Redirect URL').fill('https://documenso.com');
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Add Placeholder' })).toBeVisible();
+
+  // Add 2 signers.
+  await page.getByPlaceholder('Email').fill('recipient1@documenso.com');
+  await page.getByPlaceholder('Name').fill('Recipient 1');
+  await page.getByRole('button', { name: 'Add Placeholder Recipient' }).click();
+  await page.getByRole('textbox', { name: 'Email', exact: true }).fill('recipient2@documenso.com');
+  await page.getByRole('textbox', { name: 'Name', exact: true }).nth(1).fill('Recipient 2');
+
+  // Apply require passkey for Recipient 1.
+  if (isBillingEnabled) {
+    await page.getByLabel('Show advanced settings').check();
+    await page.getByRole('combobox').first().click();
+    await page.getByLabel('Require passkey').click();
+  }
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save template' }).click();
+
+  // Use template
+  await page.waitForURL('/templates');
+  await page.getByRole('button', { name: 'Use Template' }).click();
+  await page.getByRole('button', { name: 'Create as draft' }).click();
+
+  // Review that the document was created with the correct values.
+  await page.waitForURL(/documents/);
+
+  const documentId = Number(page.url().split('/').pop());
+
+  const document = await prisma.document.findFirstOrThrow({
+    where: {
+      id: documentId,
+    },
+    include: {
+      Recipient: true,
+      documentMeta: true,
+    },
+  });
+
+  const documentAuth = extractDocumentAuthMethods({
+    documentAuth: document.authOptions,
+  });
+
+  expect(document.title).toEqual('TEMPLATE_TITLE');
+  expect(documentAuth.documentAuthOption.globalAccessAuth).toEqual('ACCOUNT');
+  expect(documentAuth.documentAuthOption.globalActionAuth).toEqual(
+    isBillingEnabled ? 'PASSKEY' : null,
+  );
+  expect(document.documentMeta?.dateFormat).toEqual('dd/MM/yyyy hh:mm a');
+  expect(document.documentMeta?.message).toEqual('MESSAGE');
+  expect(document.documentMeta?.redirectUrl).toEqual('https://documenso.com');
+  expect(document.documentMeta?.subject).toEqual('SUBJECT');
+  expect(document.documentMeta?.timezone).toEqual('Etc/UTC');
+
+  const recipientOne = document.Recipient[0];
+  const recipientTwo = document.Recipient[1];
+
+  const recipientOneAuth = extractDocumentAuthMethods({
+    documentAuth: document.authOptions,
+    recipientAuth: recipientOne.authOptions,
+  });
+
+  const recipientTwoAuth = extractDocumentAuthMethods({
+    documentAuth: document.authOptions,
+    recipientAuth: recipientTwo.authOptions,
+  });
+
+  if (isBillingEnabled) {
+    expect(recipientOneAuth.derivedRecipientActionAuth).toEqual('PASSKEY');
+  }
+
+  expect(recipientOneAuth.derivedRecipientAccessAuth).toEqual('ACCOUNT');
+  expect(recipientTwoAuth.derivedRecipientAccessAuth).toEqual('ACCOUNT');
+});
+
+/**
+ * This is a direct copy paste of the above test but for teams.
+ */
+test('[TEMPLATE]: should create a team document from a team template', async ({ page }) => {
+  const { owner, ...team } = await seedTeam({
+    createTeamMembers: 2,
+  });
+
+  const template = await seedBlankTemplate(owner, {
+    createTemplateOptions: {
+      teamId: team.id,
+    },
+  });
+
+  const isBillingEnabled =
+    process.env.NEXT_PUBLIC_FEATURE_BILLING_ENABLED === 'true' && enterprisePriceId;
+
+  await seedUserSubscription({
+    userId: owner.id,
+    priceId: enterprisePriceId,
+  });
+
+  await apiSignin({
+    page,
+    email: owner.email,
+    redirectPath: `/t/${team.url}/templates/${template.id}`,
+  });
+
+  // Set template title.
+  await page.getByLabel('Title').fill('TEMPLATE_TITLE');
+
+  // Set template document access.
+  await page.getByTestId('documentAccessSelectValue').click();
+  await page.getByLabel('Require account').getByText('Require account').click();
+  await expect(page.getByTestId('documentAccessSelectValue')).toContainText('Require account');
+
+  // Set EE action auth.
+  if (isBillingEnabled) {
+    await page.getByTestId('documentActionSelectValue').click();
+    await page.getByLabel('Require passkey').getByText('Require passkey').click();
+    await expect(page.getByTestId('documentActionSelectValue')).toContainText('Require passkey');
+  }
+
+  // Set email options.
+  await page.getByRole('button', { name: 'Email Options' }).click();
+  await page.getByLabel('Subject (Optional)').fill('SUBJECT');
+  await page.getByLabel('Message (Optional)').fill('MESSAGE');
+
+  // Set advanced options.
+  await page.getByRole('button', { name: 'Advanced Options' }).click();
+  await page.locator('button').filter({ hasText: 'YYYY-MM-DD HH:mm a' }).click();
+  await page.getByLabel('DD/MM/YYYY').click();
+
+  await page.getByRole('combobox').nth(3).click();
+  await page.getByRole('option', { name: 'Etc/UTC' }).click();
+  await page.getByLabel('Redirect URL').fill('https://documenso.com');
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Add Placeholder' })).toBeVisible();
+
+  // Add 2 signers.
+  await page.getByPlaceholder('Email').fill('recipient1@documenso.com');
+  await page.getByPlaceholder('Name').fill('Recipient 1');
+  await page.getByRole('button', { name: 'Add Placeholder Recipient' }).click();
+  await page.getByRole('textbox', { name: 'Email', exact: true }).fill('recipient2@documenso.com');
+  await page.getByRole('textbox', { name: 'Name', exact: true }).nth(1).fill('Recipient 2');
+
+  // Apply require passkey for Recipient 1.
+  if (isBillingEnabled) {
+    await page.getByLabel('Show advanced settings').check();
+    await page.getByRole('combobox').first().click();
+    await page.getByLabel('Require passkey').click();
+  }
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await expect(page.getByRole('heading', { name: 'Add Fields' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save template' }).click();
+
+  // Use template
+  await page.waitForURL(`/t/${team.url}/templates`);
+  await page.getByRole('button', { name: 'Use Template' }).click();
+  await page.getByRole('button', { name: 'Create as draft' }).click();
+
+  // Review that the document was created with the correct values.
+  await page.waitForURL(/documents/);
+
+  const documentId = Number(page.url().split('/').pop());
+
+  const document = await prisma.document.findFirstOrThrow({
+    where: {
+      id: documentId,
+    },
+    include: {
+      Recipient: true,
+      documentMeta: true,
+    },
+  });
+
+  expect(document.teamId).toEqual(team.id);
+
+  const documentAuth = extractDocumentAuthMethods({
+    documentAuth: document.authOptions,
+  });
+
+  expect(document.title).toEqual('TEMPLATE_TITLE');
+  expect(documentAuth.documentAuthOption.globalAccessAuth).toEqual('ACCOUNT');
+  expect(documentAuth.documentAuthOption.globalActionAuth).toEqual(
+    isBillingEnabled ? 'PASSKEY' : null,
+  );
+  expect(document.documentMeta?.dateFormat).toEqual('dd/MM/yyyy hh:mm a');
+  expect(document.documentMeta?.message).toEqual('MESSAGE');
+  expect(document.documentMeta?.redirectUrl).toEqual('https://documenso.com');
+  expect(document.documentMeta?.subject).toEqual('SUBJECT');
+  expect(document.documentMeta?.timezone).toEqual('Etc/UTC');
+
+  const recipientOne = document.Recipient[0];
+  const recipientTwo = document.Recipient[1];
+
+  const recipientOneAuth = extractDocumentAuthMethods({
+    documentAuth: document.authOptions,
+    recipientAuth: recipientOne.authOptions,
+  });
+
+  const recipientTwoAuth = extractDocumentAuthMethods({
+    documentAuth: document.authOptions,
+    recipientAuth: recipientTwo.authOptions,
+  });
+
+  if (isBillingEnabled) {
+    expect(recipientOneAuth.derivedRecipientActionAuth).toEqual('PASSKEY');
+  }
+
+  expect(recipientOneAuth.derivedRecipientAccessAuth).toEqual('ACCOUNT');
+  expect(recipientTwoAuth.derivedRecipientAccessAuth).toEqual('ACCOUNT');
+});

--- a/packages/app-tests/e2e/templates/create-document-from-template.spec.ts
+++ b/packages/app-tests/e2e/templates/create-document-from-template.spec.ts
@@ -65,7 +65,7 @@ test('[TEMPLATE]: should create a document from a template', async ({ page }) =>
   await page.locator('button').filter({ hasText: 'YYYY-MM-DD HH:mm a' }).click();
   await page.getByLabel('DD/MM/YYYY').click();
 
-  await page.getByRole('combobox').nth(3).click();
+  await page.locator('.time-zone-field').click();
   await page.getByRole('option', { name: 'Etc/UTC' }).click();
   await page.getByLabel('Redirect URL').fill('https://documenso.com');
   await page.getByRole('button', { name: 'Continue' }).click();
@@ -200,7 +200,7 @@ test('[TEMPLATE]: should create a team document from a team template', async ({ 
   await page.locator('button').filter({ hasText: 'YYYY-MM-DD HH:mm a' }).click();
   await page.getByLabel('DD/MM/YYYY').click();
 
-  await page.getByRole('combobox').nth(3).click();
+  await page.locator('.time-zone-field').click();
   await page.getByRole('option', { name: 'Etc/UTC' }).click();
   await page.getByLabel('Redirect URL').fill('https://documenso.com');
   await page.getByRole('button', { name: 'Continue' }).click();

--- a/packages/lib/schemas/common.ts
+++ b/packages/lib/schemas/common.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+import { URL_REGEX } from '../constants/url-regex';
+
+export const ZUrlSchema = z
+  .string()
+  .refine((value) => value === undefined || value === '' || URL_REGEX.test(value), {
+    message: 'Please enter a valid URL',
+  });

--- a/packages/lib/schemas/common.ts
+++ b/packages/lib/schemas/common.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 import { URL_REGEX } from '../constants/url-regex';
 
+/**
+ * Note this allows empty strings.
+ */
 export const ZUrlSchema = z
   .string()
   .refine((value) => value === undefined || value === '' || URL_REGEX.test(value), {

--- a/packages/lib/server-only/recipient/set-recipients-for-template.ts
+++ b/packages/lib/server-only/recipient/set-recipients-for-template.ts
@@ -1,21 +1,32 @@
+import { isUserEnterprise } from '@documenso/ee/server-only/util/is-document-enterprise';
 import { prisma } from '@documenso/prisma';
-import type { RecipientRole } from '@documenso/prisma/client';
+import type { Recipient } from '@documenso/prisma/client';
+import { RecipientRole } from '@documenso/prisma/client';
 
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import {
+  type TRecipientActionAuthTypes,
+  ZRecipientAuthOptionsSchema,
+} from '../../types/document-auth';
 import { nanoid } from '../../universal/id';
+import { createRecipientAuthOptions } from '../../utils/document-auth';
 
 export type SetRecipientsForTemplateOptions = {
   userId: number;
+  teamId?: number;
   templateId: number;
   recipients: {
     id?: number;
     email: string;
     name: string;
     role: RecipientRole;
+    actionAuth?: TRecipientActionAuthTypes | null;
   }[];
 };
 
 export const setRecipientsForTemplate = async ({
   userId,
+  teamId,
   templateId,
   recipients,
 }: SetRecipientsForTemplateOptions) => {
@@ -41,6 +52,23 @@ export const setRecipientsForTemplate = async ({
 
   if (!template) {
     throw new Error('Template not found');
+  }
+
+  const recipientsHaveActionAuth = recipients.some((recipient) => recipient.actionAuth);
+
+  // Check if user has permission to set the global action auth.
+  if (recipientsHaveActionAuth) {
+    const isDocumentEnterprise = await isUserEnterprise({
+      userId,
+      teamId,
+    });
+
+    if (!isDocumentEnterprise) {
+      throw new AppError(
+        AppErrorCode.UNAUTHORIZED,
+        'You do not have permission to set the action auth',
+      );
+    }
   }
 
   const normalizedRecipients = recipients.map((recipient) => ({
@@ -74,31 +102,59 @@ export const setRecipientsForTemplate = async ({
     };
   });
 
-  const persistedRecipients = await prisma.$transaction(
-    // Disabling as wrapping promises here causes type issues
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    linkedRecipients.map((recipient) =>
-      prisma.recipient.upsert({
-        where: {
-          id: recipient._persisted?.id ?? -1,
-          templateId,
-        },
-        update: {
-          name: recipient.name,
-          email: recipient.email,
-          role: recipient.role,
-          templateId,
-        },
-        create: {
-          name: recipient.name,
-          email: recipient.email,
-          role: recipient.role,
-          token: nanoid(),
-          templateId,
-        },
+  const persistedRecipients = await prisma.$transaction(async (tx) => {
+    return await Promise.all(
+      linkedRecipients.map(async (recipient) => {
+        let authOptions = ZRecipientAuthOptionsSchema.parse(recipient._persisted?.authOptions);
+
+        if (recipient.actionAuth !== undefined) {
+          authOptions = createRecipientAuthOptions({
+            accessAuth: authOptions.accessAuth,
+            actionAuth: recipient.actionAuth,
+          });
+        }
+
+        const upsertedRecipient = await tx.recipient.upsert({
+          where: {
+            id: recipient._persisted?.id ?? -1,
+            templateId,
+          },
+          update: {
+            name: recipient.name,
+            email: recipient.email,
+            role: recipient.role,
+            templateId,
+            authOptions,
+          },
+          create: {
+            name: recipient.name,
+            email: recipient.email,
+            role: recipient.role,
+            token: nanoid(),
+            templateId,
+            authOptions,
+          },
+        });
+
+        const recipientId = upsertedRecipient.id;
+
+        // Clear all fields if the recipient role is changed to a type that cannot have fields.
+        if (
+          recipient._persisted &&
+          recipient._persisted.role !== recipient.role &&
+          (recipient.role === RecipientRole.CC || recipient.role === RecipientRole.VIEWER)
+        ) {
+          await tx.field.deleteMany({
+            where: {
+              recipientId,
+            },
+          });
+        }
+
+        return upsertedRecipient;
       }),
-    ),
-  );
+    );
+  });
 
   if (removedRecipients.length > 0) {
     await prisma.recipient.deleteMany({
@@ -110,5 +166,17 @@ export const setRecipientsForTemplate = async ({
     });
   }
 
-  return persistedRecipients;
+  // Filter out recipients that have been removed or have been updated.
+  const filteredRecipients: Recipient[] = existingRecipients.filter((recipient) => {
+    const isRemoved = removedRecipients.find(
+      (removedRecipient) => removedRecipient.id === recipient.id,
+    );
+    const isUpdated = persistedRecipients.find(
+      (persistedRecipient) => persistedRecipient.id === recipient.id,
+    );
+
+    return !isRemoved && !isUpdated;
+  });
+
+  return [...filteredRecipients, ...persistedRecipients];
 };

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -20,6 +20,10 @@ type FinalRecipient = Pick<Recipient, 'name' | 'email' | 'role' | 'authOptions'>
   fields: Field[];
 };
 
+export type CreateDocumentFromTemplateResponse = Awaited<
+  ReturnType<typeof createDocumentFromTemplate>
+>;
+
 export type CreateDocumentFromTemplateOptions = {
   templateId: number;
   userId: number;

--- a/packages/lib/server-only/template/get-template-with-details-by-id.ts
+++ b/packages/lib/server-only/template/get-template-with-details-by-id.ts
@@ -1,0 +1,38 @@
+import { prisma } from '@documenso/prisma';
+import type { TemplateWithDetails } from '@documenso/prisma/types/template';
+
+export type GetTemplateWithDetailsByIdOptions = {
+  id: number;
+  userId: number;
+};
+
+export const getTemplateWithDetailsById = async ({
+  id,
+  userId,
+}: GetTemplateWithDetailsByIdOptions): Promise<TemplateWithDetails> => {
+  return await prisma.template.findFirstOrThrow({
+    where: {
+      id,
+      OR: [
+        {
+          userId,
+        },
+        {
+          team: {
+            members: {
+              some: {
+                userId,
+              },
+            },
+          },
+        },
+      ],
+    },
+    include: {
+      templateDocumentData: true,
+      templateMeta: true,
+      Recipient: true,
+      Field: true,
+    },
+  });
+};

--- a/packages/lib/server-only/template/update-template-settings.ts
+++ b/packages/lib/server-only/template/update-template-settings.ts
@@ -1,0 +1,138 @@
+'use server';
+
+import { isUserEnterprise } from '@documenso/ee/server-only/util/is-document-enterprise';
+import type { RequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
+import { prisma } from '@documenso/prisma';
+import type { TemplateMeta } from '@documenso/prisma/client';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import type { TDocumentAccessAuthTypes, TDocumentActionAuthTypes } from '../../types/document-auth';
+import { createDocumentAuthOptions, extractDocumentAuthMethods } from '../../utils/document-auth';
+
+export type UpdateTemplateSettingsOptions = {
+  userId: number;
+  teamId?: number;
+  templateId: number;
+  data: {
+    title?: string;
+    globalAccessAuth?: TDocumentAccessAuthTypes | null;
+    globalActionAuth?: TDocumentActionAuthTypes | null;
+  };
+  meta?: Partial<Omit<TemplateMeta, 'id' | 'templateId'>>;
+  requestMetadata?: RequestMetadata;
+};
+
+export const updateTemplateSettings = async ({
+  userId,
+  teamId,
+  templateId,
+  meta,
+  data,
+}: UpdateTemplateSettingsOptions) => {
+  if (!data.title && !data.globalAccessAuth && !data.globalActionAuth) {
+    throw new AppError(AppErrorCode.INVALID_BODY, 'Missing data to update');
+  }
+
+  const template = await prisma.template.findFirstOrThrow({
+    where: {
+      id: templateId,
+      ...(teamId
+        ? {
+            team: {
+              id: teamId,
+              members: {
+                some: {
+                  userId,
+                },
+              },
+            },
+          }
+        : {
+            userId,
+            teamId: null,
+          }),
+    },
+    include: {
+      templateMeta: true,
+    },
+  });
+
+  const { documentAuthOption } = extractDocumentAuthMethods({
+    documentAuth: template.authOptions,
+  });
+
+  const { templateMeta } = template;
+
+  const isDateSame = (templateMeta?.dateFormat || null) === (meta?.dateFormat || null);
+  const isMessageSame = (templateMeta?.message || null) === (meta?.message || null);
+  const isPasswordSame = (templateMeta?.password || null) === (meta?.password || null);
+  const isSubjectSame = (templateMeta?.subject || null) === (meta?.subject || null);
+  const isRedirectUrlSame = (templateMeta?.redirectUrl || null) === (meta?.redirectUrl || null);
+  const isTimezoneSame = (templateMeta?.timezone || null) === (meta?.timezone || null);
+
+  // Early return to avoid unnecessary updates.
+  if (
+    template.title === data.title &&
+    JSON.stringify(template.authOptions) === JSON.stringify(documentAuthOption) &&
+    isDateSame &&
+    isMessageSame &&
+    isPasswordSame &&
+    isSubjectSame &&
+    isRedirectUrlSame &&
+    isTimezoneSame
+  ) {
+    return template;
+  }
+
+  const documentGlobalAccessAuth = documentAuthOption?.globalAccessAuth ?? null;
+  const documentGlobalActionAuth = documentAuthOption?.globalActionAuth ?? null;
+
+  // If the new global auth values aren't passed in, fallback to the current document values.
+  const newGlobalAccessAuth =
+    data?.globalAccessAuth === undefined ? documentGlobalAccessAuth : data.globalAccessAuth;
+  const newGlobalActionAuth =
+    data?.globalActionAuth === undefined ? documentGlobalActionAuth : data.globalActionAuth;
+
+  // Check if user has permission to set the global action auth.
+  if (newGlobalActionAuth) {
+    const isDocumentEnterprise = await isUserEnterprise({
+      userId,
+      teamId,
+    });
+
+    if (!isDocumentEnterprise) {
+      throw new AppError(
+        AppErrorCode.UNAUTHORIZED,
+        'You do not have permission to set the action auth',
+      );
+    }
+  }
+
+  const authOptions = createDocumentAuthOptions({
+    globalAccessAuth: newGlobalAccessAuth,
+    globalActionAuth: newGlobalActionAuth,
+  });
+
+  return await prisma.template.update({
+    where: {
+      id: templateId,
+    },
+    data: {
+      title: data.title,
+      authOptions,
+      templateMeta: {
+        upsert: {
+          where: {
+            templateId,
+          },
+          create: {
+            ...meta,
+          },
+          update: {
+            ...meta,
+          },
+        },
+      },
+    },
+  });
+};

--- a/packages/lib/server-only/template/update-template-settings.ts
+++ b/packages/lib/server-only/template/update-template-settings.ts
@@ -73,7 +73,8 @@ export const updateTemplateSettings = async ({
   // Early return to avoid unnecessary updates.
   if (
     template.title === data.title &&
-    JSON.stringify(template.authOptions) === JSON.stringify(documentAuthOption) &&
+    data.globalAccessAuth === documentAuthOption.globalAccessAuth &&
+    data.globalActionAuth === documentAuthOption.globalActionAuth &&
     isDateSame &&
     isMessageSame &&
     isPasswordSame &&

--- a/packages/prisma/migrations/20240508150017_add_template_settings/migration.sql
+++ b/packages/prisma/migrations/20240508150017_add_template_settings/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "Template" ADD COLUMN     "authOptions" JSONB;
+
+-- CreateTable
+CREATE TABLE "TemplateMeta" (
+    "id" TEXT NOT NULL,
+    "subject" TEXT,
+    "message" TEXT,
+    "timezone" TEXT DEFAULT 'Etc/UTC',
+    "password" TEXT,
+    "dateFormat" TEXT DEFAULT 'yyyy-MM-dd hh:mm a',
+    "templateId" INTEGER NOT NULL,
+    "redirectUrl" TEXT,
+
+    CONSTRAINT "TemplateMeta_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TemplateMeta_templateId_key" ON "TemplateMeta"("templateId");
+
+-- AddForeignKey
+ALTER TABLE "TemplateMeta" ADD CONSTRAINT "TemplateMeta_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "Template"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -539,15 +539,29 @@ enum TemplateType {
   PRIVATE
 }
 
+model TemplateMeta {
+  id          String   @id @default(cuid())
+  subject     String?
+  message     String?
+  timezone    String?  @default("Etc/UTC") @db.Text
+  password    String?
+  dateFormat  String?  @default("yyyy-MM-dd hh:mm a") @db.Text
+  templateId  Int      @unique
+  template    Template @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  redirectUrl String?
+}
+
 model Template {
-  id                     Int          @id @default(autoincrement())
-  type                   TemplateType @default(PRIVATE)
+  id                     Int           @id @default(autoincrement())
+  type                   TemplateType  @default(PRIVATE)
   title                  String
   userId                 Int
   teamId                 Int?
+  authOptions            Json?
+  templateMeta           TemplateMeta?
   templateDocumentDataId String
-  createdAt              DateTime     @default(now())
-  updatedAt              DateTime     @default(now()) @updatedAt
+  createdAt              DateTime      @default(now())
+  updatedAt              DateTime      @default(now()) @updatedAt
 
   team                 Team?        @relation(fields: [teamId], references: [id], onDelete: Cascade)
   templateDocumentData DocumentData @relation(fields: [templateDocumentDataId], references: [id], onDelete: Cascade)

--- a/packages/prisma/seed/templates.ts
+++ b/packages/prisma/seed/templates.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { prisma } from '..';
+import type { Prisma, User } from '../client';
 import { DocumentDataType, ReadStatus, RecipientRole, SendStatus, SigningStatus } from '../client';
 
 const examplePdf = fs
@@ -12,6 +13,32 @@ type SeedTemplateOptions = {
   title?: string;
   userId: number;
   teamId?: number;
+};
+
+type CreateTemplateOptions = {
+  key?: string | number;
+  createTemplateOptions?: Partial<Prisma.TemplateUncheckedCreateInput>;
+};
+
+export const seedBlankTemplate = async (owner: User, options: CreateTemplateOptions = {}) => {
+  const { key, createTemplateOptions = {} } = options;
+
+  const documentData = await prisma.documentData.create({
+    data: {
+      type: DocumentDataType.BYTES_64,
+      data: examplePdf,
+      initialData: examplePdf,
+    },
+  });
+
+  return await prisma.template.create({
+    data: {
+      title: `[TEST] Template ${key}`,
+      templateDocumentDataId: documentData.id,
+      userId: owner.id,
+      ...createTemplateOptions,
+    },
+  });
 };
 
 export const seedTemplate = async (options: SeedTemplateOptions) => {

--- a/packages/prisma/types/template.ts
+++ b/packages/prisma/types/template.ts
@@ -1,0 +1,19 @@
+import type {
+  DocumentData,
+  Field,
+  Recipient,
+  Template,
+  TemplateMeta,
+} from '@documenso/prisma/client';
+
+export type TemplateWithData = Template & {
+  templateDocumentData?: DocumentData | null;
+  templateMeta?: TemplateMeta | null;
+};
+
+export type TemplateWithDetails = Template & {
+  templateDocumentData: DocumentData;
+  templateMeta: TemplateMeta | null;
+  Recipient: Recipient[];
+  Field: Field[];
+};

--- a/packages/trpc/server/admin-router/router.ts
+++ b/packages/trpc/server/admin-router/router.ts
@@ -102,7 +102,7 @@ export const adminRouter = router({
       try {
         return await sealDocument({ documentId: id, isResealing: true });
       } catch (err) {
-        console.log('resealDocument error', err);
+        console.error('resealDocument error', err);
 
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -123,7 +123,7 @@ export const adminRouter = router({
 
       return await deleteUser({ id });
     } catch (err) {
-      console.log(err);
+      console.error(err);
 
       throw new TRPCError({
         code: 'BAD_REQUEST',
@@ -144,7 +144,7 @@ export const adminRouter = router({
           requestMetadata: extractNextApiRequestMetadata(ctx.req),
         });
       } catch (err) {
-        console.log(err);
+        console.error(err);
 
         throw new TRPCError({
           code: 'BAD_REQUEST',

--- a/packages/trpc/server/field-router/router.ts
+++ b/packages/trpc/server/field-router/router.ts
@@ -53,7 +53,7 @@ export const fieldRouter = router({
       const { templateId, fields } = input;
 
       try {
-        await setFieldsForTemplate({
+        return await setFieldsForTemplate({
           userId: ctx.user.id,
           templateId,
           fields: fields.map((field) => ({

--- a/packages/trpc/server/recipient-router/router.ts
+++ b/packages/trpc/server/recipient-router/router.ts
@@ -46,16 +46,18 @@ export const recipientRouter = router({
     .input(ZAddTemplateSignersMutationSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        const { templateId, signers } = input;
+        const { templateId, signers, teamId } = input;
 
         return await setRecipientsForTemplate({
           userId: ctx.user.id,
+          teamId,
           templateId,
           recipients: signers.map((signer) => ({
             id: signer.nativeId,
             email: signer.email,
             name: signer.name,
             role: signer.role,
+            actionAuth: signer.actionAuth,
           })),
         });
       } catch (err) {

--- a/packages/trpc/server/recipient-router/schema.ts
+++ b/packages/trpc/server/recipient-router/schema.ts
@@ -34,6 +34,7 @@ export type TAddSignersMutationSchema = z.infer<typeof ZAddSignersMutationSchema
 
 export const ZAddTemplateSignersMutationSchema = z
   .object({
+    teamId: z.number().optional(),
     templateId: z.number(),
     signers: z.array(
       z.object({
@@ -41,6 +42,7 @@ export const ZAddTemplateSignersMutationSchema = z
         email: z.string().email().min(1),
         name: z.string(),
         role: z.nativeEnum(RecipientRole),
+        actionAuth: ZRecipientActionAuthTypesSchema.optional().nullable(),
       }),
     ),
   })

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -7,6 +7,8 @@ import { createDocumentFromTemplate } from '@documenso/lib/server-only/template/
 import { createTemplate } from '@documenso/lib/server-only/template/create-template';
 import { deleteTemplate } from '@documenso/lib/server-only/template/delete-template';
 import { duplicateTemplate } from '@documenso/lib/server-only/template/duplicate-template';
+import { getTemplateWithDetailsById } from '@documenso/lib/server-only/template/get-template-with-details-by-id';
+import { updateTemplateSettings } from '@documenso/lib/server-only/template/update-template-settings';
 import { extractNextApiRequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
 import type { Document } from '@documenso/prisma/client';
 
@@ -16,6 +18,8 @@ import {
   ZCreateTemplateMutationSchema,
   ZDeleteTemplateMutationSchema,
   ZDuplicateTemplateMutationSchema,
+  ZGetTemplateWithDetailsByIdQuerySchema,
+  ZUpdateTemplateSettingsMutationSchema,
 } from './schema';
 
 export const templateRouter = router({
@@ -120,6 +124,54 @@ export const templateRouter = router({
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'We were unable to delete this template. Please try again later.',
+        });
+      }
+    }),
+
+  getTemplateWithDetailsById: authenticatedProcedure
+    .input(ZGetTemplateWithDetailsByIdQuerySchema)
+    .query(async ({ input, ctx }) => {
+      try {
+        return await getTemplateWithDetailsById({
+          id: input.id,
+          userId: ctx.user.id,
+        });
+      } catch (err) {
+        console.error(err);
+
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'We were unable to find this template. Please try again later.',
+        });
+      }
+    }),
+
+  // Todo: Add API
+  updateTemplateSettings: authenticatedProcedure
+    .input(ZUpdateTemplateSettingsMutationSchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { templateId, teamId, data, meta } = input;
+
+        const userId = ctx.user.id;
+
+        const requestMetadata = extractNextApiRequestMetadata(ctx.req);
+
+        return await updateTemplateSettings({
+          userId,
+          teamId,
+          templateId,
+          data,
+          meta,
+          requestMetadata,
+        });
+      } catch (err) {
+        console.error(err);
+
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'We were unable to update the settings for this document. Please try again later.',
         });
       }
     }),

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -171,7 +171,7 @@ export const templateRouter = router({
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message:
-            'We were unable to update the settings for this document. Please try again later.',
+            'We were unable to update the settings for this template. Please try again later.',
         });
       }
     }),

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
+import { URL_REGEX } from '@documenso/lib/constants/url-regex';
+import {
+  ZDocumentAccessAuthTypesSchema,
+  ZDocumentActionAuthTypesSchema,
+} from '@documenso/lib/types/document-auth';
+
 export const ZCreateTemplateMutationSchema = z.object({
   title: z.string().min(1).trim(),
   teamId: z.number().optional(),
@@ -33,10 +39,38 @@ export const ZDeleteTemplateMutationSchema = z.object({
   id: z.number().min(1),
 });
 
+export const ZUpdateTemplateSettingsMutationSchema = z.object({
+  templateId: z.number(),
+  teamId: z.number().min(1).optional(),
+  data: z.object({
+    title: z.string().min(1).optional(),
+    globalAccessAuth: ZDocumentAccessAuthTypesSchema.nullable().optional(),
+    globalActionAuth: ZDocumentActionAuthTypesSchema.nullable().optional(),
+  }),
+  meta: z.object({
+    subject: z.string(),
+    message: z.string(),
+    timezone: z.string(),
+    dateFormat: z.string(),
+    redirectUrl: z
+      .string()
+      .optional()
+      .refine((value) => value === undefined || value === '' || URL_REGEX.test(value), {
+        message: 'Please enter a valid URL',
+      }),
+  }),
+});
+
+export const ZGetTemplateWithDetailsByIdQuerySchema = z.object({
+  id: z.number().min(1),
+});
+
 export type TCreateTemplateMutationSchema = z.infer<typeof ZCreateTemplateMutationSchema>;
 export type TCreateDocumentFromTemplateMutationSchema = z.infer<
   typeof ZCreateDocumentFromTemplateMutationSchema
 >;
-
 export type TDuplicateTemplateMutationSchema = z.infer<typeof ZDuplicateTemplateMutationSchema>;
 export type TDeleteTemplateMutationSchema = z.infer<typeof ZDeleteTemplateMutationSchema>;
+export type TGetTemplateWithDetailsByIdQuerySchema = z.infer<
+  typeof ZGetTemplateWithDetailsByIdQuerySchema
+>;

--- a/packages/ui/components/document/document-global-auth-access-select.tsx
+++ b/packages/ui/components/document/document-global-auth-access-select.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+
+import type { SelectProps } from '@radix-ui/react-select';
+import { InfoIcon } from 'lucide-react';
+
+import { DOCUMENT_AUTH_TYPES } from '@documenso/lib/constants/document-auth';
+import { DocumentAccessAuth } from '@documenso/lib/types/document-auth';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@documenso/ui/primitives/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitives/tooltip';
+
+export const DocumentGlobalAuthAccessSelect = forwardRef<HTMLButtonElement, SelectProps>(
+  (props, ref) => (
+    <Select {...props}>
+      <SelectTrigger ref={ref} className="bg-background text-muted-foreground">
+        <SelectValue data-testid="documentAccessSelectValue" placeholder="None" />
+      </SelectTrigger>
+
+      <SelectContent position="popper">
+        {Object.values(DocumentAccessAuth).map((authType) => (
+          <SelectItem key={authType} value={authType}>
+            {DOCUMENT_AUTH_TYPES[authType].value}
+          </SelectItem>
+        ))}
+
+        {/* Note: -1 is remapped in the Zod schema to the required value. */}
+        <SelectItem value={'-1'}>None</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+);
+
+DocumentGlobalAuthAccessSelect.displayName = 'DocumentGlobalAuthAccessSelect';
+
+export const DocumentGlobalAuthAccessTooltip = () => (
+  <Tooltip>
+    <TooltipTrigger>
+      <InfoIcon className="mx-2 h-4 w-4" />
+    </TooltipTrigger>
+
+    <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+      <h2>
+        <strong>Document access</strong>
+      </h2>
+
+      <p>The authentication required for recipients to view the document.</p>
+
+      <ul className="ml-3.5 list-outside list-disc space-y-0.5 py-2">
+        <li>
+          <strong>Require account</strong> - The recipient must be signed in to view the document
+        </li>
+        <li>
+          <strong>None</strong> - The document can be accessed directly by the URL sent to the
+          recipient
+        </li>
+      </ul>
+    </TooltipContent>
+  </Tooltip>
+);

--- a/packages/ui/components/document/document-global-auth-action-select.tsx
+++ b/packages/ui/components/document/document-global-auth-action-select.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+
+import type { SelectProps } from '@radix-ui/react-select';
+import { InfoIcon } from 'lucide-react';
+
+import { DOCUMENT_AUTH_TYPES } from '@documenso/lib/constants/document-auth';
+import { DocumentActionAuth, DocumentAuth } from '@documenso/lib/types/document-auth';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@documenso/ui/primitives/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitives/tooltip';
+
+export const DocumentGlobalAuthActionSelect = forwardRef<HTMLButtonElement, SelectProps>(
+  (props, ref) => (
+    <Select {...props}>
+      <SelectTrigger className="bg-background text-muted-foreground">
+        <SelectValue ref={ref} data-testid="documentActionSelectValue" placeholder="None" />
+      </SelectTrigger>
+
+      <SelectContent position="popper">
+        {Object.values(DocumentActionAuth)
+          .filter((auth) => auth !== DocumentAuth.ACCOUNT)
+          .map((authType) => (
+            <SelectItem key={authType} value={authType}>
+              {DOCUMENT_AUTH_TYPES[authType].value}
+            </SelectItem>
+          ))}
+
+        {/* Note: -1 is remapped in the Zod schema to the required value. */}
+        <SelectItem value={'-1'}>None</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+);
+
+DocumentGlobalAuthActionSelect.displayName = 'DocumentGlobalAuthActionSelect';
+
+export const DocumentGlobalAuthActionTooltip = () => (
+  <Tooltip>
+    <TooltipTrigger>
+      <InfoIcon className="mx-2 h-4 w-4" />
+    </TooltipTrigger>
+
+    <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+      <h2>
+        <strong>Global recipient action authentication</strong>
+      </h2>
+
+      <p>The authentication required for recipients to sign the signature field.</p>
+
+      <p>
+        This can be overriden by setting the authentication requirements directly on each recipient
+        in the next step.
+      </p>
+
+      <ul className="ml-3.5 list-outside list-disc space-y-0.5 py-2">
+        {/* <li>
+          <strong>Require account</strong> - The recipient must be signed in
+        </li> */}
+        <li>
+          <strong>Require passkey</strong> - The recipient must have an account and passkey
+          configured via their settings
+        </li>
+        <li>
+          <strong>Require 2FA</strong> - The recipient must have an account and 2FA enabled via
+          their settings
+        </li>
+        <li>
+          <strong>None</strong> - No authentication required
+        </li>
+      </ul>
+    </TooltipContent>
+  </Tooltip>
+);

--- a/packages/ui/components/document/document-send-email-message-helper.tsx
+++ b/packages/ui/components/document/document-send-email-message-helper.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+
+export const DocumentSendEmailMessageHelper = () => {
+  return (
+    <div>
+      <p className="text-muted-foreground text-sm">
+        You can use the following variables in your message:
+      </p>
+
+      <ul className="mt-2 flex list-inside list-disc flex-col gap-y-2 text-sm">
+        <li className="text-muted-foreground">
+          <code className="text-muted-foreground bg-muted-foreground/20 rounded p-1 text-sm">
+            {'{signer.name}'}
+          </code>{' '}
+          - The signer's name
+        </li>
+        <li className="text-muted-foreground">
+          <code className="text-muted-foreground bg-muted-foreground/20 rounded p-1 text-sm">
+            {'{signer.email}'}
+          </code>{' '}
+          - The signer's email
+        </li>
+        <li className="text-muted-foreground">
+          <code className="text-muted-foreground bg-muted-foreground/20 rounded p-1 text-sm">
+            {'{document.name}'}
+          </code>{' '}
+          - The document's name
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/packages/ui/components/recipient/recipient-role-select.tsx
+++ b/packages/ui/components/recipient/recipient-role-select.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import type { SelectProps } from '@radix-ui/react-select';
 import { InfoIcon } from 'lucide-react';
@@ -12,86 +12,86 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitive
 
 export type RecipientRoleSelectProps = SelectProps;
 
-export const RecipientRoleSelect = (props: RecipientRoleSelectProps) => {
-  return (
-    <Select {...props}>
-      <SelectTrigger className="bg-background w-[60px]">
-        {/* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */}
-        {ROLE_ICONS[props.value as RecipientRole]}
-      </SelectTrigger>
+export const RecipientRoleSelect = forwardRef<HTMLButtonElement, SelectProps>((props, ref) => (
+  <Select {...props}>
+    <SelectTrigger ref={ref} className="bg-background w-[60px]">
+      {/* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */}
+      {ROLE_ICONS[props.value as RecipientRole]}
+    </SelectTrigger>
 
-      <SelectContent align="end">
-        <SelectItem value={RecipientRole.SIGNER}>
-          <div className="flex items-center">
-            <div className="flex w-[150px] items-center">
-              <span className="mr-2">{ROLE_ICONS[RecipientRole.SIGNER]}</span>
-              Needs to sign
-            </div>
-            <Tooltip>
-              <TooltipTrigger>
-                <InfoIcon className="h-4 w-4" />
-              </TooltipTrigger>
-              <TooltipContent className="text-foreground z-9999 max-w-md p-4">
-                <p>The recipient is required to sign the document for it to be completed.</p>
-              </TooltipContent>
-            </Tooltip>
+    <SelectContent align="end">
+      <SelectItem value={RecipientRole.SIGNER}>
+        <div className="flex items-center">
+          <div className="flex w-[150px] items-center">
+            <span className="mr-2">{ROLE_ICONS[RecipientRole.SIGNER]}</span>
+            Needs to sign
           </div>
-        </SelectItem>
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="h-4 w-4" />
+            </TooltipTrigger>
+            <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+              <p>The recipient is required to sign the document for it to be completed.</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </SelectItem>
 
-        <SelectItem value={RecipientRole.APPROVER}>
-          <div className="flex items-center">
-            <div className="flex w-[150px] items-center">
-              <span className="mr-2">{ROLE_ICONS[RecipientRole.APPROVER]}</span>
-              Needs to approve
-            </div>
-            <Tooltip>
-              <TooltipTrigger>
-                <InfoIcon className="h-4 w-4" />
-              </TooltipTrigger>
-              <TooltipContent className="text-foreground z-9999 max-w-md p-4">
-                <p>The recipient is required to approve the document for it to be completed.</p>
-              </TooltipContent>
-            </Tooltip>
+      <SelectItem value={RecipientRole.APPROVER}>
+        <div className="flex items-center">
+          <div className="flex w-[150px] items-center">
+            <span className="mr-2">{ROLE_ICONS[RecipientRole.APPROVER]}</span>
+            Needs to approve
           </div>
-        </SelectItem>
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="h-4 w-4" />
+            </TooltipTrigger>
+            <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+              <p>The recipient is required to approve the document for it to be completed.</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </SelectItem>
 
-        <SelectItem value={RecipientRole.VIEWER}>
-          <div className="flex items-center">
-            <div className="flex w-[150px] items-center">
-              <span className="mr-2">{ROLE_ICONS[RecipientRole.VIEWER]}</span>
-              Needs to view
-            </div>
-            <Tooltip>
-              <TooltipTrigger>
-                <InfoIcon className="h-4 w-4" />
-              </TooltipTrigger>
-              <TooltipContent className="text-foreground z-9999 max-w-md p-4">
-                <p>The recipient is required to view the document for it to be completed.</p>
-              </TooltipContent>
-            </Tooltip>
+      <SelectItem value={RecipientRole.VIEWER}>
+        <div className="flex items-center">
+          <div className="flex w-[150px] items-center">
+            <span className="mr-2">{ROLE_ICONS[RecipientRole.VIEWER]}</span>
+            Needs to view
           </div>
-        </SelectItem>
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="h-4 w-4" />
+            </TooltipTrigger>
+            <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+              <p>The recipient is required to view the document for it to be completed.</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </SelectItem>
 
-        <SelectItem value={RecipientRole.CC}>
-          <div className="flex items-center">
-            <div className="flex w-[150px] items-center">
-              <span className="mr-2">{ROLE_ICONS[RecipientRole.CC]}</span>
-              Receives copy
-            </div>
-            <Tooltip>
-              <TooltipTrigger>
-                <InfoIcon className="h-4 w-4" />
-              </TooltipTrigger>
-              <TooltipContent className="text-foreground z-9999 max-w-md p-4">
-                <p>
-                  The recipient is not required to take any action and receives a copy of the
-                  document after it is completed.
-                </p>
-              </TooltipContent>
-            </Tooltip>
+      <SelectItem value={RecipientRole.CC}>
+        <div className="flex items-center">
+          <div className="flex w-[150px] items-center">
+            <span className="mr-2">{ROLE_ICONS[RecipientRole.CC]}</span>
+            Receives copy
           </div>
-        </SelectItem>
-      </SelectContent>
-    </Select>
-  );
-};
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="h-4 w-4" />
+            </TooltipTrigger>
+            <TooltipContent className="text-foreground z-9999 max-w-md p-4">
+              <p>
+                The recipient is not required to take any action and receives a copy of the document
+                after it is completed.
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </SelectItem>
+    </SelectContent>
+  </Select>
+));
+
+RecipientRoleSelect.displayName = 'RecipientRoleSelect';

--- a/packages/ui/primitives/document-flow/add-subject.tsx
+++ b/packages/ui/primitives/document-flow/add-subject.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import type { Field, Recipient } from '@documenso/prisma/client';
 import { DocumentStatus } from '@documenso/prisma/client';
 import type { DocumentWithData } from '@documenso/prisma/types/document-with-data';
+import { DocumentSendEmailMessageHelper } from '@documenso/ui/components/document/document-send-email-message-helper';
 
 import { FormErrorMessage } from '../form/form-error-message';
 import { Input } from '../input';
@@ -104,32 +105,7 @@ export const AddSubjectFormPartial = ({
               />
             </div>
 
-            <div>
-              <p className="text-muted-foreground text-sm">
-                You can use the following variables in your message:
-              </p>
-
-              <ul className="mt-2 flex list-inside list-disc flex-col gap-y-2 text-sm">
-                <li className="text-muted-foreground">
-                  <code className="text-muted-foreground bg-muted-foreground/20 rounded p-1 text-sm">
-                    {'{signer.name}'}
-                  </code>{' '}
-                  - The signer's name
-                </li>
-                <li className="text-muted-foreground">
-                  <code className="text-muted-foreground bg-muted-foreground/20 rounded p-1 text-sm">
-                    {'{signer.email}'}
-                  </code>{' '}
-                  - The signer's email
-                </li>
-                <li className="text-muted-foreground">
-                  <code className="text-muted-foreground bg-muted-foreground/20 rounded p-1 text-sm">
-                    {'{document.name}'}
-                  </code>{' '}
-                  - The document's name
-                </li>
-              </ul>
-            </div>
+            <DocumentSendEmailMessageHelper />
           </div>
         </div>
       </DocumentFlowFormContainerContent>

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
@@ -26,6 +26,7 @@ import {
   DocumentFlowFormContainerFooter,
   DocumentFlowFormContainerStep,
 } from '../document-flow/document-flow-root';
+import { ShowFieldItem } from '../document-flow/show-field-item';
 import type { DocumentFlowStep } from '../document-flow/types';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../form/form';
 import { useStep } from '../stepper';
@@ -36,15 +37,17 @@ export type AddTemplatePlaceholderRecipientsFormProps = {
   documentFlow: DocumentFlowStep;
   recipients: Recipient[];
   fields: Field[];
-  isTemplateOwnerEnterprise: boolean;
+  isEnterprise: boolean;
+  isDocumentPdfLoaded: boolean;
   onSubmit: (_data: TAddTemplatePlacholderRecipientsFormSchema) => void;
 };
 
 export const AddTemplatePlaceholderRecipientsFormPartial = ({
   documentFlow,
-  isTemplateOwnerEnterprise,
+  isEnterprise,
   recipients,
-  fields: _fields,
+  fields,
+  isDocumentPdfLoaded,
   onSubmit,
 }: AddTemplatePlaceholderRecipientsFormProps) => {
   const initialId = useId();
@@ -144,6 +147,11 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
   return (
     <>
       <DocumentFlowFormContainerContent>
+        {isDocumentPdfLoaded &&
+          fields.map((field, index) => (
+            <ShowFieldItem key={index} field={field} recipients={recipients} />
+          ))}
+
         <AnimateGenericFadeInOut motionKey={showAdvancedSettings ? 'Show' : 'Hide'}>
           <Form {...form}>
             <div className="flex w-full flex-col gap-y-2">
@@ -209,7 +217,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
                     )}
                   />
 
-                  {showAdvancedSettings && isTemplateOwnerEnterprise && (
+                  {showAdvancedSettings && isEnterprise && (
                     <FormField
                       control={form.control}
                       name={`signers.${index}.actionAuth`}
@@ -294,7 +302,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
               </Button>
             </div>
 
-            {!alwaysShowAdvancedSettings && isTemplateOwnerEnterprise && (
+            {!alwaysShowAdvancedSettings && isEnterprise && (
               <div className="mt-4 flex flex-row items-center">
                 <Checkbox
                   id="showAdvancedRecipientSettings"

--- a/packages/ui/primitives/template-flow/add-template-settings.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.tsx
@@ -9,8 +9,8 @@ import { useForm } from 'react-hook-form';
 import { DATE_FORMATS, DEFAULT_DOCUMENT_DATE_FORMAT } from '@documenso/lib/constants/date-formats';
 import { DEFAULT_DOCUMENT_TIME_ZONE, TIME_ZONES } from '@documenso/lib/constants/time-zones';
 import { extractDocumentAuthMethods } from '@documenso/lib/utils/document-auth';
-import { DocumentStatus, type Field, type Recipient, SendStatus } from '@documenso/prisma/client';
-import type { DocumentWithData } from '@documenso/prisma/types/document-with-data';
+import { type Field, type Recipient } from '@documenso/prisma/client';
+import type { TemplateWithData } from '@documenso/prisma/types/template';
 import {
   DocumentGlobalAuthAccessSelect,
   DocumentGlobalAuthAccessTooltip,
@@ -19,6 +19,7 @@ import {
   DocumentGlobalAuthActionSelect,
   DocumentGlobalAuthActionTooltip,
 } from '@documenso/ui/components/document/document-global-auth-action-select';
+import { DocumentSendEmailMessageHelper } from '@documenso/ui/components/document/document-send-email-message-helper';
 import {
   Accordion,
   AccordionContent,
@@ -35,80 +36,73 @@ import {
 } from '@documenso/ui/primitives/form/form';
 
 import { Combobox } from '../combobox';
-import { Input } from '../input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../select';
-import { useStep } from '../stepper';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../tooltip';
-import type { TAddSettingsFormSchema } from './add-settings.types';
-import { ZAddSettingsFormSchema } from './add-settings.types';
 import {
   DocumentFlowFormContainerActions,
   DocumentFlowFormContainerContent,
   DocumentFlowFormContainerFooter,
-  DocumentFlowFormContainerHeader,
   DocumentFlowFormContainerStep,
-} from './document-flow-root';
-import { ShowFieldItem } from './show-field-item';
-import type { DocumentFlowStep } from './types';
+} from '../document-flow/document-flow-root';
+import { ShowFieldItem } from '../document-flow/show-field-item';
+import type { DocumentFlowStep } from '../document-flow/types';
+import { Input } from '../input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../select';
+import { useStep } from '../stepper';
+import { Textarea } from '../textarea';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../tooltip';
+import type { TAddTemplateSettingsFormSchema } from './add-template-settings.types';
+import { ZAddTemplateSettingsFormSchema } from './add-template-settings.types';
 
-export type AddSettingsFormProps = {
+export type AddTemplateSettingsFormProps = {
   documentFlow: DocumentFlowStep;
   recipients: Recipient[];
   fields: Field[];
-  isDocumentEnterprise: boolean;
+  isEnterprise: boolean;
   isDocumentPdfLoaded: boolean;
-  document: DocumentWithData;
-  onSubmit: (_data: TAddSettingsFormSchema) => void;
+  template: TemplateWithData;
+  onSubmit: (_data: TAddTemplateSettingsFormSchema) => void;
 };
 
-export const AddSettingsFormPartial = ({
+export const AddTemplateSettingsFormPartial = ({
   documentFlow,
   recipients,
   fields,
-  isDocumentEnterprise,
+  isEnterprise,
   isDocumentPdfLoaded,
-  document,
+  template,
   onSubmit,
-}: AddSettingsFormProps) => {
+}: AddTemplateSettingsFormProps) => {
   const { documentAuthOption } = extractDocumentAuthMethods({
-    documentAuth: document.authOptions,
+    documentAuth: template.authOptions,
   });
 
-  const form = useForm<TAddSettingsFormSchema>({
-    resolver: zodResolver(ZAddSettingsFormSchema),
+  const form = useForm<TAddTemplateSettingsFormSchema>({
+    resolver: zodResolver(ZAddTemplateSettingsFormSchema),
     defaultValues: {
-      title: document.title,
+      title: template.title,
       globalAccessAuth: documentAuthOption?.globalAccessAuth || undefined,
       globalActionAuth: documentAuthOption?.globalActionAuth || undefined,
       meta: {
-        timezone: document.documentMeta?.timezone ?? DEFAULT_DOCUMENT_TIME_ZONE,
-        dateFormat: document.documentMeta?.dateFormat ?? DEFAULT_DOCUMENT_DATE_FORMAT,
-        redirectUrl: document.documentMeta?.redirectUrl ?? '',
+        subject: template.templateMeta?.subject ?? '',
+        message: template.templateMeta?.message ?? '',
+        timezone: template.templateMeta?.timezone ?? DEFAULT_DOCUMENT_TIME_ZONE,
+        dateFormat: template.templateMeta?.dateFormat ?? DEFAULT_DOCUMENT_DATE_FORMAT,
+        redirectUrl: template.templateMeta?.redirectUrl ?? '',
       },
     },
   });
 
   const { stepIndex, currentStep, totalSteps, previousStep } = useStep();
 
-  const documentHasBeenSent = recipients.some(
-    (recipient) => recipient.sendStatus === SendStatus.SENT,
-  );
-
   // We almost always want to set the timezone to the user's local timezone to avoid confusion
   // when the document is signed.
   useEffect(() => {
-    if (!form.formState.touchedFields.meta?.timezone && !documentHasBeenSent) {
+    if (!form.formState.touchedFields.meta?.timezone) {
       form.setValue('meta.timezone', Intl.DateTimeFormat().resolvedOptions().timeZone);
     }
-  }, [documentHasBeenSent, form, form.setValue, form.formState.touchedFields.meta?.timezone]);
+  }, [form, form.setValue, form.formState.touchedFields.meta?.timezone]);
 
   return (
     <>
-      <DocumentFlowFormContainerHeader
-        title={documentFlow.title}
-        description={documentFlow.description}
-      />
-
       <DocumentFlowFormContainerContent>
         {isDocumentPdfLoaded &&
           fields.map((field, index) => (
@@ -125,14 +119,10 @@ export const AddSettingsFormPartial = ({
               name="title"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel required>Title</FormLabel>
+                  <FormLabel required>Template title</FormLabel>
 
                   <FormControl>
-                    <Input
-                      className="bg-background"
-                      {...field}
-                      disabled={document.status !== DocumentStatus.DRAFT || field.disabled}
-                    />
+                    <Input className="bg-background" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -156,7 +146,7 @@ export const AddSettingsFormPartial = ({
               )}
             />
 
-            {isDocumentEnterprise && (
+            {isEnterprise && (
               <FormField
                 control={form.control}
                 name="globalActionAuth"
@@ -175,14 +165,64 @@ export const AddSettingsFormPartial = ({
               />
             )}
 
-            <Accordion type="multiple" className="mt-6">
+            <Accordion type="multiple">
+              <AccordionItem value="email-options" className="border-none">
+                <AccordionTrigger className="text-foreground rounded border px-3 py-2 text-left hover:bg-neutral-200/30 hover:no-underline">
+                  Email Options
+                </AccordionTrigger>
+
+                <AccordionContent className="text-muted-foreground -mx-1 px-1 pt-4 text-sm leading-relaxed [&>div]:pb-0">
+                  <div className="flex flex-col space-y-6">
+                    <FormField
+                      control={form.control}
+                      name="meta.subject"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            Subject <span className="text-muted-foreground">(Optional)</span>
+                          </FormLabel>
+
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="meta.message"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            Message <span className="text-muted-foreground">(Optional)</span>
+                          </FormLabel>
+
+                          <FormControl>
+                            <Textarea className="bg-background h-32 resize-none" {...field} />
+                          </FormControl>
+
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <DocumentSendEmailMessageHelper />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+
+            <Accordion type="multiple">
               <AccordionItem value="advanced-options" className="border-none">
-                <AccordionTrigger className="text-foreground mb-2 rounded border px-3 py-2 text-left hover:bg-neutral-200/30 hover:no-underline">
+                <AccordionTrigger className="text-foreground rounded border px-3 py-2 text-left hover:bg-neutral-200/30 hover:no-underline">
                   Advanced Options
                 </AccordionTrigger>
 
-                <AccordionContent className="text-muted-foreground -mx-1 px-1 pt-2 text-sm leading-relaxed">
-                  <div className="flex flex-col space-y-6 ">
+                <AccordionContent className="text-muted-foreground -mx-1 px-1 pt-4 text-sm leading-relaxed">
+                  <div className="flex flex-col space-y-6">
                     <FormField
                       control={form.control}
                       name="meta.dateFormat"
@@ -191,11 +231,7 @@ export const AddSettingsFormPartial = ({
                           <FormLabel>Date Format</FormLabel>
 
                           <FormControl>
-                            <Select
-                              {...field}
-                              onValueChange={field.onChange}
-                              disabled={documentHasBeenSent}
-                            >
+                            <Select {...field} onValueChange={field.onChange}>
                               <SelectTrigger className="bg-background">
                                 <SelectValue />
                               </SelectTrigger>
@@ -228,7 +264,6 @@ export const AddSettingsFormPartial = ({
                               options={TIME_ZONES}
                               {...field}
                               onChange={(value) => value && field.onChange(value)}
-                              disabled={documentHasBeenSent}
                             />
                           </FormControl>
 

--- a/packages/ui/primitives/template-flow/add-template-settings.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.tsx
@@ -260,7 +260,7 @@ export const AddTemplateSettingsFormPartial = ({
 
                           <FormControl>
                             <Combobox
-                              className="bg-background"
+                              className="bg-background time-zone-field"
                               options={TIME_ZONES}
                               {...field}
                               onChange={(value) => value && field.onChange(value)}

--- a/packages/ui/primitives/template-flow/add-template-settings.types.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.types.tsx
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+import { DEFAULT_DOCUMENT_DATE_FORMAT } from '@documenso/lib/constants/date-formats';
+import { DEFAULT_DOCUMENT_TIME_ZONE } from '@documenso/lib/constants/time-zones';
+import { URL_REGEX } from '@documenso/lib/constants/url-regex';
+import {
+  ZDocumentAccessAuthTypesSchema,
+  ZDocumentActionAuthTypesSchema,
+} from '@documenso/lib/types/document-auth';
+
+import { ZMapNegativeOneToUndefinedSchema } from '../document-flow/add-settings.types';
+
+export const ZAddTemplateSettingsFormSchema = z.object({
+  title: z.string().trim().min(1, { message: "Title can't be empty" }),
+  globalAccessAuth: ZMapNegativeOneToUndefinedSchema.pipe(
+    ZDocumentAccessAuthTypesSchema.optional(),
+  ),
+  globalActionAuth: ZMapNegativeOneToUndefinedSchema.pipe(
+    ZDocumentActionAuthTypesSchema.optional(),
+  ),
+  meta: z.object({
+    subject: z.string(),
+    message: z.string(),
+    timezone: z.string().optional().default(DEFAULT_DOCUMENT_TIME_ZONE),
+    dateFormat: z.string().optional().default(DEFAULT_DOCUMENT_DATE_FORMAT),
+    redirectUrl: z
+      .string()
+      .optional()
+      .refine((value) => value === undefined || value === '' || URL_REGEX.test(value), {
+        message: 'Please enter a valid URL',
+      }),
+  }),
+});
+
+export type TAddTemplateSettingsFormSchema = z.infer<typeof ZAddTemplateSettingsFormSchema>;


### PR DESCRIPTION
## Description

General enhancements for templates.

## Changes Made

Added the following changes to the template flow:
- Allow adding document meta settings
- Allow adding email settings
- Allow adding document access & action authentication
- Allow adding recipient action authentication
- Save the state between template steps similar to how it works for documents

Other changes:
- Extract common fields between document and template flows
- Remove the title field from "Use template" since we now have it as part of the template flow

## Testing Performed

Added E2E tests for templates and creating documents from templates