### PR TITLE
fix: update publish workfow to only tag stable versions latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,22 +89,26 @@ jobs:
           APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
           GIT_SHA="$(git rev-parse HEAD)"
 
-          docker manifest create \
-            documenso/documenso:latest \
-            --amend documenso/documenso-amd64:latest \
-            --amend documenso/documenso-arm64:latest \
+          # Check if the version is stable (no rc or beta in the version)
+          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            docker manifest create \
+              documenso/documenso:latest \
+              --amend documenso/documenso-amd64:latest \
+              --amend documenso/documenso-arm64:latest
+
+            docker manifest push documenso/documenso:latest
+          fi
 
           docker manifest create \
             documenso/documenso:$GIT_SHA \
             --amend documenso/documenso-amd64:$GIT_SHA \
-            --amend documenso/documenso-arm64:$GIT_SHA \
+            --amend documenso/documenso-arm64:$GIT_SHA
 
           docker manifest create \
             documenso/documenso:$APP_VERSION \
             --amend documenso/documenso-amd64:$APP_VERSION \
-            --amend documenso/documenso-arm64:$APP_VERSION \
+            --amend documenso/documenso-arm64:$APP_VERSION
 
-          docker manifest push documenso/documenso:latest
           docker manifest push documenso/documenso:$GIT_SHA
           docker manifest push documenso/documenso:$APP_VERSION
 
@@ -113,21 +117,25 @@ jobs:
           APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
           GIT_SHA="$(git rev-parse HEAD)"
 
-          docker manifest create \
-            ghcr.io/documenso/documenso:latest \
-            --amend ghcr.io/documenso/documenso-amd64:latest \
-            --amend ghcr.io/documenso/documenso-arm64:latest \
+          # Check if the version is stable (no rc or beta in the version)
+          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            docker manifest create \
+              ghcr.io/documenso/documenso:latest \
+              --amend ghcr.io/documenso/documenso-amd64:latest \
+              --amend ghcr.io/documenso/documenso-arm64:latest
+
+            docker manifest push ghcr.io/documenso/documenso:latest
+          fi
 
           docker manifest create \
             ghcr.io/documenso/documenso:$GIT_SHA \
             --amend ghcr.io/documenso/documenso-amd64:$GIT_SHA \
-            --amend ghcr.io/documenso/documenso-arm64:$GIT_SHA \
+            --amend ghcr.io/documenso/documenso-arm64:$GIT_SHA
 
           docker manifest create \
             ghcr.io/documenso/documenso:$APP_VERSION \
             --amend ghcr.io/documenso/documenso-amd64:$APP_VERSION \
-            --amend ghcr.io/documenso/documenso-arm64:$APP_VERSION \
+            --amend ghcr.io/documenso/documenso-arm64:$APP_VERSION
 
-          docker manifest push ghcr.io/documenso/documenso:latest
           docker manifest push ghcr.io/documenso/documenso:$GIT_SHA
           docker manifest push ghcr.io/documenso/documenso:$APP_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
             docker manifest push documenso/documenso:latest
           fi
 
-          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.rc-[0-9]+$ ]]; then
+          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
             docker manifest create \
               documenso/documenso:rc \
               --amend documenso/documenso-amd64:rc \
@@ -136,7 +136,7 @@ jobs:
             docker manifest push ghcr.io/documenso/documenso:latest
           fi
 
-          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.rc-[0-9]+$ ]]; then
+          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
             docker manifest create \
               ghcr.io/documenso/documenso:rc \
               --amend ghcr.io/documenso/documenso-amd64:rc \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker
 
 on:
   push:
-    branches: ['release']
+    branches: ["release"]
 
 jobs:
   build_and_publish_platform_containers:
@@ -99,6 +99,15 @@ jobs:
             docker manifest push documenso/documenso:latest
           fi
 
+          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.rc-[0-9]+$ ]]; then
+            docker manifest create \
+              documenso/documenso:rc \
+              --amend documenso/documenso-amd64:rc \
+              --amend documenso/documenso-arm64:rc
+
+            docker manifest push documenso/documenso:rc
+          fi
+
           docker manifest create \
             documenso/documenso:$GIT_SHA \
             --amend documenso/documenso-amd64:$GIT_SHA \
@@ -125,6 +134,15 @@ jobs:
               --amend ghcr.io/documenso/documenso-arm64:latest
 
             docker manifest push ghcr.io/documenso/documenso:latest
+          fi
+
+          if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.rc-[0-9]+$ ]]; then
+            docker manifest create \
+              ghcr.io/documenso/documenso:rc \
+              --amend ghcr.io/documenso/documenso-amd64:rc \
+              --amend ghcr.io/documenso/documenso-arm64:rc
+
+            docker manifest push ghcr.io/documenso/documenso:rc
           fi
 
           docker manifest create \


### PR DESCRIPTION
## Description

This pull request introduces modifications to the GitHub Actions workflow to ensure that the `latest` Docker tag is only pushed for stable releases. It prevents the `latest` tag from being assigned to release candidates (`-rc`), beta versions, or other pre-release tags. This enhancement improves version management by keeping the `latest` tag reserved exclusively for fully stable versions (e.g., `1.0.0`).

## Related Issue

Fixes #1404

## Changes Made

- Added a conditional check to verify if the release version follows the format `X.Y.Z` (stable release format).
- Updated the Docker manifest creation steps to only push the `latest` tag if the version is a stable full release.
- Modified both DockerHub and GitHub Container Registry push steps to reflect the new versioning conditions.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved GitHub Actions workflow for publishing Docker images by adding a stability check for the `latest` tag.
	- Removed redundant lines to ensure the `latest` tag is only pushed for stable application versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->