### PR TITLE
fix: download audit log certificate

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -139,7 +139,11 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
             documentStatus={document.status}
           />
 
-          <DownloadAuditLogButton documentId={document.id} documentUploaderId={document.userId} />
+          <DownloadAuditLogButton
+            teamId={team?.id}
+            documentId={document.id}
+            documentUploaderId={document.id}
+          />
         </div>
       </div>
 

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -139,7 +139,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
             documentStatus={document.status}
           />
 
-          <DownloadAuditLogButton documentId={document.id} />
+          <DownloadAuditLogButton documentId={document.id} documentUploaderId={document.userId} />
         </div>
       </div>
 

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -139,11 +139,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
             documentStatus={document.status}
           />
 
-          <DownloadAuditLogButton
-            teamId={team?.id}
-            documentId={document.id}
-            documentUploaderId={document.userId}
-          />
+          <DownloadAuditLogButton teamId={team?.id} documentId={document.id} />
         </div>
       </div>
 

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -142,7 +142,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
           <DownloadAuditLogButton
             teamId={team?.id}
             documentId={document.id}
-            documentUploaderId={document.id}
+            documentUploaderId={document.userId}
           />
         </div>
       </div>

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
@@ -11,14 +11,12 @@ export type DownloadAuditLogButtonProps = {
   className?: string;
   teamId?: number;
   documentId: number;
-  documentUploaderId?: number;
 };
 
 export const DownloadAuditLogButton = ({
   className,
   teamId,
   documentId,
-  documentUploaderId,
 }: DownloadAuditLogButtonProps) => {
   const { toast } = useToast();
 
@@ -27,7 +25,7 @@ export const DownloadAuditLogButton = ({
 
   const onDownloadAuditLogsClick = async () => {
     try {
-      const { url } = await downloadAuditLogs({ teamId, documentId, documentUploaderId });
+      const { url } = await downloadAuditLogs({ teamId, documentId });
 
       const iframe = Object.assign(document.createElement('iframe'), {
         src: url,

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
@@ -11,7 +11,7 @@ export type DownloadAuditLogButtonProps = {
   className?: string;
   teamId?: number;
   documentId: number;
-  documentUploaderId: number;
+  documentUploaderId?: number;
 };
 
 export const DownloadAuditLogButton = ({

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
@@ -10,9 +10,14 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 export type DownloadAuditLogButtonProps = {
   className?: string;
   documentId: number;
+  documentUploaderId: number;
 };
 
-export const DownloadAuditLogButton = ({ className, documentId }: DownloadAuditLogButtonProps) => {
+export const DownloadAuditLogButton = ({
+  className,
+  documentId,
+  documentUploaderId,
+}: DownloadAuditLogButtonProps) => {
   const { toast } = useToast();
 
   const { mutateAsync: downloadAuditLogs, isLoading } =
@@ -20,7 +25,7 @@ export const DownloadAuditLogButton = ({ className, documentId }: DownloadAuditL
 
   const onDownloadAuditLogsClick = async () => {
     try {
-      const { url } = await downloadAuditLogs({ documentId });
+      const { url } = await downloadAuditLogs({ documentId, documentUploaderId });
 
       const iframe = Object.assign(document.createElement('iframe'), {
         src: url,

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/download-audit-log-button.tsx
@@ -9,12 +9,14 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export type DownloadAuditLogButtonProps = {
   className?: string;
+  teamId?: number;
   documentId: number;
   documentUploaderId: number;
 };
 
 export const DownloadAuditLogButton = ({
   className,
+  teamId,
   documentId,
   documentUploaderId,
 }: DownloadAuditLogButtonProps) => {
@@ -25,7 +27,7 @@ export const DownloadAuditLogButton = ({
 
   const onDownloadAuditLogsClick = async () => {
     try {
-      const { url } = await downloadAuditLogs({ documentId, documentUploaderId });
+      const { url } = await downloadAuditLogs({ teamId, documentId, documentUploaderId });
 
       const iframe = Object.assign(document.createElement('iframe'), {
         src: url,

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -410,7 +410,7 @@ export const documentRouter = router({
 
         const document = await getDocumentById({
           id: documentId,
-          userId: teamId ? documentUploaderId : ctx.user.id,
+          userId: teamId ? Number(documentUploaderId) : ctx.user.id,
           teamId,
         });
 

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -404,13 +404,13 @@ export const documentRouter = router({
 
   downloadAuditLogs: authenticatedProcedure
     .input(ZDownloadAuditLogsMutationSchema)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       try {
         const { documentId, teamId, documentUploaderId } = input;
 
         const document = await getDocumentById({
           id: documentId,
-          userId: documentUploaderId,
+          userId: teamId ? documentUploaderId : ctx.user.id,
           teamId,
         });
 

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -419,7 +419,7 @@ export const documentRouter = router({
           if (document.teamId !== teamId) {
             throw new TRPCError({
               code: 'FORBIDDEN',
-              message: 'fgmYou do not have access to this document.',
+              message: 'You do not have access to this document.',
             });
           }
 

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -29,6 +29,7 @@ import {
   ZCreateDocumentMutationSchema,
   ZDeleteDraftDocumentMutationSchema as ZDeleteDocumentMutationSchema,
   ZDownloadAuditLogsMutationSchema,
+  ZDownloadCertificateMutationSchema,
   ZFindDocumentAuditLogsQuerySchema,
   ZGetDocumentByIdQuerySchema,
   ZGetDocumentByTokenQuerySchema,
@@ -403,13 +404,13 @@ export const documentRouter = router({
 
   downloadAuditLogs: authenticatedProcedure
     .input(ZDownloadAuditLogsMutationSchema)
-    .mutation(async ({ input, ctx }) => {
+    .mutation(async ({ input }) => {
       try {
-        const { documentId, teamId } = input;
+        const { documentId, teamId, documentUploaderId } = input;
 
         const document = await getDocumentById({
           id: documentId,
-          userId: ctx.user.id,
+          userId: documentUploaderId,
           teamId,
         });
 
@@ -433,7 +434,7 @@ export const documentRouter = router({
     }),
 
   downloadCertificate: authenticatedProcedure
-    .input(ZDownloadAuditLogsMutationSchema)
+    .input(ZDownloadCertificateMutationSchema)
     .mutation(async ({ input, ctx }) => {
       try {
         const { documentId, teamId } = input;

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -170,6 +170,12 @@ export const ZSearchDocumentsMutationSchema = z.object({
 export const ZDownloadAuditLogsMutationSchema = z.object({
   documentId: z.number(),
   teamId: z.number().optional(),
+  documentUploaderId: z.number(),
+});
+
+export const ZDownloadCertificateMutationSchema = z.object({
+  documentId: z.number(),
+  teamId: z.number().optional(),
 });
 
 export const ZMoveDocumentsToTeamSchema = z.object({

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -170,7 +170,7 @@ export const ZSearchDocumentsMutationSchema = z.object({
 export const ZDownloadAuditLogsMutationSchema = z.object({
   documentId: z.number(),
   teamId: z.number().optional(),
-  documentUploaderId: z.number(),
+  documentUploaderId: z.number().optional(),
 });
 
 export const ZDownloadCertificateMutationSchema = z.object({

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -170,7 +170,6 @@ export const ZSearchDocumentsMutationSchema = z.object({
 export const ZDownloadAuditLogsMutationSchema = z.object({
   documentId: z.number(),
   teamId: z.number().optional(),
-  documentUploaderId: z.number().optional(),
 });
 
 export const ZDownloadCertificateMutationSchema = z.object({


### PR DESCRIPTION
## Description

Previously, it wasn't possible to download an audit log of a document uploaded by another user because the function used the ID of the user making the request to retrieve the document. However, the document uploaded by another user has that user's ID, not the ID of the user making the request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Download Audit Log button to support team-specific logging, improving audit tracking capabilities.
	- Introduced a new mutation for downloading certificates, expanding document management functionality.

- **Bug Fixes**
	- Updated input handling for the downloadAuditLogs mutation to accurately identify users using documentUploaderId.

- **Documentation**
	- Revised schema definitions to include additional parameters for audit log and certificate downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->