### PR TITLE
fix: add check for invalid locales

### DIFF
--- a/packages/lib/utils/i18n.ts
+++ b/packages/lib/utils/i18n.ts
@@ -90,8 +90,18 @@ export const extractLocaleData = ({
     lang = 'en';
   }
 
+  // Filter out locales that are not valid.
+  const locales = (langHeader?.locales ?? []).filter((locale) => {
+    try {
+      new Intl.Locale(locale);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
   return {
     lang: lang || APP_I18N_OPTIONS.sourceLang,
-    locales: langHeader.locales,
+    locales,
   };
 };


### PR DESCRIPTION
## Description

Currently invalid or missing `accept-language` headers will cause issues rendering Plural components since we do not validate them.

This adds a check to try filter out invalid locales.

## Testing Performed

TBD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced locale filtering process to ensure only valid locales are processed.
  
- **Bug Fixes**
	- Improved data integrity by preventing invalid locales from affecting application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->