### PR TITLE
chore: prevent user selection within signature pad

### DIFF
--- a/packages/ui/primitives/signature-pad/signature-pad.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad.tsx
@@ -454,7 +454,7 @@ export const SignaturePad = ({
 
   return (
     <div
-      className={cn('relative block', containerClassName, {
+      className={cn('relative block select-none', containerClassName, {
         'pointer-events-none opacity-50': disabled,
       })}
     >


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the project for review and inclusion
---

## Description

This PR adds a `select-none` class to the signature pad in order to prevent iPadOS from becoming too trigger happy with the context menu and auto corrects. Please ensure this doesn't break anything by accident.

I know this could present an issue with typed signatures, but those should be workable without select/paste.

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- add a `select-none` to the signature pad container div

## Testing Performed

I didn't have the time yet to get a local setup to work, so please run a manual test before accepting. Sorry for the inconvenience.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable
