### PR TITLE
fix: tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@ jobs:
   e2e_tests:
     name: 'E2E Tests'
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

Tests have begun to fail randomly due to upstream issues.

Pin E2E tests action to run on ubuntu-22.04

Notes:
- Updating playwright to ~1.49.1 did not resolve the issue