### PR TITLE
fix: wrong signing invitation message

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/signing-page-view.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/signing-page-view.tsx
@@ -53,6 +53,15 @@ export const SigningPageView = ({
 }: SigningPageViewProps) => {
   const { documentData, documentMeta } = document;
 
+  const shouldUseTeamDetails =
+    document.teamId && document.team?.teamGlobalSettings?.includeSenderDetails === false;
+  const senderName = shouldUseTeamDetails ? document.team?.name : (document.User.name ?? '');
+  const senderEmail = shouldUseTeamDetails
+    ? document.team?.teamEmail?.email
+      ? `(${document.team.teamEmail.email})`
+      : ''
+    : `(${document.User.email})`;
+
   return (
     <div className="mx-auto w-full max-w-screen-xl">
       <h1
@@ -64,23 +73,35 @@ export const SigningPageView = ({
 
       <div className="mt-2.5 flex flex-wrap items-center justify-between gap-x-6">
         <div>
-          <p
-            className="text-muted-foreground truncate"
-            title={document.User.name ? document.User.name : ''}
-          >
-            {document.User.name}
+          <p className="text-muted-foreground truncate" title={senderName}>
+            {senderName} {senderEmail}
           </p>
 
           <p className="text-muted-foreground">
             {match(recipient.role)
               .with(RecipientRole.VIEWER, () => (
-                <Trans>({document.User.email}) has invited you to view this document</Trans>
+                <Trans>
+                  {document.teamId && !shouldUseTeamDetails
+                    ? `on behalf of "${document.team?.name}" `
+                    : ''}
+                  has invited you to view this document
+                </Trans>
               ))
               .with(RecipientRole.SIGNER, () => (
-                <Trans>({document.User.email}) has invited you to sign this document</Trans>
+                <Trans>
+                  {document.teamId && !shouldUseTeamDetails
+                    ? `on behalf of "${document.team?.name}" `
+                    : ''}
+                  has invited you to sign this document
+                </Trans>
               ))
               .with(RecipientRole.APPROVER, () => (
-                <Trans>({document.User.email}) has invited you to approve this document</Trans>
+                <Trans>
+                  {document.teamId && !shouldUseTeamDetails
+                    ? `on behalf of "${document.team?.name}" `
+                    : ''}
+                  has invited you to approve this document
+                </Trans>
               ))
               .otherwise(() => null)}
           </p>

--- a/apps/web/src/app/(signing)/sign/[token]/signing-page-view.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/signing-page-view.tsx
@@ -55,12 +55,14 @@ export const SigningPageView = ({
 
   const shouldUseTeamDetails =
     document.teamId && document.team?.teamGlobalSettings?.includeSenderDetails === false;
-  const senderName = shouldUseTeamDetails ? document.team?.name : (document.User.name ?? '');
-  const senderEmail = shouldUseTeamDetails
-    ? document.team?.teamEmail?.email
-      ? `(${document.team.teamEmail.email})`
-      : ''
-    : `(${document.User.email})`;
+
+  let senderName = document.User.name ?? '';
+  let senderEmail = `(${document.User.email})`;
+
+  if (shouldUseTeamDetails) {
+    senderName = document.team?.name ?? '';
+    senderEmail = document.team?.teamEmail?.email ? `(${document.team.teamEmail.email})` : '';
+  }
 
   return (
     <div className="mx-auto w-full max-w-screen-xl">
@@ -79,30 +81,33 @@ export const SigningPageView = ({
 
           <p className="text-muted-foreground">
             {match(recipient.role)
-              .with(RecipientRole.VIEWER, () => (
-                <Trans>
-                  {document.teamId && !shouldUseTeamDetails
-                    ? `on behalf of "${document.team?.name}" `
-                    : ''}
-                  has invited you to view this document
-                </Trans>
-              ))
-              .with(RecipientRole.SIGNER, () => (
-                <Trans>
-                  {document.teamId && !shouldUseTeamDetails
-                    ? `on behalf of "${document.team?.name}" `
-                    : ''}
-                  has invited you to sign this document
-                </Trans>
-              ))
-              .with(RecipientRole.APPROVER, () => (
-                <Trans>
-                  {document.teamId && !shouldUseTeamDetails
-                    ? `on behalf of "${document.team?.name}" `
-                    : ''}
-                  has invited you to approve this document
-                </Trans>
-              ))
+              .with(RecipientRole.VIEWER, () =>
+                document.teamId && !shouldUseTeamDetails ? (
+                  <Trans>
+                    on behalf of "{document.team?.name}" has invited you to view this document
+                  </Trans>
+                ) : (
+                  <Trans>has invited you to view this document</Trans>
+                ),
+              )
+              .with(RecipientRole.SIGNER, () =>
+                document.teamId && !shouldUseTeamDetails ? (
+                  <Trans>
+                    on behalf of "{document.team?.name}" has invited you to sign this document
+                  </Trans>
+                ) : (
+                  <Trans>has invited you to sign this document</Trans>
+                ),
+              )
+              .with(RecipientRole.APPROVER, () =>
+                document.teamId && !shouldUseTeamDetails ? (
+                  <Trans>
+                    on behalf of "{document.team?.name}" has invited you to approve this document
+                  </Trans>
+                ) : (
+                  <Trans>has invited you to approve this document</Trans>
+                ),
+              )
               .otherwise(() => null)}
           </p>
         </div>

--- a/apps/web/src/app/(signing)/sign/[token]/signing-page-view.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/signing-page-view.tsx
@@ -74,12 +74,11 @@ export const SigningPageView = ({
       </h1>
 
       <div className="mt-2.5 flex flex-wrap items-center justify-between gap-x-6">
-        <div>
-          <p className="text-muted-foreground truncate" title={senderName}>
+        <div className="max-w-[50ch]">
+          <span className="text-muted-foreground truncate" title={senderName}>
             {senderName} {senderEmail}
-          </p>
-
-          <p className="text-muted-foreground">
+          </span>{' '}
+          <span className="text-muted-foreground">
             {match(recipient.role)
               .with(RecipientRole.VIEWER, () =>
                 document.teamId && !shouldUseTeamDetails ? (
@@ -109,7 +108,7 @@ export const SigningPageView = ({
                 ),
               )
               .otherwise(() => null)}
-          </p>
+          </span>
         </div>
 
         <RejectDocumentDialog document={document} token={recipient.token} />

--- a/packages/email/template-components/template-document-invite.tsx
+++ b/packages/email/template-components/template-document-invite.tsx
@@ -61,7 +61,7 @@ export const TemplateDocumentInvite = ({
             <>
               {includeSenderDetails ? (
                 <Trans>
-                  {inviterName} on behalf of {teamName} has invited you to{' '}
+                  {inviterName} on behalf of "{teamName}" has invited you to{' '}
                   {_(actionVerb).toLowerCase()}
                 </Trans>
               ) : (

--- a/packages/email/templates/document-invite.tsx
+++ b/packages/email/templates/document-invite.tsx
@@ -42,7 +42,7 @@ export const DocumentInviteEmailTemplate = ({
 
   if (isTeamInvite) {
     previewText = includeSenderDetails
-      ? msg`${inviterName} on behalf of ${teamName} has invited you to ${action} ${documentName}`
+      ? msg`${inviterName} on behalf of "${teamName}" has invited you to ${action} ${documentName}`
       : msg`${teamName} has invited you to ${action} ${documentName}`;
   }
 

--- a/packages/email/templates/document-invite.tsx
+++ b/packages/email/templates/document-invite.tsx
@@ -90,14 +90,16 @@ export const DocumentInviteEmailTemplate = ({
 
           <Container className="mx-auto mt-12 max-w-xl">
             <Section>
-              <Text className="my-4 text-base font-semibold">
-                <Trans>
-                  {inviterName}{' '}
-                  <Link className="font-normal text-slate-400" href="mailto:{inviterEmail}">
-                    ({inviterEmail})
-                  </Link>
-                </Trans>
-              </Text>
+              {!isTeamInvite && (
+                <Text className="my-4 text-base font-semibold">
+                  <Trans>
+                    {inviterName}{' '}
+                    <Link className="font-normal text-slate-400" href="mailto:{inviterEmail}">
+                      ({inviterEmail})
+                    </Link>
+                  </Trans>
+                </Text>
+              )}
 
               <Text className="mt-2 text-base text-slate-400">
                 {customBody ? (

--- a/packages/lib/jobs/definitions/emails/send-signing-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-signing-email.ts
@@ -133,7 +133,7 @@ export const SEND_SIGNING_EMAIL_JOB_DEFINITION = {
       if (!emailMessage) {
         emailMessage = i18n._(
           team.teamGlobalSettings?.includeSenderDetails
-            ? msg`${user.name} on behalf of ${team.name} has invited you to ${recipientActionVerb} the document "${document.title}".`
+            ? msg`${user.name} on behalf of "${team.name}" has invited you to ${recipientActionVerb} the document "${document.title}".`
             : msg`${team.name} has invited you to ${recipientActionVerb} the document "${document.title}".`,
         );
       }

--- a/packages/lib/server-only/document/get-document-by-token.ts
+++ b/packages/lib/server-only/document/get-document-by-token.ts
@@ -81,6 +81,17 @@ export const getDocumentAndSenderByToken = async ({
           token,
         },
       },
+      team: {
+        select: {
+          name: true,
+          teamEmail: true,
+          teamGlobalSettings: {
+            select: {
+              includeSenderDetails: true,
+            },
+          },
+        },
+      },
     },
   });
 

--- a/packages/lib/server-only/document/resend-document.tsx
+++ b/packages/lib/server-only/document/resend-document.tsx
@@ -134,7 +134,7 @@ export const resendDocument = async ({
         emailMessage =
           customEmail?.message ||
           i18n._(
-            msg`${user.name} on behalf of ${document.team.name} has invited you to ${recipientActionVerb} the document "${document.title}".`,
+            msg`${user.name} on behalf of "${document.team.name}" has invited you to ${recipientActionVerb} the document "${document.title}".`,
           );
       }
 


### PR DESCRIPTION
## Description

Fix the wrong message on the signing pages and emails.

## After - Team account

### `Send on Behalf of Team` enabled

![CleanShot 2024-11-29 at 15 06 16](https://github.com/user-attachments/assets/e20f61aa-7d8a-428b-814a-2a33ead0988f)

### `Send on Behalf of Team` disabled

![CleanShot 2024-11-29 at 15 06 51](https://github.com/user-attachments/assets/2229e6e6-dc4b-490d-aa71-10701504976e)

## After - Personal account

![CleanShot 2024-11-29 at 15 07 20](https://github.com/user-attachments/assets/58e8b0aa-187d-4d40-9ca1-3572c2da9bef)

## After - Personal account email invite

![CleanShot 2024-11-29 at 15 15 27@2x](https://github.com/user-attachments/assets/db908913-e965-4d5a-bf5f-a20caba7eb95)

## After - Team account email invite `Send on Behalf of Team` enabled

![CleanShot 2024-11-29 at 15 17 24@2x](https://github.com/user-attachments/assets/d85b0f1d-7b74-4c8c-8301-bd9003d44a1e)

## After - Team account email invite `Send on Behalf of Team` disabled

![CleanShot 2024-11-29 at 15 20 23@2x](https://github.com/user-attachments/assets/95befa6d-9d01-4519-b7cb-f5a109dfda92)

