### PR TITLE
fix: default to user timezone

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/upload-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/upload-document.tsx
@@ -12,6 +12,7 @@ import { useSession } from 'next-auth/react';
 import { useLimits } from '@documenso/ee/server-only/limits/provider/client';
 import { useAnalytics } from '@documenso/lib/client-only/hooks/use-analytics';
 import { APP_DOCUMENT_UPLOAD_SIZE_LIMIT } from '@documenso/lib/constants/app';
+import { DEFAULT_DOCUMENT_TIME_ZONE, TIME_ZONES } from '@documenso/lib/constants/time-zones';
 import { AppError } from '@documenso/lib/errors/app-error';
 import { createDocumentData } from '@documenso/lib/server-only/document-data/create-document-data';
 import { putPdfFile } from '@documenso/lib/universal/upload/put-file';
@@ -33,7 +34,9 @@ export type UploadDocumentProps = {
 export const UploadDocument = ({ className, team }: UploadDocumentProps) => {
   const router = useRouter();
   const analytics = useAnalytics();
-  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const userTimezone =
+    TIME_ZONES.find((timezone) => timezone === Intl.DateTimeFormat().resolvedOptions().timeZone) ??
+    DEFAULT_DOCUMENT_TIME_ZONE;
 
   const { data: session } = useSession();
 

--- a/apps/web/src/app/(dashboard)/documents/upload-document.tsx
+++ b/apps/web/src/app/(dashboard)/documents/upload-document.tsx
@@ -33,6 +33,7 @@ export type UploadDocumentProps = {
 export const UploadDocument = ({ className, team }: UploadDocumentProps) => {
   const router = useRouter();
   const analytics = useAnalytics();
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   const { data: session } = useSession();
 
@@ -73,6 +74,7 @@ export const UploadDocument = ({ className, team }: UploadDocumentProps) => {
         title: file.name,
         documentDataId,
         teamId: team?.id,
+        timezone: userTimezone,
       });
 
       void refreshLimits();

--- a/packages/lib/server-only/document/create-document.ts
+++ b/packages/lib/server-only/document/create-document.ts
@@ -26,6 +26,7 @@ export type CreateDocumentOptions = {
   documentDataId: string;
   formValues?: Record<string, string | number | boolean>;
   normalizePdf?: boolean;
+  timezone?: string;
   requestMetadata?: RequestMetadata;
 };
 
@@ -42,6 +43,7 @@ export const createDocument = async ({
   normalizePdf,
   formValues,
   requestMetadata,
+  timezone,
 }: CreateDocumentOptions): Promise<TCreateDocumentResponse> => {
   const user = await prisma.user.findFirstOrThrow({
     where: {
@@ -150,6 +152,7 @@ export const createDocument = async ({
           create: {
             language: team?.teamGlobalSettings?.documentLanguage,
             typedSignatureEnabled: team?.teamGlobalSettings?.typedSignatureEnabled,
+            timezone: timezone,
           },
         },
       },

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -181,7 +181,7 @@ export const documentRouter = router({
     .input(ZCreateDocumentMutationSchema)
     .output(ZCreateDocumentResponseSchema)
     .mutation(async ({ input, ctx }) => {
-      const { title, documentDataId, teamId } = input;
+      const { title, documentDataId, teamId, timezone } = input;
 
       const { remaining } = await getServerLimits({ email: ctx.user.email, teamId });
 
@@ -198,6 +198,7 @@ export const documentRouter = router({
         title,
         documentDataId,
         normalizePdf: true,
+        timezone,
         requestMetadata: extractNextApiRequestMetadata(ctx.req),
       });
     }),

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -66,6 +66,7 @@ export const ZCreateDocumentMutationSchema = z.object({
   title: z.string().min(1),
   documentDataId: z.string().min(1),
   teamId: z.number().optional(),
+  timezone: z.string().optional(),
 });
 
 export type TCreateDocumentMutationSchema = z.infer<typeof ZCreateDocumentMutationSchema>;


### PR DESCRIPTION
## Description

Passes the timezone of the user uploading the document/template via the UI to the server.

If the user uploads a document/template via the API and doesn't set a timezone, it defaults to `Etc/UTC`. 

## Testing Performed

- Changed my machine's timezone and uploaded a document via the UI.
  ✅ The correct timezone was set.
- I created a template via the UI.
  ✅ The correct timezone was set.
- I generated a document from the template.
  ✅ The correct timezone was set.

- I created a document via the API without setting a timezone.
	  ✅ The default `UTC` timezone was set.
- I created a document via the API and specified a timezone.
  ✅ The correct timezone was set.

- I changed my machine's timezone again and repeated the whole process.
  ✅ The correct timezones were set.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
