### PR TITLE
fix: document creation timezone

### DIFF
--- a/packages/ui/primitives/document-flow/add-settings.tsx
+++ b/packages/ui/primitives/document-flow/add-settings.tsx
@@ -98,8 +98,12 @@ export const AddSettingsFormPartial = ({
   // We almost always want to set the timezone to the user's local timezone to avoid confusion
   // when the document is signed.
   useEffect(() => {
-    if (!form.formState.touchedFields.meta?.timezone && !documentHasBeenSent) {
-      form.setValue('meta.timezone', Intl.DateTimeFormat().resolvedOptions().timeZone);
+    // Check if the timezone field has not been modified and the document hasn't been sent
+    if (!form.formState.dirtyFields.meta?.timezone && !documentHasBeenSent) {
+      // If the timezone is the default timezone, set it to the user's local timezone automatically
+      if (form.getValues('meta.timezone') === DEFAULT_DOCUMENT_TIME_ZONE) {
+        form.setValue('meta.timezone', Intl.DateTimeFormat().resolvedOptions().timeZone);
+      }
     }
   }, [documentHasBeenSent, form, form.setValue, form.formState.touchedFields.meta?.timezone]);
 


### PR DESCRIPTION
The UI sets the timezone to the user's local timezone even when the user selects a specific timezone. It overrides the user's choice.

With this change, it only sets the timezone to the user's local timezone when the default one is `Etc/UTC`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logic for timezone management in the Add Settings form, ensuring user modifications are respected and defaults are set when necessary.
  
- **Bug Fixes**
	- Enhanced checks to prevent unwanted overwrites of user input related to the timezone field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->