### PR TITLE
feat: open the advanced settings automatically

### DIFF
--- a/packages/lib/utils/advanced-fields-helpers.ts
+++ b/packages/lib/utils/advanced-fields-helpers.ts
@@ -4,7 +4,7 @@ import { ZFieldMetaSchema } from '../types/field-meta';
 
 // Currently it seems that the majority of fields have advanced fields for font reasons.
 // This array should only contain fields that have an optional setting in the fieldMeta.
-const ADVANCED_FIELD_TYPES_WITH_OPTIONAL_SETTING: FieldType[] = [
+export const ADVANCED_FIELD_TYPES_WITH_OPTIONAL_SETTING: FieldType[] = [
   FieldType.NUMBER,
   FieldType.TEXT,
   FieldType.DROPDOWN,

--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -34,6 +34,7 @@ import {
   ZFieldMetaSchema,
 } from '@documenso/lib/types/field-meta';
 import { nanoid } from '@documenso/lib/universal/id';
+import { ADVANCED_FIELD_TYPES_WITH_OPTIONAL_SETTING } from '@documenso/lib/utils/advanced-fields-helpers';
 import { validateFieldsUninserted } from '@documenso/lib/utils/fields';
 import { parseMessageDescriptor } from '@documenso/lib/utils/i18n';
 import {
@@ -81,15 +82,6 @@ const MIN_WIDTH_PX = 36;
 
 const DEFAULT_HEIGHT_PX = MIN_HEIGHT_PX * 2.5;
 const DEFAULT_WIDTH_PX = MIN_WIDTH_PX * 2.5;
-
-const fieldsWithAdvancedSettings: FieldType[] = [
-  FieldType.INITIALS,
-  FieldType.TEXT,
-  FieldType.NUMBER,
-  FieldType.CHECKBOX,
-  FieldType.RADIO,
-  FieldType.DROPDOWN,
-];
 
 export type FieldFormType = {
   nativeId?: number;
@@ -362,7 +354,9 @@ export const AddFieldsFormPartial = ({
 
       append(field);
 
-      if (fieldsWithAdvancedSettings.includes(selectedField)) {
+      // Only open fields with significant amount of settings (instead of just a font setting) to
+      // reduce friction when adding fields.
+      if (ADVANCED_FIELD_TYPES_WITH_OPTIONAL_SETTING.includes(selectedField)) {
         setCurrentField(field);
         setShowAdvancedSettings(true);
       }

--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -82,6 +82,15 @@ const MIN_WIDTH_PX = 36;
 const DEFAULT_HEIGHT_PX = MIN_HEIGHT_PX * 2.5;
 const DEFAULT_WIDTH_PX = MIN_WIDTH_PX * 2.5;
 
+const fieldsWithAdvancedSettings: FieldType[] = [
+  FieldType.INITIALS,
+  FieldType.TEXT,
+  FieldType.NUMBER,
+  FieldType.CHECKBOX,
+  FieldType.RADIO,
+  FieldType.DROPDOWN,
+];
+
 export type FieldFormType = {
   nativeId?: number;
   formId: string;
@@ -352,6 +361,11 @@ export const AddFieldsFormPartial = ({
       };
 
       append(field);
+
+      if (fieldsWithAdvancedSettings.includes(selectedField)) {
+        setCurrentField(field);
+        setShowAdvancedSettings(true);
+      }
 
       setIsFieldWithinBounds(false);
       setSelectedField(null);


### PR DESCRIPTION
fixes https://github.com/documenso/backlog-internal/issues/230

Open the advanced settings tab when the field gets placed on the document in the document editor.

https://github.com/user-attachments/assets/a7565f77-22c5-4a33-8c99-69b37fb61016

