### PR TITLE
fix: direct links for teams are generated wrong

### DIFF
--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -481,7 +481,9 @@ export const createDocumentFromDirectTemplate = async ({
     const emailTemplate = createElement(DocumentCreatedFromDirectTemplateEmailTemplate, {
       recipientName: directRecipientEmail,
       recipientRole: directTemplateRecipient.role,
-      documentLink: `${formatDocumentsPath(document.team?.url)}/${document.id}`,
+      documentLink: `${NEXT_PUBLIC_WEBAPP_URL()}${formatDocumentsPath(document.team?.url)}/${
+        document.id
+      }`,
       documentName: document.title,
       assetBaseUrl: NEXT_PUBLIC_WEBAPP_URL() || 'http://localhost:3000',
     });


### PR DESCRIPTION
use `NEXT_PUBLIC_WEBAPP_URL()` for the base URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with document link generation by incorporating the correct base URL, ensuring links are correctly formatted and functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->