### PR TITLE
fix: certificate translations

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -139,6 +139,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
             className="mr-2"
             documentId={document.id}
             documentStatus={document.status}
+            teamId={team?.id}
           />
 
           <DownloadAuditLogButton teamId={team?.id} documentId={document.id} />

--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/download-certificate-button.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/download-certificate-button.tsx
@@ -14,12 +14,14 @@ export type DownloadCertificateButtonProps = {
   className?: string;
   documentId: number;
   documentStatus: DocumentStatus;
+  teamId?: number;
 };
 
 export const DownloadCertificateButton = ({
   className,
   documentId,
   documentStatus,
+  teamId,
 }: DownloadCertificateButtonProps) => {
   const { toast } = useToast();
   const { _ } = useLingui();
@@ -29,7 +31,7 @@ export const DownloadCertificateButton = ({
 
   const onDownloadCertificatesClick = async () => {
     try {
-      const { url } = await downloadCertificate({ documentId });
+      const { url } = await downloadCertificate({ documentId, teamId });
 
       const iframe = Object.assign(document.createElement('iframe'), {
         src: url,

--- a/apps/web/src/app/(teams)/t/[teamUrl]/settings/preferences/document-preferences.tsx
+++ b/apps/web/src/app/(teams)/t/[teamUrl]/settings/preferences/document-preferences.tsx
@@ -206,9 +206,9 @@ export const TeamDocumentPreferencesForm = ({
 
                   <Alert variant="neutral" className="mt-1 px-2.5 py-1.5 text-sm">
                     {includeSenderDetails
-                      ? _(msg`"${placeholderEmail}" on behalf of "${team.name}" has invited you to sign "example
-                      document".`)
-                      : _(msg`"${team.name}" has invited you to sign "example document".`)}
+                      ? _(msg`'${placeholderEmail}' on behalf of '${team.name}' has invited you to sign 'example
+                      document'.`)
+                      : _(msg`'${team.name}' has invited you to sign 'example document'.`)}
                   </Alert>
                 </div>
 

--- a/packages/lib/server-only/document/seal-document.ts
+++ b/packages/lib/server-only/document/seal-document.ts
@@ -10,6 +10,7 @@ import { DocumentStatus, RecipientRole, SigningStatus } from '@documenso/prisma/
 import { WebhookTriggerEvents } from '@documenso/prisma/client';
 import { signPdf } from '@documenso/signing';
 
+import { ZSupportedLanguageCodeSchema } from '../../constants/i18n';
 import type { RequestMetadata } from '../../universal/extract-request-metadata';
 import { getFile } from '../../universal/upload/get-file';
 import { putPdfFile } from '../../universal/upload/put-file';
@@ -45,6 +46,7 @@ export const sealDocument = async ({
     },
     include: {
       documentData: true,
+      documentMeta: true,
       Recipient: true,
     },
   });
@@ -90,7 +92,9 @@ export const sealDocument = async ({
   // !: Need to write the fields onto the document as a hard copy
   const pdfData = await getFile(documentData);
 
-  const certificate = await getCertificatePdf({ documentId })
+  const documentLanguage = ZSupportedLanguageCodeSchema.parse(document.documentMeta?.language);
+
+  const certificate = await getCertificatePdf({ documentId, language: documentLanguage })
     .then(async (doc) => PDFDocument.load(doc))
     .catch(() => null);
 


### PR DESCRIPTION
## Description

Currently certificate translations on production sometimes does not show the required language.

This could not be replicated when creating certificates on staging (Browserless.io) and local development (Chromium), which means this fix ultimately cannot be tested unless on live.

This is an attempt to fix it by isolating the certificate generation into it's own context, and applying a cookie to define the required language.

This fix is based on the assumption that there is some sort of error which pushes the certificate to be generated on the client side, which ultimately will render in English due to constraints on nextjs.

## Changes Made

- Apply language into cookie instead purely dynamically on SSR
- Minor unrelated fixes

## Testing Performed

Tested to ensure certificates could still be generated 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a `teamId` prop to the `DownloadCertificateButton`, enhancing its functionality by allowing team context during certificate downloads.
  - Introduced language support in certificate PDF generation, ensuring documents respect the specified language settings.

- **Bug Fixes**
  - Improved string formatting in the `TeamDocumentPreferencesForm` for better clarity in user messages.

- **Chores**
  - Enhanced resource management in the PDF generation process by properly handling browser context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->