### PR TITLE
fix: broken direct template webhook

### DIFF
--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -609,6 +609,7 @@ export const createDocumentFromDirectTemplate = async ({
       },
       include: {
         documentData: true,
+        documentMeta: true,
         Recipient: true,
       },
     });


### PR DESCRIPTION
## Description

Currently the document signed webhook for direct links will fail due to a schema issue since`documentMeta` is being passed through as `optional` instead of `nullable`

```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [
      "documentMeta"
    ],
    "message": "Required"
  }
]
```

```ts
export const ZWebhookDocumentSchema = z.object({
  ...
  documentMeta: ZWebhookDocumentMetaSchema.nullable(), // <-
  ...
});
```
