### PR TITLE
fix: changed the default file path for NEXT_PRIVATE_SIGNING_LOCAL_FIL…

### DIFF
--- a/packages/signing/transports/local-cert.ts
+++ b/packages/signing/transports/local-cert.ts
@@ -29,7 +29,9 @@ export const signWithLocalCert = async ({ pdf }: SignWithLocalCertOptions) => {
 
   if (!cert) {
     cert = Buffer.from(
-      fs.readFileSync(process.env.NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH || './example/cert.p12'),
+      fs.readFileSync(
+        process.env.NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH || './opt/documenso/cert.p12',
+      ),
     );
   }
 


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the project for review and inclusion
---

## Description

<!--- Changed the default file path for .env variable NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH from './example/cert.p12' to './opt/documenso/cert.p12'-->
<!--- If NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH is empty the above line will determine the default location -->

## Related Issue

<!--- Fixed #1265  -->

## Changes Made

Changed the default value of NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH env variable

- Change 1
   Replaced './example/cert.p12' with './opt/documenso/cert.p12' in local-cert.ts

## Testing Performed

Tested by leaving the NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH empty and running project. Project run successfully.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
