### PR TITLE
feat: support windows for 2fa tokens

### DIFF
--- a/packages/lib/server-only/document/is-recipient-authorized.ts
+++ b/packages/lib/server-only/document/is-recipient-authorized.ts
@@ -112,6 +112,7 @@ export const isRecipientAuthorized = async ({
       return await verifyTwoFactorAuthenticationToken({
         user,
         totpCode: token,
+        window: 10, // 5 minutes worth of tokens
       });
     })
     .exhaustive();


### PR DESCRIPTION
## Description

When using 2fa enabled authentication on direct templates we run into an issue where a 2fa token has been attached to a field but it's submitted at a later point. 

To better facilitate this we have introduced the ability to have a window of valid tokens.

This won't affect other signing methods since tokens are verified immediately after they're entered.

## Related Issue

N/A

## Changes Made

- Updated our validate2FAToken method to use a window based approach rather than the default verify method.

## Testing Performed

- Created a series of tokens and tested upon different intervals and windows to confirm functionality works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transitioned from TOTP to HOTP for two-factor authentication, allowing for configurable time windows and periods for token validation.
  - Extended the time frame for token validation to 10 minutes in the authorization process.

- **Bug Fixes**
  - Improved error handling for token verification processes while maintaining existing authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->