### PR TITLE
feat: add team user management endpoints to api

### DIFF
--- a/packages/api/v1/contract.ts
+++ b/packages/api/v1/contract.ts
@@ -16,6 +16,7 @@ import {
   ZGenerateDocumentFromTemplateMutationSchema,
   ZGetDocumentsQuerySchema,
   ZGetTemplatesQuerySchema,
+  ZInviteTeamMemberMutationSchema,
   ZNoBodyMutationSchema,
   ZResendDocumentForSigningMutationSchema,
   ZSendDocumentForSigningMutationSchema,
@@ -26,13 +27,17 @@ import {
   ZSuccessfulGetDocumentResponseSchema,
   ZSuccessfulGetTemplateResponseSchema,
   ZSuccessfulGetTemplatesResponseSchema,
+  ZSuccessfulInviteTeamMemberResponseSchema,
   ZSuccessfulRecipientResponseSchema,
+  ZSuccessfulRemoveTeamMemberResponseSchema,
   ZSuccessfulResendDocumentResponseSchema,
   ZSuccessfulResponseSchema,
   ZSuccessfulSigningResponseSchema,
+  ZSuccessfulUpdateTeamMemberResponseSchema,
   ZUnsuccessfulResponseSchema,
   ZUpdateFieldMutationSchema,
   ZUpdateRecipientMutationSchema,
+  ZUpdateTeamMemberMutationSchema,
 } from './schema';
 
 const c = initContract();
@@ -272,6 +277,61 @@ export const ApiContractV1 = c.router(
         500: ZUnsuccessfulResponseSchema,
       },
       summary: 'Delete a field from a document',
+    },
+
+    findTeamMembers: {
+      method: 'GET',
+      path: '/api/v1/team/:id/members',
+      responses: {
+        200: ZFindTeamMembersResponseSchema,
+        400: ZUnsuccessfulResponseSchema,
+        401: ZUnsuccessfulResponseSchema,
+        404: ZUnsuccessfulResponseSchema,
+        500: ZUnsuccessfulResponseSchema,
+      },
+      summary: 'List team members',
+    },
+
+    inviteTeamMember: {
+      method: 'POST',
+      path: '/api/v1/team/:id/members/invite',
+      body: ZInviteTeamMemberMutationSchema,
+      responses: {
+        200: ZSuccessfulInviteTeamMemberResponseSchema,
+        400: ZUnsuccessfulResponseSchema,
+        401: ZUnsuccessfulResponseSchema,
+        404: ZUnsuccessfulResponseSchema,
+        500: ZUnsuccessfulResponseSchema,
+      },
+      summary: 'Invite a member to a team',
+    },
+
+    updateTeamMember: {
+      method: 'PUT',
+      path: '/api/v1/team/:id/members/:memberId',
+      body: ZUpdateTeamMemberMutationSchema,
+      responses: {
+        200: ZSuccessfulUpdateTeamMemberResponseSchema,
+        400: ZUnsuccessfulResponseSchema,
+        401: ZUnsuccessfulResponseSchema,
+        404: ZUnsuccessfulResponseSchema,
+        500: ZUnsuccessfulResponseSchema,
+      },
+      summary: 'Update a team member',
+    },
+
+    removeTeamMember: {
+      method: 'DELETE',
+      path: '/api/v1/team/:id/members/:memberId',
+      body: null,
+      responses: {
+        200: ZSuccessfulRemoveTeamMemberResponseSchema,
+        400: ZUnsuccessfulResponseSchema,
+        401: ZUnsuccessfulResponseSchema,
+        404: ZUnsuccessfulResponseSchema,
+        500: ZUnsuccessfulResponseSchema,
+      },
+      summary: 'Remove a member from a team',
     },
   },
   {

--- a/packages/api/v1/contract.ts
+++ b/packages/api/v1/contract.ts
@@ -12,6 +12,7 @@ import {
   ZDeleteFieldMutationSchema,
   ZDeleteRecipientMutationSchema,
   ZDownloadDocumentSuccessfulSchema,
+  ZFindTeamMembersResponseSchema,
   ZGenerateDocumentFromTemplateMutationResponseSchema,
   ZGenerateDocumentFromTemplateMutationSchema,
   ZGetDocumentsQuerySchema,

--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -1434,7 +1434,7 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
       };
     }
 
-    const member = await prisma.teamMember.findUnique({
+    const member = await prisma.teamMember.findFirst({
       where: {
         id: Number(memberId),
         teamId: team.id,

--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -51,7 +51,12 @@ import {
 } from '@documenso/lib/universal/upload/server-actions';
 import { createDocumentAuditLogData } from '@documenso/lib/utils/document-audit-logs';
 import { prisma } from '@documenso/prisma';
-import { DocumentDataType, DocumentStatus, SigningStatus } from '@documenso/prisma/client';
+import {
+  DocumentDataType,
+  DocumentStatus,
+  SigningStatus,
+  TeamMemberRole,
+} from '@documenso/prisma/client';
 
 import { ApiContractV1 } from './contract';
 import { authenticatedMiddleware } from './middleware/authenticated';
@@ -1287,9 +1292,25 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
     if (team?.id !== Number(teamId)) {
       return {
-        status: 400,
+        status: 403,
         body: {
-          message: 'You must use the correct team api token for the provided team id.',
+          message: 'You are not authorized to perform actions against this team.',
+        },
+      };
+    }
+
+    const self = await prisma.teamMember.findFirst({
+      where: {
+        userId: user.id,
+        teamId: team.id,
+      },
+    });
+
+    if (self?.role !== TeamMemberRole.ADMIN) {
+      return {
+        status: 403,
+        body: {
+          message: 'You are not authorized to perform actions against this team.',
         },
       };
     }
@@ -1322,15 +1343,32 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
     if (team?.id !== Number(teamId)) {
       return {
-        status: 400,
+        status: 403,
         body: {
-          message: 'You must use the correct team api token for the provided team id.',
+          message: 'You are not authorized to perform actions against this team.',
+        },
+      };
+    }
+
+    const self = await prisma.teamMember.findFirst({
+      where: {
+        userId: user.id,
+        teamId: team.id,
+      },
+    });
+
+    if (self?.role !== TeamMemberRole.ADMIN) {
+      return {
+        status: 403,
+        body: {
+          message: 'You are not authorized to perform actions against this team.',
         },
       };
     }
 
     const hasAlreadyBeenInvited = await prisma.teamMember.findFirst({
       where: {
+        teamId: team.id,
         user: {
           email,
         },
@@ -1373,9 +1411,25 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
     if (team?.id !== Number(teamId)) {
       return {
-        status: 400,
+        status: 403,
         body: {
-          message: 'You must use the correct team api token for the provided team id.',
+          message: 'You are not authorized to perform actions against this team.',
+        },
+      };
+    }
+
+    const self = await prisma.teamMember.findFirst({
+      where: {
+        userId: user.id,
+        teamId: team.id,
+      },
+    });
+
+    if (self?.role !== TeamMemberRole.ADMIN) {
+      return {
+        status: 403,
+        body: {
+          message: 'You are not authorized to perform actions against this team.',
         },
       };
     }
@@ -1423,9 +1477,25 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
     if (team?.id !== Number(teamId)) {
       return {
-        status: 400,
+        status: 403,
         body: {
-          message: 'You must use the correct team api token for the provided team id.',
+          message: 'You are not authorized to perform actions against this team.',
+        },
+      };
+    }
+
+    const self = await prisma.teamMember.findFirst({
+      where: {
+        userId: user.id,
+        teamId: team.id,
+      },
+    });
+
+    if (self?.role !== TeamMemberRole.ADMIN) {
+      return {
+        status: 403,
+        body: {
+          message: 'You are not authorized to perform actions against this team.',
         },
       };
     }
@@ -1451,9 +1521,18 @@ export const ApiContractV1Implementation = createNextRoute(ApiContractV1, {
 
     if (team.ownerUserId === member.userId) {
       return {
-        status: 400,
+        status: 403,
         body: {
           message: 'You cannot remove the owner of the team',
+        },
+      };
+    }
+
+    if (member.userId === user.id) {
+      return {
+        status: 403,
+        body: {
+          message: 'You cannot remove yourself from the team',
         },
       };
     }

--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -19,6 +19,7 @@ import {
   RecipientRole,
   SendStatus,
   SigningStatus,
+  TeamMemberRole,
   TemplateType,
 } from '@documenso/prisma/client';
 
@@ -531,4 +532,42 @@ export const ZSuccessfulGetTemplatesResponseSchema = z.object({
 export const ZGetTemplatesQuerySchema = z.object({
   page: z.coerce.number().min(1).optional().default(1),
   perPage: z.coerce.number().min(1).optional().default(1),
+});
+
+export const ZFindTeamMembersResponseSchema = z.object({
+  members: z.array(
+    z.object({
+      id: z.number(),
+      email: z.string().email(),
+      role: z.nativeEnum(TeamMemberRole),
+    }),
+  ),
+});
+
+export const ZInviteTeamMemberMutationSchema = z.object({
+  email: z
+    .string()
+    .email()
+    .transform((email) => email.toLowerCase()),
+  role: z.nativeEnum(TeamMemberRole).optional().default(TeamMemberRole.MEMBER),
+});
+
+export const ZSuccessfulInviteTeamMemberResponseSchema = z.object({
+  message: z.string(),
+});
+
+export const ZUpdateTeamMemberMutationSchema = z.object({
+  role: z.nativeEnum(TeamMemberRole),
+});
+
+export const ZSuccessfulUpdateTeamMemberResponseSchema = z.object({
+  id: z.number(),
+  email: z.string().email(),
+  role: z.nativeEnum(TeamMemberRole),
+});
+
+export const ZSuccessfulRemoveTeamMemberResponseSchema = z.object({
+  id: z.number(),
+  email: z.string().email(),
+  role: z.nativeEnum(TeamMemberRole),
 });

--- a/packages/app-tests/e2e/api/v1/team-user-management.spec.ts
+++ b/packages/app-tests/e2e/api/v1/team-user-management.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  ZFindTeamMembersResponseSchema,
+  ZSuccessfulInviteTeamMemberResponseSchema,
+  ZSuccessfulRemoveTeamMemberResponseSchema,
+  ZSuccessfulUpdateTeamMemberResponseSchema,
+  ZUnsuccessfulResponseSchema,
+} from '@documenso/api/v1/schema';
+import { WEBAPP_BASE_URL } from '@documenso/lib/constants/app';
+import { createApiToken } from '@documenso/lib/server-only/public-api/create-api-token';
+import { prisma } from '@documenso/prisma';
+import { TeamMemberRole } from '@documenso/prisma/client';
+import { seedTeam } from '@documenso/prisma/seed/teams';
+import { seedUser } from '@documenso/prisma/seed/users';
+
+test.describe('Team API', () => {
+  test('findTeamMembers: should list team members', async ({ request }) => {
+    const team = await seedTeam({
+      createTeamMembers: 3,
+    });
+
+    const { token } = await createApiToken({
+      userId: team.owner.id,
+      teamId: team.id,
+      tokenName: 'test',
+      expiresIn: null,
+    });
+
+    const response = await request.get(`${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    const parsed = ZFindTeamMembersResponseSchema.safeParse(data);
+
+    const safeData = parsed.success ? parsed.data : null;
+
+    expect(parsed.success).toBeTruthy();
+
+    expect(safeData!.members).toHaveLength(4); // Owner + 3 members
+    expect(safeData!.members[0]).toHaveProperty('id');
+    expect(safeData!.members[0]).toHaveProperty('email');
+    expect(safeData!.members[0]).toHaveProperty('role');
+
+    expect(safeData!.members).toContainEqual({
+      id: team.owner.id,
+      email: team.owner.email,
+      role: TeamMemberRole.ADMIN,
+    });
+  });
+
+  test('inviteTeamMember: should invite a new team member', async ({ request }) => {
+    const team = await seedTeam();
+
+    const { token } = await createApiToken({
+      userId: team.owner.id,
+      teamId: team.id,
+      tokenName: 'test',
+      expiresIn: null,
+    });
+
+    const newUser = await seedUser();
+
+    const response = await request.post(
+      `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/invite`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        data: {
+          email: newUser.email,
+          role: TeamMemberRole.MEMBER,
+        },
+      },
+    );
+
+    expect(response.ok()).toBeTruthy();
+
+    const data = await response.json();
+
+    const parsed = ZSuccessfulInviteTeamMemberResponseSchema.safeParse(data);
+
+    const safeData = parsed.success ? parsed.data : null;
+
+    expect(parsed.success).toBeTruthy();
+    expect(safeData!.message).toBe('An invite has been sent to the member');
+
+    const invite = await prisma.teamMemberInvite.findFirst({
+      where: {
+        email: newUser.email,
+        teamId: team.id,
+      },
+    });
+
+    expect(invite).toBeTruthy();
+  });
+
+  test('updateTeamMember: should update a team member role', async ({ request }) => {
+    const team = await seedTeam({
+      createTeamMembers: 3,
+    });
+
+    const { token } = await createApiToken({
+      userId: team.owner.id,
+      teamId: team.id,
+      tokenName: 'test',
+      expiresIn: null,
+    });
+
+    const member = team.members.at(-1)!;
+
+    expect(member.role).toBe(TeamMemberRole.MEMBER);
+
+    const response = await request.put(
+      `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${member.id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        data: {
+          role: TeamMemberRole.ADMIN,
+        },
+      },
+    );
+
+    expect(response.ok()).toBeTruthy();
+
+    const data = await response.json();
+
+    const parsed = ZSuccessfulUpdateTeamMemberResponseSchema.safeParse(data);
+
+    const safeData = parsed.success ? parsed.data : null;
+
+    expect(parsed.success).toBeTruthy();
+
+    expect(safeData!.id).toBe(member.id);
+    expect(safeData!.email).toBe(member.user.email);
+    expect(safeData!.role).toBe(TeamMemberRole.ADMIN);
+  });
+
+  test('removeTeamMember: should remove a team member', async ({ request }) => {
+    const team = await seedTeam({
+      createTeamMembers: 3,
+    });
+
+    const { token } = await createApiToken({
+      userId: team.owner.id,
+      teamId: team.id,
+      tokenName: 'test',
+      expiresIn: null,
+    });
+
+    const member = team.members.at(-1)!;
+
+    expect(member.role).toBe(TeamMemberRole.MEMBER);
+
+    const response = await request.delete(
+      `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${member.id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    const parsed = ZSuccessfulRemoveTeamMemberResponseSchema.safeParse(data);
+
+    const safeData = parsed.success ? parsed.data : null;
+
+    expect(parsed.success).toBeTruthy();
+
+    expect(safeData!.id).toBe(member.id);
+    expect(safeData!.email).toBe(member.user.email);
+    expect(safeData!.role).toBe(member.role);
+
+    const removedMemberCount = await prisma.teamMember.count({
+      where: {
+        userId: member.userId,
+        teamId: team.id,
+      },
+    });
+
+    expect(removedMemberCount).toBe(0);
+  });
+
+  test('removeTeamMember: should not remove team owner', async ({ request }) => {
+    const team = await seedTeam({
+      createTeamMembers: 3,
+    });
+
+    const { token } = await createApiToken({
+      userId: team.owner.id,
+      teamId: team.id,
+      tokenName: 'test',
+      expiresIn: null,
+    });
+
+    const response = await request.delete(
+      `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${team.owner.id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(response.status()).toBe(400);
+
+    const parsed = ZUnsuccessfulResponseSchema.safeParse(await response.json());
+
+    expect(parsed.success).toBeTruthy();
+  });
+});

--- a/packages/app-tests/e2e/api/v1/team-user-management.spec.ts
+++ b/packages/app-tests/e2e/api/v1/team-user-management.spec.ts
@@ -20,6 +20,11 @@ test.describe('Team API', () => {
       createTeamMembers: 3,
     });
 
+    const ownerMember = team.members.find((member) => member.userId === team.owner.id)!;
+
+    // Should not be undefined
+    expect(ownerMember).toBeTruthy();
+
     const { token } = await createApiToken({
       userId: team.owner.id,
       teamId: team.id,
@@ -50,9 +55,9 @@ test.describe('Team API', () => {
     expect(safeData!.members[0]).toHaveProperty('role');
 
     expect(safeData!.members).toContainEqual({
-      id: team.owner.id,
-      email: team.owner.email,
-      role: TeamMemberRole.ADMIN,
+      id: ownerMember.id,
+      email: ownerMember.user.email,
+      role: ownerMember.role,
     });
   });
 
@@ -115,9 +120,10 @@ test.describe('Team API', () => {
       expiresIn: null,
     });
 
-    const member = team.members.at(-1)!;
+    const member = team.members.find((member) => member.role === TeamMemberRole.MEMBER)!;
 
-    expect(member.role).toBe(TeamMemberRole.MEMBER);
+    // Should not be undefined
+    expect(member).toBeTruthy();
 
     const response = await request.put(
       `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${member.id}`,
@@ -159,9 +165,10 @@ test.describe('Team API', () => {
       expiresIn: null,
     });
 
-    const member = team.members.at(-1)!;
+    const member = team.members.find((member) => member.role === TeamMemberRole.MEMBER)!;
 
-    expect(member.role).toBe(TeamMemberRole.MEMBER);
+    // Should not be undefined
+    expect(member).toBeTruthy();
 
     const response = await request.delete(
       `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${member.id}`,
@@ -188,7 +195,7 @@ test.describe('Team API', () => {
 
     const removedMemberCount = await prisma.teamMember.count({
       where: {
-        userId: member.userId,
+        id: member.id,
         teamId: team.id,
       },
     });
@@ -208,8 +215,13 @@ test.describe('Team API', () => {
       expiresIn: null,
     });
 
+    const ownerMember = team.members.find((member) => member.userId === team.owner.id)!;
+
+    // Should not be undefined
+    expect(ownerMember).toBeTruthy();
+
     const response = await request.delete(
-      `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${team.owner.id}`,
+      `${WEBAPP_BASE_URL}/api/v1/team/${team.id}/members/${ownerMember.id}`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/packages/app-tests/package.json
+++ b/packages/app-tests/package.json
@@ -5,9 +5,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test:dev": "playwright test",
-    "test-ui:dev": "playwright test --ui",
-    "test:e2e": "start-server-and-test \"npm run start -w @documenso/web\" http://localhost:3000 \"playwright test\""
+    "test:dev": "NODE_OPTIONS=--experimental-require-module playwright test",
+    "test-ui:dev": "NODE_OPTIONS=--experimental-require-module playwright test --ui",
+    "test:e2e": "NODE_OPTIONS=--experimental-require-module start-server-and-test \"npm run start -w @documenso/web\" http://localhost:3000 \"playwright test\""
   },
   "keywords": [],
   "author": "",

--- a/packages/lib/server-only/public-api/create-api-token.ts
+++ b/packages/lib/server-only/public-api/create-api-token.ts
@@ -51,7 +51,7 @@ export const createApiToken = async ({
       name: tokenName,
       token: hashedToken,
       expires: expiresIn ? DateTime.now().plus(timeConstantsRecords[expiresIn]).toJSDate() : null,
-      userId: teamId ? null : userId,
+      userId,
       teamId,
     },
   });

--- a/packages/lib/server-only/public-api/delete-api-token-by-id.ts
+++ b/packages/lib/server-only/public-api/delete-api-token-by-id.ts
@@ -25,8 +25,7 @@ export const deleteTokenById = async ({ id, userId, teamId }: DeleteTokenByIdOpt
   return await prisma.apiToken.delete({
     where: {
       id,
-      userId: teamId ? null : userId,
-      teamId,
+      teamId: teamId ?? null,
     },
   });
 };

--- a/packages/lib/server-only/public-api/get-all-user-tokens.ts
+++ b/packages/lib/server-only/public-api/get-all-user-tokens.ts
@@ -8,6 +8,7 @@ export const getUserTokens = async ({ userId }: GetUserTokensOptions) => {
   return await prisma.apiToken.findMany({
     where: {
       userId,
+      teamId: null,
     },
     select: {
       id: true,

--- a/packages/lib/server-only/public-api/get-api-token-by-token.ts
+++ b/packages/lib/server-only/public-api/get-api-token-by-token.ts
@@ -23,7 +23,8 @@ export const getApiTokenByToken = async ({ token }: { token: string }) => {
     throw new Error('Expired token');
   }
 
-  if (apiToken.team) {
+  // Handle a silly choice from many moons ago
+  if (apiToken.team && !apiToken.user) {
     apiToken.user = await prisma.user.findFirst({
       where: {
         id: apiToken.team.ownerUserId,
@@ -33,9 +34,13 @@ export const getApiTokenByToken = async ({ token }: { token: string }) => {
 
   const { user } = apiToken;
 
+  // This will never happen but we need to narrow types
   if (!user) {
     throw new Error('Invalid token');
   }
 
-  return { ...apiToken, user };
+  return {
+    ...apiToken,
+    user,
+  };
 };

--- a/packages/prisma/seed/teams.ts
+++ b/packages/prisma/seed/teams.ts
@@ -42,7 +42,7 @@ export const seedTeam = async ({
         createMany: {
           data: [teamOwner, ...teamMembers].map((user) => ({
             userId: user.id,
-            role: TeamMemberRole.ADMIN,
+            role: user === teamOwner ? TeamMemberRole.ADMIN : TeamMemberRole.MEMBER,
           })),
         },
       },


### PR DESCRIPTION
## Description

Adds user management capabilities to our current API. Allows for adding, removing, listing and updating members of a given team using a valid API token.

## Related Issue

N/A

## Changes Made

- Added an endpoint for inviting a team member
- Added an endpoint for removing a team member
- Added an endpoint for updating a team member
- Added an endpoint for listing team members

## Testing Performed

Tests were written for this feature request
