### PR TITLE
fix: use khebab case for embedding css variables

### DIFF
--- a/apps/web/src/app/embed/css-vars.ts
+++ b/apps/web/src/app/embed/css-vars.ts
@@ -47,7 +47,7 @@ export const toNativeCssVars = (vars: TCssVarsSchema) => {
       const color = colord(value);
       const { h, s, l } = color.toHsl();
 
-      cssVars[`--${toSnakeCase(key)}`] = `${h} ${s} ${l}`;
+      cssVars[`--${toSnakeCase(key)}`] = `${h}deg ${s}% ${l}%`;
     }
   }
 

--- a/apps/web/src/app/embed/css-vars.ts
+++ b/apps/web/src/app/embed/css-vars.ts
@@ -1,5 +1,4 @@
 import { colord } from 'colord';
-import { toSnakeCase } from 'remeda';
 import { z } from 'zod';
 
 export const ZCssVarsSchema = z
@@ -47,7 +46,9 @@ export const toNativeCssVars = (vars: TCssVarsSchema) => {
       const color = colord(value);
       const { h, s, l } = color.toHsl();
 
-      cssVars[`--${toSnakeCase(key)}`] = `${h}deg ${s}% ${l}%`;
+      // Convert camelCase to kebab-case (e.g., mutedForeground -> muted-foreground)
+      const kebabKey = key.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+      cssVars[`--${kebabKey}`] = `${h} ${s} ${l}`;
     }
   }
 

--- a/apps/web/src/app/embed/css-vars.ts
+++ b/apps/web/src/app/embed/css-vars.ts
@@ -1,4 +1,5 @@
 import { colord } from 'colord';
+import { toKebabCase } from 'remeda';
 import { z } from 'zod';
 
 export const ZCssVarsSchema = z
@@ -46,9 +47,7 @@ export const toNativeCssVars = (vars: TCssVarsSchema) => {
       const color = colord(value);
       const { h, s, l } = color.toHsl();
 
-      // Convert camelCase to kebab-case (e.g., mutedForeground -> muted-foreground)
-      const kebabKey = key.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
-      cssVars[`--${kebabKey}`] = `${h} ${s} ${l}`;
+      cssVars[`--${toKebabCase(key)}`] = `${h} ${s} ${l}`;
     }
   }
 


### PR DESCRIPTION
Given the following CSS Variables, 

```js
  const cssVars = {
    primaryForeground: "#fff",
    primary: "#7f1d1d",
    radius: "2rem",
  };
```

This is how the embedding looks

### Before

![CleanShot 2024-12-11 at 16 06 34@2x](https://github.com/user-attachments/assets/3b91d347-4900-47fb-998f-98d1c6959dfb)

[Current Production](https://stg-app.documenso.com/embed/direct/dgvlmj3braNVTACRJFbyL#JTdCJTIybmFtZSUyMiUzQSUyMkRpY3RhJTIwZXglMjBxdWlzJTIwZXN0JTIwbiUyMiUyQyUyMmxvY2tOYW1lJTIyJTNBdHJ1ZSUyQyUyMmVtYWlsJTIyJTNBJTIyZ2F0b2d5aCU0MG1haWxpbmF0b3IuY29tJTIyJTJDJTIybG9ja0VtYWlsJTIyJTNBdHJ1ZSUyQyUyMmNzc1ZhcnMlMjIlM0ElN0IlMjJwcmltYXJ5Rm9yZWdyb3VuZCUyMiUzQSUyMiUyM2ZmZiUyMiUyQyUyMnByaW1hcnklMjIlM0ElMjIlMjM3ZjFkMWQlMjIlMkMlMjJyYWRpdXMlMjIlM0ElMjIycmVtJTIyJTdEJTdE)


### After 

![CleanShot 2024-12-11 at 16 07 00@2x](https://github.com/user-attachments/assets/9e23639f-2af3-4dd0-a768-5be2cace3a77)

[Deployment for this PR](https://stg-app-git-fix-embed-whitelabel-colors-documenso.vercel.app/embed/direct/0QZo7ial78RoelGRAPyp6#JTdCJTIybmFtZSUyMiUzQSUyMkRpY3RhJTIwZXglMjBxdWlzJTIwZXN0JTIwbiUyMiUyQyUyMmxvY2tOYW1lJTIyJTNBdHJ1ZSUyQyUyMmVtYWlsJTIyJTNBJTIyZ2F0b2d5aCU0MG1haWxpbmF0b3IuY29tJTIyJTJDJTIybG9ja0VtYWlsJTIyJTNBdHJ1ZSUyQyUyMmNzc1ZhcnMlMjIlM0ElN0IlMjJwcmltYXJ5Rm9yZWdyb3VuZCUyMiUzQSUyMiUyM2ZmZiUyMiUyQyUyMnByaW1hcnklMjIlM0ElMjIlMjM3ZjFkMWQlMjIlMkMlMjJyYWRpdXMlMjIlM0ElMjIycmVtJTIyJTdEJTdE)



