### PR TITLE
chore: remove redundant translations on upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "trigger:dev": "npm run with:env -- npx trigger-cli dev --handler-path=\"/api/jobs\"",
     "inngest:dev": "inngest dev -u http://localhost:3000/api/jobs",
     "make:version": " npm version --workspace @documenso/web --workspace @documenso/marketing --include-workspace-root --no-git-tag-version -m \"v%s\"",
-    "translate:extract": "lingui extract",
+    "translate:extract": "lingui extract --clean",
     "translate:compile": "turbo run translate:compile --filter=@documenso/web --filter=@documenso/marketing --filter=@documenso/ui"
   },
   "packageManager": "npm@10.7.0",


### PR DESCRIPTION
## Description

Clean redundant translations by default.

This should stop the AI from doing strange things to commented out translations.
