### PR TITLE
fix: trigger webhook when a direct link signer signs a document

### DIFF
--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -540,23 +540,6 @@ export const createDocumentFromDirectTemplate = async ({
       text: render(emailTemplate, { plainText: true }),
     });
 
-    const updatedDocument = await tx.document.findFirstOrThrow({
-      where: {
-        id: document.id,
-      },
-      include: {
-        documentData: true,
-        Recipient: true,
-      },
-    });
-
-    await triggerWebhook({
-      event: WebhookTriggerEvents.DOCUMENT_SIGNED,
-      data: updatedDocument,
-      userId: document.userId,
-      teamId: document.teamId ?? undefined,
-    });
-
     return {
       token: createdDirectRecipient.token,
       documentId: document.id,
@@ -571,6 +554,23 @@ export const createDocumentFromDirectTemplate = async ({
       userId: template.userId,
       teamId: template.teamId || undefined,
       requestMetadata,
+    });
+
+    const updatedDocument = await prisma.document.findFirstOrThrow({
+      where: {
+        id: documentId,
+      },
+      include: {
+        documentData: true,
+        Recipient: true,
+      },
+    });
+
+    await triggerWebhook({
+      event: WebhookTriggerEvents.DOCUMENT_SIGNED,
+      data: updatedDocument,
+      userId: updatedDocument.userId,
+      teamId: updatedDocument.teamId ?? undefined,
     });
   } catch (err) {
     console.error('[CREATE_DOCUMENT_FROM_DIRECT_TEMPLATE]:', err);

--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -540,14 +540,22 @@ export const createDocumentFromDirectTemplate = async ({
       text: render(emailTemplate, { plainText: true }),
     });
 
-    if (user?.id) {
-      await triggerWebhook({
-        event: WebhookTriggerEvents.DOCUMENT_SIGNED,
-        data: document,
-        userId: user.id,
-        teamId: document.teamId ?? undefined,
-      });
-    }
+    const updatedDocument = await tx.document.findFirstOrThrow({
+      where: {
+        id: document.id,
+      },
+      include: {
+        documentData: true,
+        Recipient: true,
+      },
+    });
+
+    await triggerWebhook({
+      event: WebhookTriggerEvents.DOCUMENT_SIGNED,
+      data: updatedDocument,
+      userId: document.userId,
+      teamId: document.teamId ?? undefined,
+    });
 
     return {
       token: createdDirectRecipient.token,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced document creation process with webhook integration for document signing events.
	- Automatic retrieval of updated documents post-creation, including associated data.

- **Bug Fixes**
	- Improved handling of document data and associated recipient information during the creation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->