### PR TITLE
fix: fix `passkeys` page-breaking error 

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/security/passkeys/user-passkeys-data-table.tsx
+++ b/apps/web/src/app/(dashboard)/settings/security/passkeys/user-passkeys-data-table.tsx
@@ -73,7 +73,7 @@ export const UserPasskeysDataTable = () => {
         cell: ({ row }) =>
           row.original.lastUsedAt
             ? DateTime.fromJSDate(row.original.lastUsedAt).toRelative()
-            : msg`Never`,
+            : _(msg`Never`),
       },
       {
         id: 'actions',


### PR DESCRIPTION
## Description

<!--- Describe the changes introduced by this pull request. -->

This PR fixes the bug that was breaking the `Passkeys` page.

<!--- Explain what problem it solves or what feature/fix it adds. -->

## Related Issue

fixes: #1347 

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

## Changes Made

Changed `` msg `Never` `` to `` `_(msg`Never`)` `` So that `columns` don't take it as an object (that can't be passed directly to a react component.)

## Testing Performed

Here is how this change fixed the problem :


https://github.com/user-attachments/assets/cbbbade7-608a-49da-9273-cf657d0ae8ae



## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced internationalization support for the "Never" message in the User Passkeys Data Table, improving localization based on user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->