### PR TITLE
feat: automatically set public profile url for OIDC users

### DIFF
--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -77,6 +77,22 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
           });
         }
 
+        // auto set public profile name
+        if (account.provider === 'oidc' && user.name && 'url' in user && !user.url) {
+          let sanitizedPublicUrl = user.name?.replace(' ', '');
+          let counter = 1;
+          while (await prisma.user.findFirst({ where: { url: sanitizedPublicUrl } })) {
+            sanitizedPublicUrl = `${sanitizedPublicUrl}${counter}`;
+            counter++;
+          }
+          await prisma.user.update({
+            where: { id: userId },
+            data: {
+              url: sanitizedPublicUrl,
+            },
+          });
+        }
+
         await prisma.userSecurityAuditLog.create({
           data: {
             userId,

--- a/packages/lib/utils/slugify.ts
+++ b/packages/lib/utils/slugify.ts
@@ -1,0 +1,3 @@
+export * from '@sindresorhus/slugify';
+
+export { default as slugify } from '@sindresorhus/slugify';


### PR DESCRIPTION
## Description
I found the public profile dialog request to be confusing for internal (OIDC) users hence this PR will set the url parameter automatically using the users name. It will remove spaces in the username and will try to find the next available one if the users name is already taken for a public profile. 

This change is based on https://github.com/documenso/documenso/pull/1208 as it contains changes that otherwise would conflict this PR

## Related Issue
-

## Changes Made

Updated the linkAccount functionality to automatically set the user.url property using user.name

## Testing Performed
Tested manually:
* Create new user using OIDC Login 
* Created new user using OIDC Login but user.url already taken


## Checklist
- [X] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [X] I have followed the project's coding style guidelines.
- [X] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

* It should be considered whether the iteration logic for the next free url should be moved to another class/service. 
* It should be considered whether an environment variable should be used as a feature flag for this
* It should be considered whether regex should be used instead of `.replace()`
* Unfortunately the next auth doesnt allow accessing any prism user property like `.url` hence I had to use the workaround of `'url' in user && !user.url` please let me know if there is any better alternative. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced environment variables to control user sign-up and email verification settings.
  - Enhanced account linking with additional parameters for improved user profile management.
  - Automatically generates unique public profile URLs for users upon authentication via the OpenID Connect (OIDC) provider.

- **Configuration**
  - Updated configuration files to include new environment variables `NEXT_PRIVATE_OIDC_ALLOW_SIGNUP` and `NEXT_PRIVATE_OIDC_TRUST_EMAILADDRESSES`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->