### PR TITLE
fix: external id null for documents created from templates

### DIFF
--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -1,8 +1,9 @@
 import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
-import type { DocumentSigningOrder, Field } from '@documenso/prisma/client';
 import {
+  DocumentSigningOrder,
   DocumentSource,
+  type Field,
   type Recipient,
   RecipientRole,
   SendStatus,
@@ -34,7 +35,6 @@ export type CreateDocumentFromTemplateResponse = Awaited<
 
 export type CreateDocumentFromTemplateOptions = {
   templateId: number;
-  externalId?: string | null;
   userId: number;
   teamId?: number;
   recipients: {
@@ -62,7 +62,6 @@ export type CreateDocumentFromTemplateOptions = {
 
 export const createDocumentFromTemplate = async ({
   templateId,
-  externalId,
   userId,
   teamId,
   recipients,
@@ -153,7 +152,7 @@ export const createDocumentFromTemplate = async ({
     const document = await tx.document.create({
       data: {
         source: DocumentSource.TEMPLATE,
-        externalId,
+        externalId: template.externalId,
         templateId: template.id,
         userId,
         teamId: template.teamId,
@@ -172,7 +171,9 @@ export const createDocumentFromTemplate = async ({
             dateFormat: override?.dateFormat || template.templateMeta?.dateFormat,
             redirectUrl: override?.redirectUrl || template.templateMeta?.redirectUrl,
             signingOrder:
-              override?.signingOrder || template.templateMeta?.signingOrder || undefined,
+              override?.signingOrder ||
+              template.templateMeta?.signingOrder ||
+              DocumentSigningOrder.PARALLEL,
           },
         },
         Recipient: {

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -35,6 +35,7 @@ export type CreateDocumentFromTemplateResponse = Awaited<
 
 export type CreateDocumentFromTemplateOptions = {
   templateId: number;
+  externalId?: string | null;
   userId: number;
   teamId?: number;
   recipients: {
@@ -62,6 +63,7 @@ export type CreateDocumentFromTemplateOptions = {
 
 export const createDocumentFromTemplate = async ({
   templateId,
+  externalId,
   userId,
   teamId,
   recipients,
@@ -152,7 +154,7 @@ export const createDocumentFromTemplate = async ({
     const document = await tx.document.create({
       data: {
         source: DocumentSource.TEMPLATE,
-        externalId: template.externalId,
+        externalId: externalId || template.externalId,
         templateId: template.id,
         userId,
         teamId: template.teamId,

--- a/packages/lib/server-only/template/update-template-settings.ts
+++ b/packages/lib/server-only/template/update-template-settings.ts
@@ -100,7 +100,7 @@ export const updateTemplateSettings = async ({
     },
     data: {
       title: data.title,
-      externalId: data.externalId || null,
+      externalId: data.externalId,
       type: data.type,
       publicDescription: data.publicDescription,
       publicTitle: data.publicTitle,

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -101,7 +101,7 @@ export const templateRouter = router({
     .input(ZCreateDocumentFromTemplateMutationSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        const { templateId, teamId } = input;
+        const { templateId, teamId, recipients } = input;
 
         const limits = await getServerLimits({ email: ctx.user.email, teamId });
 
@@ -115,7 +115,7 @@ export const templateRouter = router({
           templateId,
           teamId,
           userId: ctx.user.id,
-          recipients: input.recipients,
+          recipients,
           requestMetadata,
         });
 

--- a/packages/ui/primitives/document-flow/add-settings.tsx
+++ b/packages/ui/primitives/document-flow/add-settings.tsx
@@ -95,7 +95,7 @@ export const AddSettingsFormPartial = ({
           TIME_ZONES.find((timezone) => timezone === document.documentMeta?.timezone) ??
           DEFAULT_DOCUMENT_TIME_ZONE,
         dateFormat:
-          DATE_FORMATS.find((format) => format.label === document.documentMeta?.dateFormat)
+          DATE_FORMATS.find((format) => format.value === document.documentMeta?.dateFormat)
             ?.value ?? DEFAULT_DOCUMENT_DATE_FORMAT,
         redirectUrl: document.documentMeta?.redirectUrl ?? '',
       },


### PR DESCRIPTION
Fix #1282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document creation by improving default handling for `externalId` and `signingOrder`.
	- Added a `recipients` property to mutation input in the template router for improved functionality.
  
- **Bug Fixes**
	- Updated logic in `updateTemplateSettings` to correctly handle `externalId` assignment without defaulting to `null`.
	- Modified date format selection logic in `AddSettingsFormPartial` for better accuracy.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->