### PR TITLE
fix: support dynamic external ids for direct templates

### DIFF
--- a/apps/web/src/app/(recipient)/d/[token]/direct-template.tsx
+++ b/apps/web/src/app/(recipient)/d/[token]/direct-template.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { RECIPIENT_ROLES_DESCRIPTION } from '@documenso/lib/constants/recipient-roles';
 import type { Field } from '@documenso/prisma/client';
@@ -39,6 +39,7 @@ export const DirectTemplatePageView = ({
   directTemplateToken,
 }: TemplatesDirectPageViewProps) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const { toast } = useToast();
 
@@ -82,8 +83,15 @@ export const DirectTemplatePageView = ({
 
   const onSignDirectTemplateSubmit = async (fields: DirectTemplateLocalField[]) => {
     try {
+      let directTemplateExternalId = searchParams?.get('externalId') || undefined;
+
+      if (directTemplateExternalId) {
+        directTemplateExternalId = decodeURIComponent(directTemplateExternalId);
+      }
+
       const token = await createDocumentFromDirectTemplate({
         directTemplateToken,
+        directTemplateExternalId,
         directRecipientName: fullName,
         directRecipientEmail: recipient.email,
         templateUpdatedAt: template.updatedAt,

--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -44,6 +44,7 @@ export type CreateDocumentFromDirectTemplateOptions = {
   directRecipientName?: string;
   directRecipientEmail: string;
   directTemplateToken: string;
+  directTemplateExternalId?: string;
   signedFieldValues: TSignFieldWithTokenMutationSchema[];
   templateUpdatedAt: Date;
   requestMetadata: RequestMetadata;
@@ -63,6 +64,7 @@ export const createDocumentFromDirectTemplate = async ({
   directRecipientName: initialDirectRecipientName,
   directRecipientEmail,
   directTemplateToken,
+  directTemplateExternalId,
   signedFieldValues,
   templateUpdatedAt,
   requestMetadata,
@@ -227,6 +229,7 @@ export const createDocumentFromDirectTemplate = async ({
         title: template.title,
         createdAt: initialRequestTime,
         status: DocumentStatus.PENDING,
+        externalId: directTemplateExternalId,
         documentDataId: documentData.id,
         authOptions: createDocumentAuthOptions({
           globalAccessAuth: templateAuthOptions.globalAccessAuth,

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -66,6 +66,7 @@ export const templateRouter = router({
           directRecipientName,
           directRecipientEmail,
           directTemplateToken,
+          directTemplateExternalId,
           signedFieldValues,
           templateUpdatedAt,
         } = input;
@@ -76,6 +77,7 @@ export const templateRouter = router({
           directRecipientName,
           directRecipientEmail,
           directTemplateToken,
+          directTemplateExternalId,
           signedFieldValues,
           templateUpdatedAt,
           user: ctx.user

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -20,6 +20,7 @@ export const ZCreateDocumentFromDirectTemplateMutationSchema = z.object({
   directRecipientName: z.string().optional(),
   directRecipientEmail: z.string().email(),
   directTemplateToken: z.string().min(1),
+  directTemplateExternalId: z.string().optional(),
   signedFieldValues: z.array(ZSignFieldWithTokenMutationSchema),
   templateUpdatedAt: z.date(),
 });


### PR DESCRIPTION
## Description

Adds support for an `externalId` query param to be passed when linking a user to a direct template. This external id will then be stored on the document upon signing completion.

## Related Issue

N/A

## Changes Made

- Checks the direct template page for an `externalId` query param and passes it to the `createDocumentFromDirectTemplate` endpoint
- Adds support for an External ID to be added to the `createDocumentFromDirectTemplate` endpoint

## Testing Performed

Created a direct template and passed the externalId query param and verified it was stored on the resulting document.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

N/A