### PR TITLE
docs: Fix documentation typo regarding the Webhook secret header

### DIFF
--- a/apps/documentation/pages/developers/webhooks.mdx
+++ b/apps/documentation/pages/developers/webhooks.mdx
@@ -37,7 +37,7 @@ To create a new webhook subscription, you need to provide the following informat
 
 - Enter the webhook URL that will receive the event payload.
 - Select the event(s) you want to subscribe to: `document.created`, `document.sent`, `document.opened`, `document.signed`, `document.completed`.
-- Optionally, you can provide a secret key that will be used to sign the payload. This key will be included in the `X-Documenso-Signature` header of the request.
+- Optionally, you can provide a secret key that will be used to sign the payload. This key will be included in the `X-Documenso-Secret` header of the request.
 
 ![A screenshot of the Create Webhook modal that shows the URL input field and the event checkboxes](/webhook-images/webhooks-page-create-webhook-modal.webp)
 


### PR DESCRIPTION
---
name: Fix documentation typo regarding the Webhook secret header
about: Submit changes to the project for review and inclusion
---

## Description

The documentation has inaccurate information about the Webhook security headers. This updates the docs instead of changing the code.

## Related Issue

Could not find any, I discovered while building an integration.

## Changes Made

Changed the documentation about webhook signing secrets. Despite the code to make webhook requests as such, the documentation refers to an `X-Documenso-Signature` header that is nonpresent.

```js
const response = await fetch(url, {
    method: 'POST',
    body: JSON.stringify(payload),
    headers: {
      'Content-Type': 'application/json',
      'X-Documenso-Secret': secret ?? '',
    },
  });
```

## Testing Performed
Docs will compile.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated webhook subscription documentation to reflect a change in header name from `X-Documenso-Signature` to `X-Documenso-Secret` for improved clarity on the use of the secret key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->