### PR TITLE
fix: broken endpoint to update a field in a document

### DIFF
--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -1050,7 +1050,8 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
   updateField: authenticatedMiddleware(async (args, user, team) => {
     const { id: documentId, fieldId } = args.params;
-    const { recipientId, type, pageNumber, pageWidth, pageHeight, pageX, pageY } = args.body;
+    const { recipientId, type, pageNumber, pageWidth, pageHeight, pageX, pageY, fieldMeta } =
+      args.body;
 
     const document = await getDocumentById({
       id: Number(documentId),
@@ -1112,6 +1113,7 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
       pageWidth,
       pageHeight,
       requestMetadata: extractNextApiRequestMetadata(args.req),
+      fieldMeta: fieldMeta ? ZFieldMetaSchema.parse(fieldMeta) : undefined,
     });
 
     const remappedField = {

--- a/packages/lib/server-only/field/update-field.ts
+++ b/packages/lib/server-only/field/update-field.ts
@@ -65,6 +65,11 @@ export const updateField = async ({
     },
   });
 
+  const newFieldMeta = {
+    ...(oldField.fieldMeta as FieldMeta),
+    ...fieldMeta,
+  };
+
   const field = prisma.$transaction(async (tx) => {
     const updatedField = await tx.field.update({
       where: {
@@ -78,12 +83,38 @@ export const updateField = async ({
         positionY: pageY,
         width: pageWidth,
         height: pageHeight,
-        fieldMeta,
+        fieldMeta: newFieldMeta,
       },
       include: {
         Recipient: true,
       },
     });
+
+    const user = await prisma.user.findFirstOrThrow({
+      where: {
+        id: userId,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    });
+
+    let team: Team | null = null;
+
+    if (teamId) {
+      team = await prisma.team.findFirst({
+        where: {
+          id: teamId,
+          members: {
+            some: {
+              userId,
+            },
+          },
+        },
+      });
+    }
 
     await tx.documentAuditLog.create({
       data: createDocumentAuditLogData({
@@ -107,32 +138,6 @@ export const updateField = async ({
 
     return updatedField;
   });
-
-  const user = await prisma.user.findFirstOrThrow({
-    where: {
-      id: userId,
-    },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-    },
-  });
-
-  let team: Team | null = null;
-
-  if (teamId) {
-    team = await prisma.team.findFirst({
-      where: {
-        id: teamId,
-        members: {
-          some: {
-            userId,
-          },
-        },
-      },
-    });
-  }
 
   return field;
 };


### PR DESCRIPTION
## Description

Fixes #1318 and allows to submit a partial `fieldMeta` when updating a field instead of replacing the current `fieldMeta`, to be consistent with other endpoints.

## Related Issue

Fixes #1318

## Changes Made

- Moved some variables higher in the code because they were referenced by code above it, causing the Unauthorized response.
- Actually provided the `fieldMeta` object from the endpoint implementation to the `updateField` function so it can update the database.

## Testing Performed

I tested to patch a field with the following payload: 

```
{
  "recipientId": 3,
  "fieldMeta": {
    "text": "my super text"
  }
}
```

And I observed in the GUI that the text has changed.
Then I tested to patch the exact same field with this payload : 
```
{
  "recipientId": 3,
  "fieldMeta": {
    "label": "my super label"
  }
}
```

And I was able to confirm in the GUI that the text was still `my super text` and the label had been updated to  `my super label`

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `updateField` functionality to accept additional metadata, allowing for more complex data updates.
	- Improved handling of field metadata by merging old and new values during updates.

- **Bug Fixes**
	- Optimized user and team data retrieval by moving it inside the transaction block, ensuring data integrity during field updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->