### PR TITLE
fix: missing signing order when using templates

### DIFF
--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -10,6 +10,7 @@ import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
 import type { Field, Signature } from '@documenso/prisma/client';
 import {
+  DocumentSigningOrder,
   DocumentSource,
   DocumentStatus,
   FieldType,
@@ -142,6 +143,7 @@ export const createDocumentFromDirectTemplate = async ({
   const metaDateFormat = template.templateMeta?.dateFormat || DEFAULT_DOCUMENT_DATE_FORMAT;
   const metaEmailMessage = template.templateMeta?.message || '';
   const metaEmailSubject = template.templateMeta?.subject || '';
+  const metaSigningOrder = template.templateMeta?.signingOrder || DocumentSigningOrder.PARALLEL;
 
   // Associate, validate and map to a query every direct template recipient field with the provided fields.
   const createDirectRecipientFieldArgs = await Promise.all(
@@ -256,6 +258,7 @@ export const createDocumentFromDirectTemplate = async ({
                   recipient.role === RecipientRole.CC
                     ? SigningStatus.SIGNED
                     : SigningStatus.NOT_SIGNED,
+                signingOrder: recipient.signingOrder,
                 token: nanoid(),
               };
             }),
@@ -267,6 +270,7 @@ export const createDocumentFromDirectTemplate = async ({
             dateFormat: metaDateFormat,
             message: metaEmailMessage,
             subject: metaEmailSubject,
+            signingOrder: metaSigningOrder,
           },
         },
       },
@@ -330,6 +334,7 @@ export const createDocumentFromDirectTemplate = async ({
         signingStatus: SigningStatus.SIGNED,
         sendStatus: SendStatus.SENT,
         signedAt: initialRequestTime,
+        signingOrder: directTemplateRecipient.signingOrder,
         Field: {
           createMany: {
             data: directTemplateNonSignatureFields.map(({ templateField, customText }) => ({

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -24,7 +24,10 @@ import {
 } from '../../utils/document-auth';
 import { triggerWebhook } from '../webhooks/trigger/trigger-webhook';
 
-type FinalRecipient = Pick<Recipient, 'name' | 'email' | 'role' | 'authOptions'> & {
+type FinalRecipient = Pick<
+  Recipient,
+  'name' | 'email' | 'role' | 'authOptions' | 'signingOrder'
+> & {
   templateRecipientId: number;
   fields: Field[];
 };
@@ -197,6 +200,7 @@ export const createDocumentFromTemplate = async ({
                   recipient.role === RecipientRole.CC
                     ? SigningStatus.SIGNED
                     : SigningStatus.NOT_SIGNED,
+                signingOrder: recipient.signingOrder,
                 token: nanoid(),
               };
             }),


### PR DESCRIPTION
## Description

Currently when using a template with the signing sequence enabled, the created document will not have the sequence enabled.

These changes resolves that by passing along the required meta data and recipient data to the created document from the template.

Should resolve #1398 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document creation from templates with a new signing order feature for recipients.
	- Recipients can now have a specified signing order, improving the management of document signing processes.

- **Bug Fixes**
	- Improved error handling for template validity and recipient roles, ensuring a smoother document creation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->