### PR TITLE
chore: allow documenso team name for us

### DIFF
--- a/packages/lib/constants/teams.ts
+++ b/packages/lib/constants/teams.ts
@@ -54,7 +54,6 @@ export const PROTECTED_TEAM_URLS = [
   'criminal',
   'dashboard',
   'docs',
-  'documenso',
   'documentation',
   'document',
   'documents',


### PR DESCRIPTION
chore: allow documenso team name for us

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the criteria for protected team URLs, refining access control measures.
  
- **Bug Fixes**
	- Removed an outdated entry from the protected team URLs to enhance security and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->