### PR TITLE
fix: show the full count of documents

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/documents-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/documents-page-view.tsx
@@ -135,10 +135,7 @@ export const DocumentsPageView = async ({ searchParams = {}, team }: DocumentsPa
                     <DocumentStatus status={value} />
 
                     {value !== ExtendedDocumentStatus.ALL && (
-                      <span className="ml-1 inline-block opacity-50">
-                        {Math.min(stats[value], 99)}
-                        {stats[value] > 99 && '+'}
-                      </span>
+                      <span className="ml-1 inline-block opacity-50">{stats[value]}</span>
                     )}
                   </Link>
                 </TabsTrigger>


### PR DESCRIPTION
![doc-count](https://github.com/user-attachments/assets/aad4fe92-e2d8-4b78-ac93-5f6ada73b03a)

A client requested it, and it makes sense showing the full count.

This is how it was before.

![CleanShot 2024-10-04 at 08 47 16@2x](https://github.com/user-attachments/assets/bd4c97a5-1805-4faa-bae7-feeb932ed614)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated document status tab counts to display actual numbers without capping at 99 or using '+' symbols.

- **Bug Fixes**
	- Improved clarity and accuracy of document status counts in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->