### PR TITLE
feat: add document distribution setting

### DIFF
--- a/apps/web/src/app/(dashboard)/templates/data-table-templates.tsx
+++ b/apps/web/src/app/(dashboard)/templates/data-table-templates.tsx
@@ -145,6 +145,7 @@ export const TemplatesDataTable = ({
               <UseTemplateDialog
                 templateId={row.original.id}
                 templateSigningOrder={row.original.templateMeta?.signingOrder}
+                documentDistributionMethod={row.original.templateMeta?.distributionMethod}
                 recipients={row.original.Recipient}
                 documentRootPath={documentRootPath}
               />

--- a/apps/web/src/app/(dashboard)/templates/use-template-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/templates/use-template-dialog.tsx
@@ -368,8 +368,8 @@ export function UseTemplateDialog({
 
                                   <p className="mt-2">
                                     <Trans>
-                                      We will generate signing links for with you, which you can
-                                      send to the recipients through your method of choice.
+                                      We will generate signing links for you, which you can send to
+                                      the recipients through your method of choice.
                                     </Trans>
                                   </p>
                                 </TooltipContent>

--- a/apps/web/src/app/(dashboard)/templates/use-template-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/templates/use-template-dialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '@documenso/lib/constants/template';
 import { AppError } from '@documenso/lib/errors/app-error';
 import type { Recipient } from '@documenso/prisma/client';
-import { DocumentSigningOrder } from '@documenso/prisma/client';
+import { DocumentDistributionMethod, DocumentSigningOrder } from '@documenso/prisma/client';
 import { trpc } from '@documenso/trpc/react';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
@@ -49,7 +49,7 @@ import { useOptionalCurrentTeam } from '~/providers/team';
 
 const ZAddRecipientsForNewDocumentSchema = z
   .object({
-    sendDocument: z.boolean(),
+    distributeDocument: z.boolean(),
     recipients: z.array(
       z.object({
         id: z.number(),
@@ -93,12 +93,14 @@ export type UseTemplateDialogProps = {
   templateId: number;
   templateSigningOrder?: DocumentSigningOrder | null;
   recipients: Recipient[];
+  documentDistributionMethod?: DocumentDistributionMethod;
   documentRootPath: string;
   trigger?: React.ReactNode;
 };
 
 export function UseTemplateDialog({
   recipients,
+  documentDistributionMethod = DocumentDistributionMethod.EMAIL,
   documentRootPath,
   templateId,
   templateSigningOrder,
@@ -116,7 +118,7 @@ export function UseTemplateDialog({
   const form = useForm<TAddRecipientsForNewDocumentSchema>({
     resolver: zodResolver(ZAddRecipientsForNewDocumentSchema),
     defaultValues: {
-      sendDocument: false,
+      distributeDocument: false,
       recipients: recipients
         .sort((a, b) => (a.signingOrder || 0) - (b.signingOrder || 0))
         .map((recipient) => {
@@ -147,7 +149,7 @@ export function UseTemplateDialog({
         templateId,
         teamId: team?.id,
         recipients: data.recipients,
-        sendDocument: data.sendDocument,
+        distributeDocument: data.distributeDocument,
       });
 
       toast({
@@ -156,7 +158,16 @@ export function UseTemplateDialog({
         duration: 5000,
       });
 
-      router.push(`${documentRootPath}/${id}`);
+      let documentPath = `${documentRootPath}/${id}`;
+
+      if (
+        data.distributeDocument &&
+        documentDistributionMethod === DocumentDistributionMethod.NONE
+      ) {
+        documentPath += '?action=view-signing-links';
+      }
+
+      router.push(documentPath);
     } catch (err) {
       const error = AppError.parseError(err);
 
@@ -295,43 +306,76 @@ export function UseTemplateDialog({
                 <div className="mt-4 flex flex-row items-center">
                   <FormField
                     control={form.control}
-                    name="sendDocument"
+                    name="distributeDocument"
                     render={({ field }) => (
                       <FormItem>
                         <div className="flex flex-row items-center">
                           <Checkbox
-                            id="sendDocument"
+                            id="distributeDocument"
                             className="h-5 w-5"
                             checkClassName="dark:text-white text-primary"
                             checked={field.value}
                             onCheckedChange={field.onChange}
                           />
 
-                          <label
-                            className="text-muted-foreground ml-2 flex items-center text-sm"
-                            htmlFor="sendDocument"
-                          >
-                            <Trans>Send document</Trans>
-                            <Tooltip>
-                              <TooltipTrigger type="button">
-                                <InfoIcon className="mx-1 h-4 w-4" />
-                              </TooltipTrigger>
+                          {documentDistributionMethod === DocumentDistributionMethod.EMAIL && (
+                            <label
+                              className="text-muted-foreground ml-2 flex items-center text-sm"
+                              htmlFor="distributeDocument"
+                            >
+                              <Trans>Send document</Trans>
+                              <Tooltip>
+                                <TooltipTrigger type="button">
+                                  <InfoIcon className="mx-1 h-4 w-4" />
+                                </TooltipTrigger>
 
-                              <TooltipContent className="text-muted-foreground z-[99999] max-w-md space-y-2 p-4">
-                                <p>
-                                  <Trans>
-                                    {' '}
-                                    The document will be immediately sent to recipients if this is
-                                    checked.
-                                  </Trans>
-                                </p>
+                                <TooltipContent className="text-muted-foreground z-[99999] max-w-md space-y-2 p-4">
+                                  <p>
+                                    <Trans>
+                                      The document will be immediately sent to recipients if this is
+                                      checked.
+                                    </Trans>
+                                  </p>
 
-                                <p>
-                                  <Trans>Otherwise, the document will be created as a draft.</Trans>
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </label>
+                                  <p>
+                                    <Trans>
+                                      Otherwise, the document will be created as a draft.
+                                    </Trans>
+                                  </p>
+                                </TooltipContent>
+                              </Tooltip>
+                            </label>
+                          )}
+
+                          {documentDistributionMethod === DocumentDistributionMethod.NONE && (
+                            <label
+                              className="text-muted-foreground ml-2 flex items-center text-sm"
+                              htmlFor="distributeDocument"
+                            >
+                              <Trans>Create as pending</Trans>
+                              <Tooltip>
+                                <TooltipTrigger type="button">
+                                  <InfoIcon className="mx-1 h-4 w-4" />
+                                </TooltipTrigger>
+                                <TooltipContent className="text-muted-foreground z-[99999] max-w-md space-y-2 p-4">
+                                  <p>
+                                    <Trans>Create the document as pending and ready to sign.</Trans>
+                                  </p>
+
+                                  <p>
+                                    <Trans>We won't send anything to notify recipients.</Trans>
+                                  </p>
+
+                                  <p className="mt-2">
+                                    <Trans>
+                                      We will generate signing links for with you, which you can
+                                      send to the recipients through your method of choice.
+                                    </Trans>
+                                  </p>
+                                </TooltipContent>
+                              </Tooltip>
+                            </label>
+                          )}
                         </div>
                       </FormItem>
                     )}
@@ -347,10 +391,12 @@ export function UseTemplateDialog({
                 </DialogClose>
 
                 <Button type="submit" loading={form.formState.isSubmitting}>
-                  {form.getValues('sendDocument') ? (
+                  {!form.getValues('distributeDocument') ? (
+                    <Trans>Create as draft</Trans>
+                  ) : documentDistributionMethod === DocumentDistributionMethod.EMAIL ? (
                     <Trans>Create and send</Trans>
                   ) : (
-                    <Trans>Create as draft</Trans>
+                    <Trans>Create signing links</Trans>
                   )}
                 </Button>
               </DialogFooter>

--- a/packages/app-tests/e2e/document-flow/stepper-component.spec.ts
+++ b/packages/app-tests/e2e/document-flow/stepper-component.spec.ts
@@ -106,7 +106,7 @@ test('[DOCUMENT_FLOW]: should be able to create a document', async ({ page }) =>
   await page.getByRole('button', { name: 'Continue' }).click();
 
   // Add subject and send
-  await expect(page.getByRole('heading', { name: 'Add Subject' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Distribute Document' })).toBeVisible();
   await page.getByRole('button', { name: 'Send' }).click();
 
   await page.waitForURL('/documents');
@@ -190,7 +190,7 @@ test('[DOCUMENT_FLOW]: should be able to create a document with multiple recipie
   await page.getByRole('button', { name: 'Continue' }).click();
 
   // Add subject and send
-  await expect(page.getByRole('heading', { name: 'Add Subject' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Distribute Document' })).toBeVisible();
   await page.getByRole('button', { name: 'Send' }).click();
 
   await page.waitForURL('/documents');
@@ -287,7 +287,7 @@ test('[DOCUMENT_FLOW]: should be able to create a document with multiple recipie
   await page.getByRole('button', { name: 'Continue' }).click();
 
   // Add subject and send
-  await expect(page.getByRole('heading', { name: 'Add Subject' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Distribute Document' })).toBeVisible();
   await page.getByRole('button', { name: 'Send' }).click();
 
   await page.waitForURL('/documents');
@@ -566,7 +566,7 @@ test('[DOCUMENT_FLOW]: should be able to create and sign a document with 3 recip
 
   await page.getByRole('button', { name: 'Continue' }).click();
 
-  await expect(page.getByRole('heading', { name: 'Add Subject' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Distribute Document' })).toBeVisible();
   await page.getByRole('button', { name: 'Send' }).click();
 
   await page.waitForURL('/documents');

--- a/packages/lib/constants/document.ts
+++ b/packages/lib/constants/document.ts
@@ -1,7 +1,7 @@
 import type { MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/macro';
 
-import { DocumentStatus } from '@documenso/prisma/client';
+import { DocumentDistributionMethod, DocumentStatus } from '@documenso/prisma/client';
 
 export const DOCUMENT_STATUS: {
   [status in DocumentStatus]: { description: MessageDescriptor };
@@ -16,3 +16,19 @@ export const DOCUMENT_STATUS: {
     description: msg`Pending`,
   },
 };
+
+type DocumentDistributionMethodTypeData = {
+  value: DocumentDistributionMethod;
+  description: MessageDescriptor;
+};
+
+export const DOCUMENT_DISTRIBUTION_METHODS: Record<string, DocumentDistributionMethodTypeData> = {
+  [DocumentDistributionMethod.EMAIL]: {
+    value: DocumentDistributionMethod.EMAIL,
+    description: msg`Email`,
+  },
+  [DocumentDistributionMethod.NONE]: {
+    value: DocumentDistributionMethod.NONE,
+    description: msg`None`,
+  },
+} satisfies Record<DocumentDistributionMethod, DocumentDistributionMethodTypeData>;

--- a/packages/lib/jobs/definitions/emails/send-signing-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-signing-email.ts
@@ -21,6 +21,7 @@ import {
   RECIPIENT_ROLE_TO_EMAIL_TYPE,
 } from '../../../constants/recipient-roles';
 import { DOCUMENT_AUDIT_LOG_TYPE } from '../../../types/document-audit-logs';
+import { extractDerivedDocumentEmailSettings } from '../../../types/document-email';
 import { ZRequestMetadataSchema } from '../../../universal/extract-request-metadata';
 import { createDocumentAuditLogData } from '../../../utils/document-audit-logs';
 import { renderCustomEmailTemplate } from '../../../utils/render-custom-email-template';
@@ -78,6 +79,14 @@ export const SEND_SIGNING_EMAIL_JOB_DEFINITION = {
     const { documentMeta, team } = document;
 
     if (recipient.role === RecipientRole.CC) {
+      return;
+    }
+
+    const isRecipientSigningRequestEmailEnabled = extractDerivedDocumentEmailSettings(
+      document.documentMeta,
+    ).recipientSigningRequest;
+
+    if (!isRecipientSigningRequestEmailEnabled) {
       return;
     }
 

--- a/packages/lib/server-only/document-meta/upsert-document-meta.ts
+++ b/packages/lib/server-only/document-meta/upsert-document-meta.ts
@@ -7,9 +7,10 @@ import {
   diffDocumentMetaChanges,
 } from '@documenso/lib/utils/document-audit-logs';
 import { prisma } from '@documenso/prisma';
-import type { DocumentSigningOrder } from '@documenso/prisma/client';
+import type { DocumentDistributionMethod, DocumentSigningOrder } from '@documenso/prisma/client';
 
 import type { SupportedLanguageCodes } from '../../constants/i18n';
+import type { TDocumentEmailSettings } from '../../types/document-email';
 
 export type CreateDocumentMetaOptions = {
   documentId: number;
@@ -19,7 +20,9 @@ export type CreateDocumentMetaOptions = {
   password?: string;
   dateFormat?: string;
   redirectUrl?: string;
+  emailSettings?: TDocumentEmailSettings;
   signingOrder?: DocumentSigningOrder;
+  distributionMethod?: DocumentDistributionMethod;
   typedSignatureEnabled?: boolean;
   language?: SupportedLanguageCodes;
   userId: number;
@@ -36,6 +39,8 @@ export const upsertDocumentMeta = async ({
   userId,
   redirectUrl,
   signingOrder,
+  emailSettings,
+  distributionMethod,
   typedSignatureEnabled,
   language,
   requestMetadata,
@@ -88,6 +93,8 @@ export const upsertDocumentMeta = async ({
         documentId,
         redirectUrl,
         signingOrder,
+        emailSettings,
+        distributionMethod,
         typedSignatureEnabled,
         language,
       },
@@ -99,6 +106,8 @@ export const upsertDocumentMeta = async ({
         timezone,
         redirectUrl,
         signingOrder,
+        emailSettings,
+        distributionMethod,
         typedSignatureEnabled,
         language,
       },

--- a/packages/lib/server-only/document/delete-document.ts
+++ b/packages/lib/server-only/document/delete-document.ts
@@ -184,7 +184,7 @@ const handleDocumentOwnerDelete = async ({
   ).documentDeleted;
 
   if (!isDocumentDeleteEmailEnabled) {
-    return deleteDocument;
+    return deletedDocument;
   }
 
   // Send cancellation emails to recipients.

--- a/packages/lib/server-only/document/delete-document.ts
+++ b/packages/lib/server-only/document/delete-document.ts
@@ -14,6 +14,7 @@ import { getI18nInstance } from '../../client-only/providers/i18n.server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../constants/app';
 import { FROM_ADDRESS, FROM_NAME } from '../../constants/email';
 import { DOCUMENT_AUDIT_LOG_TYPE } from '../../types/document-audit-logs';
+import { extractDerivedDocumentEmailSettings } from '../../types/document-email';
 import type { RequestMetadata } from '../../universal/extract-request-metadata';
 import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
 import { renderEmailWithI18N } from '../../utils/render-email-with-i18n';
@@ -177,6 +178,14 @@ const handleDocumentOwnerDelete = async ({
       },
     });
   });
+
+  const isDocumentDeleteEmailEnabled = extractDerivedDocumentEmailSettings(
+    document.documentMeta,
+  ).documentDeleted;
+
+  if (!isDocumentDeleteEmailEnabled) {
+    return deleteDocument;
+  }
 
   // Send cancellation emails to recipients.
   await Promise.all(

--- a/packages/lib/server-only/document/resend-document.tsx
+++ b/packages/lib/server-only/document/resend-document.tsx
@@ -19,6 +19,7 @@ import type { Prisma } from '@documenso/prisma/client';
 
 import { getI18nInstance } from '../../client-only/providers/i18n.server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../constants/app';
+import { extractDerivedDocumentEmailSettings } from '../../types/document-email';
 import { renderEmailWithI18N } from '../../utils/render-email-with-i18n';
 import { getDocumentWhereInput } from './get-document-by-id';
 
@@ -87,6 +88,14 @@ export const resendDocument = async ({
 
   if (document.status === DocumentStatus.COMPLETED) {
     throw new Error('Can not send completed document');
+  }
+
+  const isRecipientSigningRequestEmailEnabled = extractDerivedDocumentEmailSettings(
+    document.documentMeta,
+  ).recipientSigningRequest;
+
+  if (!isRecipientSigningRequestEmailEnabled) {
+    return;
   }
 
   await Promise.all(

--- a/packages/lib/server-only/document/send-delete-email.ts
+++ b/packages/lib/server-only/document/send-delete-email.ts
@@ -8,6 +8,7 @@ import { prisma } from '@documenso/prisma';
 
 import { getI18nInstance } from '../../client-only/providers/i18n.server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../constants/app';
+import { extractDerivedDocumentEmailSettings } from '../../types/document-email';
 import { renderEmailWithI18N } from '../../utils/render-email-with-i18n';
 
 export interface SendDeleteEmailOptions {
@@ -22,11 +23,20 @@ export const sendDeleteEmail = async ({ documentId, reason }: SendDeleteEmailOpt
     },
     include: {
       User: true,
+      documentMeta: true,
     },
   });
 
   if (!document) {
     throw new Error('Document not found');
+  }
+
+  const isDocumentDeletedEmailEnabled = extractDerivedDocumentEmailSettings(
+    document.documentMeta,
+  ).documentDeleted;
+
+  if (!isDocumentDeletedEmailEnabled) {
+    return;
   }
 
   const { email, name } = document.User;

--- a/packages/lib/server-only/document/send-pending-email.ts
+++ b/packages/lib/server-only/document/send-pending-email.ts
@@ -8,6 +8,7 @@ import { prisma } from '@documenso/prisma';
 
 import { getI18nInstance } from '../../client-only/providers/i18n.server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../constants/app';
+import { extractDerivedDocumentEmailSettings } from '../../types/document-email';
 import { renderEmailWithI18N } from '../../utils/render-email-with-i18n';
 
 export interface SendPendingEmailOptions {
@@ -41,6 +42,14 @@ export const sendPendingEmail = async ({ documentId, recipientId }: SendPendingE
 
   if (document.Recipient.length === 0) {
     throw new Error('Document has no recipients');
+  }
+
+  const isDocumentPendingEmailEnabled = extractDerivedDocumentEmailSettings(
+    document.documentMeta,
+  ).documentPending;
+
+  if (!isDocumentPendingEmailEnabled) {
+    return;
   }
 
   const [recipient] = document.Recipient;

--- a/packages/lib/server-only/document/super-delete-document.ts
+++ b/packages/lib/server-only/document/super-delete-document.ts
@@ -13,6 +13,7 @@ import { getI18nInstance } from '../../client-only/providers/i18n.server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../constants/app';
 import { FROM_ADDRESS, FROM_NAME } from '../../constants/email';
 import { DOCUMENT_AUDIT_LOG_TYPE } from '../../types/document-audit-logs';
+import { extractDerivedDocumentEmailSettings } from '../../types/document-email';
 import type { RequestMetadata } from '../../universal/extract-request-metadata';
 import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
 import { renderEmailWithI18N } from '../../utils/render-email-with-i18n';
@@ -40,8 +41,16 @@ export const superDeleteDocument = async ({ id, requestMetadata }: SuperDeleteDo
 
   const { status, User: user } = document;
 
+  const isDocumentDeletedEmailEnabled = extractDerivedDocumentEmailSettings(
+    document.documentMeta,
+  ).documentDeleted;
+
   // if the document is pending, send cancellation emails to all recipients
-  if (status === DocumentStatus.PENDING && document.Recipient.length > 0) {
+  if (
+    status === DocumentStatus.PENDING &&
+    document.Recipient.length > 0 &&
+    isDocumentDeletedEmailEnabled
+  ) {
     await Promise.all(
       document.Recipient.map(async (recipient) => {
         if (recipient.sendStatus !== SendStatus.SENT) {

--- a/packages/lib/server-only/recipient/set-recipients-for-document.ts
+++ b/packages/lib/server-only/recipient/set-recipients-for-document.ts
@@ -26,6 +26,7 @@ import { getI18nInstance } from '../../client-only/providers/i18n.server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../constants/app';
 import { FROM_ADDRESS, FROM_NAME } from '../../constants/email';
 import { AppError, AppErrorCode } from '../../errors/app-error';
+import { extractDerivedDocumentEmailSettings } from '../../types/document-email';
 import { canRecipientBeModified } from '../../utils/recipients';
 import { renderEmailWithI18N } from '../../utils/render-email-with-i18n';
 
@@ -280,10 +281,14 @@ export const setRecipientsForDocument = async ({
       });
     });
 
+    const isRecipientRemovedEmailEnabled = extractDerivedDocumentEmailSettings(
+      document.documentMeta,
+    ).recipientRemoved;
+
     // Send emails to deleted recipients.
     await Promise.all(
       removedRecipients.map(async (recipient) => {
-        if (recipient.sendStatus !== SendStatus.SENT) {
+        if (recipient.sendStatus !== SendStatus.SENT || !isRecipientRemovedEmailEnabled) {
           return;
         }
 

--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -275,6 +275,7 @@ export const createDocumentFromDirectTemplate = async ({
             subject: metaEmailSubject,
             language: metaLanguage,
             signingOrder: metaSigningOrder,
+            distributionMethod: template.templateMeta?.distributionMethod,
           },
         },
       },

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -1,5 +1,6 @@
 import { nanoid } from '@documenso/lib/universal/id';
 import { prisma } from '@documenso/prisma';
+import type { DocumentDistributionMethod } from '@documenso/prisma/client';
 import {
   DocumentSigningOrder,
   DocumentSource,
@@ -62,6 +63,7 @@ export type CreateDocumentFromTemplateOptions = {
     redirectUrl?: string;
     signingOrder?: DocumentSigningOrder;
     language?: SupportedLanguageCodes;
+    distributionMethod?: DocumentDistributionMethod;
   };
   requestMetadata?: RequestMetadata;
 };
@@ -177,6 +179,9 @@ export const createDocumentFromTemplate = async ({
             password: override?.password || template.templateMeta?.password,
             dateFormat: override?.dateFormat || template.templateMeta?.dateFormat,
             redirectUrl: override?.redirectUrl || template.templateMeta?.redirectUrl,
+            distributionMethod:
+              override?.distributionMethod || template.templateMeta?.distributionMethod,
+            emailSettings: template.templateMeta?.emailSettings || undefined,
             signingOrder:
               override?.signingOrder ||
               template.templateMeta?.signingOrder ||

--- a/packages/lib/server-only/template/duplicate-template.ts
+++ b/packages/lib/server-only/template/duplicate-template.ts
@@ -60,7 +60,10 @@ export const duplicateTemplate = async ({
 
   if (template.templateMeta) {
     templateMeta = {
-      create: omit(template.templateMeta, ['id', 'templateId']),
+      create: {
+        ...omit(template.templateMeta, ['id', 'templateId']),
+        emailSettings: template.templateMeta.emailSettings || undefined,
+      },
     };
   }
 

--- a/packages/lib/server-only/template/find-templates.ts
+++ b/packages/lib/server-only/template/find-templates.ts
@@ -54,6 +54,7 @@ export const findTemplates = async ({
         templateMeta: {
           select: {
             signingOrder: true,
+            distributionMethod: true,
           },
         },
         directLink: {

--- a/packages/lib/server-only/template/update-template-settings.ts
+++ b/packages/lib/server-only/template/update-template-settings.ts
@@ -112,9 +112,11 @@ export const updateTemplateSettings = async ({
           },
           create: {
             ...meta,
+            emailSettings: meta?.emailSettings || undefined,
           },
           update: {
             ...meta,
+            emailSettings: meta?.emailSettings || undefined,
           },
         },
       },

--- a/packages/lib/types/document-email.ts
+++ b/packages/lib/types/document-email.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+import type { DocumentMeta } from '@documenso/prisma/client';
+import { DocumentDistributionMethod } from '@documenso/prisma/client';
+
+export enum DocumentEmailEvents {
+  RecipientSigningRequest = 'recipientSigningRequest',
+  RecipientRemoved = 'recipientRemoved',
+  DocumentPending = 'documentPending',
+  DocumentCompleted = 'documentCompleted',
+  DocumentDeleted = 'documentDeleted',
+}
+
+export const ZDocumentEmailSettingsSchema = z
+  .object({
+    recipientSigningRequest: z.boolean().default(true),
+    recipientRemoved: z.boolean().default(true),
+    documentPending: z.boolean().default(true),
+    documentCompleted: z.boolean().default(true),
+    documentDeleted: z.boolean().default(true),
+  })
+  .strip()
+  .catch(() => ({
+    recipientSigningRequest: true,
+    recipientRemoved: true,
+    documentPending: true,
+    documentCompleted: true,
+    documentDeleted: true,
+  }));
+
+export type TDocumentEmailSettings = z.infer<typeof ZDocumentEmailSettingsSchema>;
+
+export const extractDerivedDocumentEmailSettings = (
+  documentMeta?: DocumentMeta | null,
+): TDocumentEmailSettings => {
+  const emailSettings = ZDocumentEmailSettingsSchema.parse(documentMeta?.emailSettings ?? {});
+
+  if (
+    !documentMeta?.distributionMethod ||
+    documentMeta?.distributionMethod === DocumentDistributionMethod.EMAIL
+  ) {
+    return emailSettings;
+  }
+
+  return {
+    recipientSigningRequest: false,
+    recipientRemoved: false,
+    documentPending: false,
+    documentCompleted: false,
+    documentDeleted: false,
+  };
+};

--- a/packages/prisma/migrations/20241107095908_add_document_email_setting/migration.sql
+++ b/packages/prisma/migrations/20241107095908_add_document_email_setting/migration.sql
@@ -1,0 +1,10 @@
+-- CreateEnum
+CREATE TYPE "DocumentDistributionMethod" AS ENUM ('EMAIL', 'NONE');
+
+-- AlterTable
+ALTER TABLE "DocumentMeta" ADD COLUMN     "distributionMethod" "DocumentDistributionMethod" NOT NULL DEFAULT 'EMAIL',
+ADD COLUMN     "emailSettings" JSONB;
+
+-- AlterTable
+ALTER TABLE "TemplateMeta" ADD COLUMN     "distributionMethod" "DocumentDistributionMethod" NOT NULL DEFAULT 'EMAIL',
+ADD COLUMN     "emailSettings" JSONB;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -358,19 +358,26 @@ model DocumentData {
   Template    Template?
 }
 
+enum DocumentDistributionMethod {
+  EMAIL
+  NONE
+}
+
 model DocumentMeta {
-  id                    String               @id @default(cuid())
+  id                    String                     @id @default(cuid())
   subject               String?
   message               String?
-  timezone              String?              @default("Etc/UTC") @db.Text
+  timezone              String?                    @default("Etc/UTC") @db.Text
   password              String?
-  dateFormat            String?              @default("yyyy-MM-dd hh:mm a") @db.Text
-  documentId            Int                  @unique
-  document              Document             @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  dateFormat            String?                    @default("yyyy-MM-dd hh:mm a") @db.Text
+  documentId            Int                        @unique
+  document              Document                   @relation(fields: [documentId], references: [id], onDelete: Cascade)
   redirectUrl           String?
-  signingOrder          DocumentSigningOrder @default(PARALLEL)
-  typedSignatureEnabled Boolean              @default(false)
-  language              String               @default("en")
+  signingOrder          DocumentSigningOrder       @default(PARALLEL)
+  typedSignatureEnabled Boolean                    @default(false)
+  language              String                     @default("en")
+  distributionMethod    DocumentDistributionMethod @default(EMAIL)
+  emailSettings         Json?
 }
 
 enum ReadStatus {
@@ -603,17 +610,19 @@ enum TemplateType {
 }
 
 model TemplateMeta {
-  id           String                @id @default(cuid())
-  subject      String?
-  message      String?
-  timezone     String?               @default("Etc/UTC") @db.Text
-  password     String?
-  dateFormat   String?               @default("yyyy-MM-dd hh:mm a") @db.Text
-  signingOrder DocumentSigningOrder? @default(PARALLEL)
-  templateId   Int                   @unique
-  template     Template              @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  redirectUrl  String?
-  language     String                @default("en")
+  id                 String                     @id @default(cuid())
+  subject            String?
+  message            String?
+  timezone           String?                    @default("Etc/UTC") @db.Text
+  password           String?
+  dateFormat         String?                    @default("yyyy-MM-dd hh:mm a") @db.Text
+  signingOrder       DocumentSigningOrder?      @default(PARALLEL)
+  templateId         Int                        @unique
+  template           Template                   @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  redirectUrl        String?
+  language           String                     @default("en")
+  distributionMethod DocumentDistributionMethod @default(EMAIL)
+  emailSettings      Json?
 }
 
 model Template {

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -413,7 +413,15 @@ export const documentRouter = router({
       try {
         const { documentId, teamId, meta } = input;
 
-        if (meta.message || meta.subject || meta.timezone || meta.dateFormat || meta.redirectUrl) {
+        if (
+          meta.message ||
+          meta.subject ||
+          meta.timezone ||
+          meta.dateFormat ||
+          meta.redirectUrl ||
+          meta.distributionMethod ||
+          meta.emailSettings
+        ) {
           await upsertDocumentMeta({
             documentId,
             subject: meta.subject,
@@ -421,7 +429,9 @@ export const documentRouter = router({
             dateFormat: meta.dateFormat,
             timezone: meta.timezone,
             redirectUrl: meta.redirectUrl,
+            distributionMethod: meta.distributionMethod,
             userId: ctx.user.id,
+            emailSettings: meta.emailSettings,
             requestMetadata: extractNextApiRequestMetadata(ctx.req),
           });
         }

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -5,9 +5,11 @@ import {
   ZDocumentAccessAuthTypesSchema,
   ZDocumentActionAuthTypesSchema,
 } from '@documenso/lib/types/document-auth';
+import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
 import { ZBaseTableSearchParamsSchema } from '@documenso/lib/types/search-params';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
 import {
+  DocumentDistributionMethod,
   DocumentSigningOrder,
   DocumentSource,
   DocumentStatus,
@@ -155,6 +157,7 @@ export const ZSendDocumentMutationSchema = z.object({
     message: z.string(),
     timezone: z.string().optional(),
     dateFormat: z.string().optional(),
+    distributionMethod: z.nativeEnum(DocumentDistributionMethod).optional(),
     redirectUrl: z
       .string()
       .optional()
@@ -162,6 +165,7 @@ export const ZSendDocumentMutationSchema = z.object({
         message:
           'Please enter a valid URL, make sure you include http:// or https:// part of the url.',
       }),
+    emailSettings: ZDocumentEmailSettingsSchema.optional(),
   }),
 });
 

--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -120,7 +120,7 @@ export const templateRouter = router({
           requestMetadata,
         });
 
-        if (input.sendDocument) {
+        if (input.distributeDocument) {
           document = await sendDocument({
             documentId: document.id,
             userId: ctx.user.id,

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -5,9 +5,14 @@ import {
   ZDocumentAccessAuthTypesSchema,
   ZDocumentActionAuthTypesSchema,
 } from '@documenso/lib/types/document-auth';
+import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
 import { ZBaseTableSearchParamsSchema } from '@documenso/lib/types/search-params';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
-import { DocumentSigningOrder, TemplateType } from '@documenso/prisma/client';
+import {
+  DocumentDistributionMethod,
+  DocumentSigningOrder,
+  TemplateType,
+} from '@documenso/prisma/client';
 
 import { ZSignFieldWithTokenMutationSchema } from '../field-router/schema';
 
@@ -41,7 +46,7 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
       const emails = recipients.map((signer) => signer.email);
       return new Set(emails).size === emails.length;
     }, 'Recipients must have unique emails'),
-  sendDocument: z.boolean().optional(),
+  distributeDocument: z.boolean().optional(),
 });
 
 export const ZDuplicateTemplateMutationSchema = z.object({
@@ -99,6 +104,8 @@ export const ZUpdateTemplateSettingsMutationSchema = z.object({
       message: z.string(),
       timezone: z.string(),
       dateFormat: z.string(),
+      distributionMethod: z.nativeEnum(DocumentDistributionMethod),
+      emailSettings: ZDocumentEmailSettingsSchema,
       redirectUrl: z
         .string()
         .optional()

--- a/packages/ui/components/document/document-email-checkboxes.tsx
+++ b/packages/ui/components/document/document-email-checkboxes.tsx
@@ -1,0 +1,222 @@
+import { Trans } from '@lingui/macro';
+import { InfoIcon } from 'lucide-react';
+
+import { DocumentEmailEvents } from '@documenso/lib/types/document-email';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitives/tooltip';
+
+import { cn } from '../../lib/utils';
+import { Checkbox } from '../../primitives/checkbox';
+
+type Value = Record<DocumentEmailEvents, boolean>;
+
+type DocumentEmailCheckboxesProps = {
+  value: Value;
+  onChange: (value: Value) => void;
+  className?: string;
+};
+
+export const DocumentEmailCheckboxes = ({
+  value,
+  onChange,
+  className,
+}: DocumentEmailCheckboxesProps) => {
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="flex flex-row items-center">
+        <Checkbox
+          id={DocumentEmailEvents.RecipientSigningRequest}
+          className="h-5 w-5"
+          checkClassName="dark:text-white text-primary"
+          checked={value.recipientSigningRequest}
+          onCheckedChange={(checked) =>
+            onChange({ ...value, [DocumentEmailEvents.RecipientSigningRequest]: Boolean(checked) })
+          }
+        />
+
+        <label
+          className="text-muted-foreground ml-2 flex flex-row items-center text-sm"
+          htmlFor={DocumentEmailEvents.RecipientSigningRequest}
+        >
+          <Trans>Send recipient signing request email</Trans>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="mx-2 h-4 w-4" />
+            </TooltipTrigger>
+
+            <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+              <h2>
+                <strong>
+                  <Trans>Recipient signing request email</Trans>
+                </strong>
+              </h2>
+
+              <p>
+                <Trans>
+                  This email is sent to the recipient requesting them to sign the document.
+                </Trans>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </label>
+      </div>
+
+      <div className="flex flex-row items-center">
+        <Checkbox
+          id={DocumentEmailEvents.RecipientRemoved}
+          className="h-5 w-5"
+          checkClassName="dark:text-white text-primary"
+          checked={value.recipientRemoved}
+          onCheckedChange={(checked) =>
+            onChange({ ...value, [DocumentEmailEvents.RecipientRemoved]: Boolean(checked) })
+          }
+        />
+
+        <label
+          className="text-muted-foreground ml-2 flex flex-row items-center text-sm"
+          htmlFor={DocumentEmailEvents.RecipientRemoved}
+        >
+          <Trans>Send recipient removed email</Trans>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="mx-2 h-4 w-4" />
+            </TooltipTrigger>
+
+            <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+              <h2>
+                <strong>
+                  <Trans>Recipient removed email</Trans>
+                </strong>
+              </h2>
+
+              <p>
+                <Trans>
+                  This email is sent to the recipient if they are removed from a pending document.
+                </Trans>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </label>
+      </div>
+
+      <div className="flex flex-row items-center">
+        <Checkbox
+          id={DocumentEmailEvents.DocumentPending}
+          className="h-5 w-5"
+          checkClassName="dark:text-white text-primary"
+          checked={value.documentPending}
+          onCheckedChange={(checked) =>
+            onChange({ ...value, [DocumentEmailEvents.DocumentPending]: Boolean(checked) })
+          }
+        />
+
+        <label
+          className="text-muted-foreground ml-2 flex flex-row items-center text-sm"
+          htmlFor={DocumentEmailEvents.DocumentPending}
+        >
+          <Trans>Send document pending email</Trans>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="mx-2 h-4 w-4" />
+            </TooltipTrigger>
+
+            <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+              <h2>
+                <strong>
+                  <Trans>Document pending email</Trans>
+                </strong>
+              </h2>
+
+              <p>
+                <Trans>
+                  This email will be sent to the recipient who has just signed the document, if
+                  there are still other recipients who have not signed yet.
+                </Trans>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </label>
+      </div>
+
+      <div className="flex flex-row items-center">
+        <Checkbox
+          id={DocumentEmailEvents.DocumentCompleted}
+          className="h-5 w-5"
+          checkClassName="dark:text-white text-primary"
+          checked={value.documentCompleted}
+          onCheckedChange={(checked) =>
+            onChange({ ...value, [DocumentEmailEvents.DocumentCompleted]: Boolean(checked) })
+          }
+        />
+
+        <label
+          className="text-muted-foreground ml-2 flex flex-row items-center text-sm"
+          htmlFor={DocumentEmailEvents.DocumentCompleted}
+        >
+          <Trans>Send document completed email</Trans>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="mx-2 h-4 w-4" />
+            </TooltipTrigger>
+
+            <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+              <h2>
+                <strong>
+                  <Trans>Document completed email</Trans>
+                </strong>
+              </h2>
+
+              <p>
+                <Trans>
+                  This will be sent to all recipients once the document has been fully completed.
+                </Trans>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </label>
+      </div>
+
+      <div className="flex flex-row items-center">
+        <Checkbox
+          id={DocumentEmailEvents.DocumentDeleted}
+          className="h-5 w-5"
+          checkClassName="dark:text-white text-primary"
+          checked={value.documentDeleted}
+          onCheckedChange={(checked) =>
+            onChange({ ...value, [DocumentEmailEvents.DocumentDeleted]: Boolean(checked) })
+          }
+        />
+
+        <label
+          className="text-muted-foreground ml-2 flex flex-row items-center text-sm"
+          htmlFor={DocumentEmailEvents.DocumentDeleted}
+        >
+          <Trans>Send document deleted email</Trans>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="mx-2 h-4 w-4" />
+            </TooltipTrigger>
+
+            <TooltipContent className="text-foreground max-w-md space-y-2 p-4">
+              <h2>
+                <strong>
+                  <Trans>Document deleted email</Trans>
+                </strong>
+              </h2>
+
+              <p>
+                <Trans>
+                  This will be sent to all recipients if a pending document has been deleted.
+                </Trans>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/primitives/document-flow/add-subject.tsx
+++ b/packages/ui/primitives/document-flow/add-subject.tsx
@@ -2,18 +2,32 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Trans, msg } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';
 
+import { RECIPIENT_ROLES_DESCRIPTION } from '@documenso/lib/constants/recipient-roles';
+import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
+import { formatSigningLink } from '@documenso/lib/utils/recipients';
 import type { Field, Recipient } from '@documenso/prisma/client';
-import { DocumentStatus } from '@documenso/prisma/client';
+import {
+  DocumentDistributionMethod,
+  DocumentStatus,
+  RecipientRole,
+} from '@documenso/prisma/client';
 import type { DocumentWithData } from '@documenso/prisma/types/document-with-data';
 import { DocumentSendEmailMessageHelper } from '@documenso/ui/components/document/document-send-email-message-helper';
+import { Tabs, TabsList, TabsTrigger } from '@documenso/ui/primitives/tabs';
 
+import { CopyTextButton } from '../../components/common/copy-text-button';
+import { DocumentEmailCheckboxes } from '../../components/document/document-email-checkboxes';
+import { AvatarWithText } from '../avatar';
 import { FormErrorMessage } from '../form/form-error-message';
 import { Input } from '../input';
 import { Label } from '../label';
 import { useStep } from '../stepper';
 import { Textarea } from '../textarea';
+import { toast } from '../use-toast';
 import { type TAddSubjectFormSchema, ZAddSubjectFormSchema } from './add-subject.types';
 import {
   DocumentFlowFormContainerActions,
@@ -42,19 +56,44 @@ export const AddSubjectFormPartial = ({
   onSubmit,
   isDocumentPdfLoaded,
 }: AddSubjectFormProps) => {
+  const { _ } = useLingui();
+
   const {
     register,
     handleSubmit,
+    setValue,
+    watch,
     formState: { errors, isSubmitting },
   } = useForm<TAddSubjectFormSchema>({
     defaultValues: {
       meta: {
         subject: document.documentMeta?.subject ?? '',
         message: document.documentMeta?.message ?? '',
+        distributionMethod:
+          document.documentMeta?.distributionMethod || DocumentDistributionMethod.EMAIL,
+        emailSettings: ZDocumentEmailSettingsSchema.parse(document?.documentMeta?.emailSettings),
       },
     },
     resolver: zodResolver(ZAddSubjectFormSchema),
   });
+
+  const GoNextLabel = {
+    [DocumentDistributionMethod.EMAIL]: {
+      [DocumentStatus.DRAFT]: msg`Send`,
+      [DocumentStatus.PENDING]: recipients.some((recipient) => recipient.sendStatus === 'SENT')
+        ? msg`Resend`
+        : msg`Send`,
+      [DocumentStatus.COMPLETED]: msg`Update`,
+    },
+    [DocumentDistributionMethod.NONE]: {
+      [DocumentStatus.DRAFT]: msg`Generate Links`,
+      [DocumentStatus.PENDING]: msg`View Document`,
+      [DocumentStatus.COMPLETED]: msg`View Document`,
+    },
+  };
+
+  const distributionMethod = watch('meta.distributionMethod');
+  const emailSettings = watch('meta.emailSettings');
 
   const onFormSubmit = handleSubmit(onSubmit);
   const { currentStep, totalSteps, previousStep } = useStep();
@@ -72,46 +111,158 @@ export const AddSubjectFormPartial = ({
               <ShowFieldItem key={index} field={field} recipients={recipients} />
             ))}
 
-          <div className="flex flex-col gap-y-4">
-            <div>
-              <Label htmlFor="subject">
-                <Trans>
-                  Subject <span className="text-muted-foreground">(Optional)</span>
-                </Trans>
-              </Label>
+          <Tabs
+            onValueChange={(value) =>
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              setValue('meta.distributionMethod', value as DocumentDistributionMethod)
+            }
+            value={distributionMethod}
+            className="mb-2"
+          >
+            <TabsList className="w-full">
+              <TabsTrigger className="w-full" value={DocumentDistributionMethod.EMAIL}>
+                Email
+              </TabsTrigger>
+              <TabsTrigger className="w-full" value={DocumentDistributionMethod.NONE}>
+                None
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
 
-              <Input
-                id="subject"
-                className="bg-background mt-2"
-                disabled={isSubmitting}
-                {...register('meta.subject')}
-              />
+          <AnimatePresence mode="wait">
+            {distributionMethod === DocumentDistributionMethod.EMAIL && (
+              <motion.div
+                key={'Emails'}
+                initial={{ opacity: 0, y: 15 }}
+                animate={{ opacity: 1, y: 0, transition: { duration: 0.3 } }}
+                exit={{ opacity: 0, transition: { duration: 0.15 } }}
+                className="flex flex-col gap-y-4 rounded-lg border p-4"
+              >
+                <div>
+                  <Label htmlFor="subject">
+                    <Trans>
+                      Subject <span className="text-muted-foreground">(Optional)</span>
+                    </Trans>
+                  </Label>
 
-              <FormErrorMessage className="mt-2" error={errors.meta?.subject} />
-            </div>
+                  <Input
+                    id="subject"
+                    className="bg-background mt-2"
+                    disabled={isSubmitting}
+                    {...register('meta.subject')}
+                  />
 
-            <div>
-              <Label htmlFor="message">
-                <Trans>
-                  Message <span className="text-muted-foreground">(Optional)</span>
-                </Trans>
-              </Label>
+                  <FormErrorMessage className="mt-2" error={errors.meta?.subject} />
+                </div>
 
-              <Textarea
-                id="message"
-                className="bg-background mt-2 h-32 resize-none"
-                disabled={isSubmitting}
-                {...register('meta.message')}
-              />
+                <div>
+                  <Label htmlFor="message">
+                    <Trans>
+                      Message <span className="text-muted-foreground">(Optional)</span>
+                    </Trans>
+                  </Label>
 
-              <FormErrorMessage
-                className="mt-2"
-                error={typeof errors.meta?.message !== 'string' ? errors.meta?.message : undefined}
-              />
-            </div>
+                  <Textarea
+                    id="message"
+                    className="bg-background mt-2 h-32 resize-none"
+                    disabled={isSubmitting}
+                    {...register('meta.message')}
+                  />
 
-            <DocumentSendEmailMessageHelper />
-          </div>
+                  <FormErrorMessage
+                    className="mt-2"
+                    error={
+                      typeof errors.meta?.message !== 'string' ? errors.meta?.message : undefined
+                    }
+                  />
+                </div>
+
+                <DocumentSendEmailMessageHelper />
+
+                <DocumentEmailCheckboxes
+                  className="mt-2"
+                  value={emailSettings}
+                  onChange={(value) => setValue('meta.emailSettings', value)}
+                />
+              </motion.div>
+            )}
+
+            {distributionMethod === DocumentDistributionMethod.NONE && (
+              <motion.div
+                key={'Links'}
+                initial={{ opacity: 0, y: 15 }}
+                animate={{ opacity: 1, y: 0, transition: { duration: 0.3 } }}
+                exit={{ opacity: 0, transition: { duration: 0.15 } }}
+                className="rounded-lg border"
+              >
+                {document.status === DocumentStatus.DRAFT ? (
+                  <div className="text-muted-foreground py-16 text-center text-sm">
+                    <p>
+                      <Trans>We won't send anything to notify recipients.</Trans>
+                    </p>
+
+                    <p className="mt-2">
+                      <Trans>
+                        We will generate signing links for with you, which you can send to the
+                        recipients through your method of choice.
+                      </Trans>
+                    </p>
+                  </div>
+                ) : (
+                  <ul className="text-muted-foreground divide-y">
+                    {recipients.length === 0 && (
+                      <li className="flex flex-col items-center justify-center py-6 text-sm">
+                        <Trans>No recipients</Trans>
+                      </li>
+                    )}
+
+                    {recipients.map((recipient) => (
+                      <li
+                        key={recipient.id}
+                        className="flex items-center justify-between px-4 py-3 text-sm"
+                      >
+                        <AvatarWithText
+                          avatarFallback={recipient.email.slice(0, 1).toUpperCase()}
+                          primaryText={
+                            <p className="text-muted-foreground text-sm">{recipient.email}</p>
+                          }
+                          secondaryText={
+                            <p className="text-muted-foreground/70 text-xs">
+                              {_(RECIPIENT_ROLES_DESCRIPTION[recipient.role].roleName)}
+                            </p>
+                          }
+                        />
+
+                        {recipient.role !== RecipientRole.CC && (
+                          <CopyTextButton
+                            value={formatSigningLink(recipient.token)}
+                            onCopySuccess={() => {
+                              toast({
+                                title: _(msg`Copied to clipboard`),
+                                description: _(
+                                  msg`The signing link has been copied to your clipboard.`,
+                                ),
+                              });
+                            }}
+                            badgeContentUncopied={
+                              <p className="ml-1 text-xs">
+                                <Trans>Copy</Trans>
+                              </p>
+                            }
+                            badgeContentCopied={
+                              <p className="ml-1 text-xs">
+                                <Trans>Copied</Trans>
+                              </p>
+                            }
+                          />
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </DocumentFlowFormContainerContent>
 
@@ -121,7 +272,7 @@ export const AddSubjectFormPartial = ({
         <DocumentFlowFormContainerActions
           loading={isSubmitting}
           disabled={isSubmitting}
-          goNextLabel={document.status === DocumentStatus.DRAFT ? msg`Send` : msg`Update`}
+          goNextLabel={GoNextLabel[distributionMethod][document.status]}
           onGoBackClick={previousStep}
           onGoNextClick={() => void onFormSubmit()}
         />

--- a/packages/ui/primitives/document-flow/add-subject.tsx
+++ b/packages/ui/primitives/document-flow/add-subject.tsx
@@ -112,8 +112,9 @@ export const AddSubjectFormPartial = ({
             ))}
 
           <Tabs
-            onValueChange={(value: DocumentDistributionMethod) =>
-              setValue('meta.distributionMethod', value)
+            onValueChange={(value) =>
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              setValue('meta.distributionMethod', value as DocumentDistributionMethod)
             }
             value={distributionMethod}
             className="mb-2"

--- a/packages/ui/primitives/document-flow/add-subject.tsx
+++ b/packages/ui/primitives/document-flow/add-subject.tsx
@@ -112,9 +112,8 @@ export const AddSubjectFormPartial = ({
             ))}
 
           <Tabs
-            onValueChange={(value) =>
-              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-              setValue('meta.distributionMethod', value as DocumentDistributionMethod)
+            onValueChange={(value: DocumentDistributionMethod) =>
+              setValue('meta.distributionMethod', value)
             }
             value={distributionMethod}
             className="mb-2"

--- a/packages/ui/primitives/document-flow/add-subject.types.ts
+++ b/packages/ui/primitives/document-flow/add-subject.types.ts
@@ -1,9 +1,18 @@
 import { z } from 'zod';
 
+import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
+
+import { DocumentDistributionMethod } from '.prisma/client';
+
 export const ZAddSubjectFormSchema = z.object({
   meta: z.object({
     subject: z.string(),
     message: z.string(),
+    distributionMethod: z
+      .nativeEnum(DocumentDistributionMethod)
+      .optional()
+      .default(DocumentDistributionMethod.EMAIL),
+    emailSettings: ZDocumentEmailSettingsSchema,
   }),
 });
 

--- a/packages/ui/primitives/template-flow/add-template-settings.types.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.types.tsx
@@ -7,9 +7,11 @@ import {
   ZDocumentAccessAuthTypesSchema,
   ZDocumentActionAuthTypesSchema,
 } from '@documenso/lib/types/document-auth';
+import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
 
 import { ZMapNegativeOneToUndefinedSchema } from '../document-flow/add-settings.types';
+import { DocumentDistributionMethod } from '.prisma/client';
 
 export const ZAddTemplateSettingsFormSchema = z.object({
   title: z.string().trim().min(1, { message: "Title can't be empty" }),
@@ -25,6 +27,10 @@ export const ZAddTemplateSettingsFormSchema = z.object({
     message: z.string(),
     timezone: z.string().optional().default(DEFAULT_DOCUMENT_TIME_ZONE),
     dateFormat: z.string().optional().default(DEFAULT_DOCUMENT_DATE_FORMAT),
+    distributionMethod: z
+      .nativeEnum(DocumentDistributionMethod)
+      .optional()
+      .default(DocumentDistributionMethod.EMAIL),
     redirectUrl: z
       .string()
       .optional()
@@ -36,6 +42,7 @@ export const ZAddTemplateSettingsFormSchema = z.object({
       .union([z.string(), z.enum(SUPPORTED_LANGUAGE_CODES)])
       .optional()
       .default('en'),
+    emailSettings: ZDocumentEmailSettingsSchema,
   }),
 });
 


### PR DESCRIPTION
## Description

Add a document distribution setting which will allow us to further configure how recipients currently receive documents.

## Testing Performed

Tested that templates pass along meta
Tested that created documents from templates pass along meta and follow rules
Tested that created documents from direct templates pass along meta and follow rules
Tested that documents created follow email rules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced document submission process with improved notifications for different distribution methods (Email and Signing Links).
  - Introduced a tabbed interface for selecting document distribution methods in forms.
  - Added a new component for managing document email settings with checkboxes for various email events.
  - New enum for document distribution methods (EMAIL and NONE) added to enhance functionality.
  - Enhanced forms with dynamic rendering based on selected distribution methods, improving user experience.

- **Bug Fixes**
  - Updated email sending logic to ensure emails are sent only when appropriate based on document settings.

- **Documentation**
  - Improved documentation for email settings and document distribution methods.

- **Chores**
  - Added new types and constants to support document distribution features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->