### PR TITLE
fix: dateformat bug

### DIFF
--- a/packages/ui/primitives/document-flow/add-settings.tsx
+++ b/packages/ui/primitives/document-flow/add-settings.tsx
@@ -95,7 +95,7 @@ export const AddSettingsFormPartial = ({
           TIME_ZONES.find((timezone) => timezone === document.documentMeta?.timezone) ??
           DEFAULT_DOCUMENT_TIME_ZONE,
         dateFormat:
-          DATE_FORMATS.find((format) => format.label === document.documentMeta?.dateFormat)
+          DATE_FORMATS.find((format) => format.value === document.documentMeta?.dateFormat)
             ?.value ?? DEFAULT_DOCUMENT_DATE_FORMAT,
         redirectUrl: document.documentMeta?.redirectUrl ?? '',
       },


### PR DESCRIPTION
## Description

It used the wrong property for finding the document's dateFormat in the `DATE_FORMATS` array.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved date format selection in the settings form to ensure accurate formatting based on value.
	- Default timezone now automatically set to the user's local timezone for better user experience.

- **Bug Fixes**
	- Corrected initialization of the timezone field to enhance form accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->