### PR TITLE
fix: set lang cookie expiry

### DIFF
--- a/packages/lib/server-only/i18n/switch-i18n-language.ts
+++ b/packages/lib/server-only/i18n/switch-i18n-language.ts
@@ -4,5 +4,8 @@ import { cookies } from 'next/headers';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const switchI18NLanguage = async (lang: string) => {
-  cookies().set('language', lang);
+  // Two year expiry.
+  const maxAge = 60 * 60 * 24 * 365 * 2;
+
+  cookies().set('language', lang, { maxAge });
 };


### PR DESCRIPTION
## Description

Currently the language cookie is set to session, so restarting browser will reset it.

This sets the expiry for two years.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced language preference functionality with extended cookie lifespan for improved user experience.
  
- **Bug Fixes**
	- Resolved issues related to cookie expiration for language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->