### PR TITLE
fix: missing not found page for deleted documents

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/page.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/page.tsx
@@ -43,12 +43,6 @@ export default async function SigningPage({ params: { token } }: SigningPageProp
 
   const requestMetadata = extractNextHeaderRequestMetadata(requestHeaders);
 
-  const isRecipientsTurn = await getIsRecipientsTurnToSign({ token });
-
-  if (!isRecipientsTurn) {
-    return redirect(`/sign/${token}/waiting`);
-  }
-
   const [document, fields, recipient, completedFields] = await Promise.all([
     getDocumentAndSenderByToken({
       token,
@@ -67,6 +61,12 @@ export default async function SigningPage({ params: { token } }: SigningPageProp
     document.status === DocumentStatus.DRAFT
   ) {
     return notFound();
+  }
+
+  const isRecipientsTurn = await getIsRecipientsTurnToSign({ token });
+
+  if (!isRecipientsTurn) {
+    return redirect(`/sign/${token}/waiting`);
   }
 
   const { derivedRecipientAccessAuth } = extractDocumentAuthMethods({


### PR DESCRIPTION
## Description

Resolves #1387 

Currently `getIsRecipientsTurnToSign` throws an error when a document is not found, which causes an unfriendly error on the front-end.

This commit pushes the check to occur after the `notFound` check is run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for determining if it is the recipient's turn to sign, improving the sequence of operations on the signing page.
  
- **Bug Fixes**
	- Retained error handling for unauthorized signing, ensuring users are redirected appropriately.
  
- **Refactor**
	- Adjusted control flow to prioritize data retrieval before evaluating signing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->