### PR TITLE
fix: unable to check on the checkbox field

### DIFF
--- a/apps/web/src/app/(signing)/sign/[token]/checkbox-field.tsx
+++ b/apps/web/src/app/(signing)/sign/[token]/checkbox-field.tsx
@@ -183,28 +183,25 @@ export const CheckboxField = ({
           ...checkedValues,
           item.value.length > 0 ? item.value : `empty-value-${item.id}`,
         ];
-
-        await removeSignedFieldWithToken({
-          token: recipient.token,
-          fieldId: field.id,
-        });
-
-        if (isLengthConditionMet) {
-          await signFieldWithToken({
-            token: recipient.token,
-            fieldId: field.id,
-            value: toCheckboxValue(checkedValues),
-            isBase64: true,
-          });
-        }
       } else {
         updatedValues = checkedValues.filter(
           (v) => v !== item.value && v !== `empty-value-${item.id}`,
         );
+      }
 
-        await removeSignedFieldWithToken({
+      setCheckedValues(updatedValues);
+
+      await removeSignedFieldWithToken({
+        token: recipient.token,
+        fieldId: field.id,
+      });
+
+      if (updatedValues.length > 0) {
+        await signFieldWithToken({
           token: recipient.token,
           fieldId: field.id,
+          value: toCheckboxValue(updatedValues),
+          isBase64: true,
         });
       }
     } catch (err) {
@@ -216,7 +213,6 @@ export const CheckboxField = ({
         variant: 'destructive',
       });
     } finally {
-      setCheckedValues(updatedValues);
       startTransition(() => router.refresh());
     }
   };


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/de18a53d-1065-4647-b612-6eba109a9bfb

## After

https://github.com/user-attachments/assets/a486e280-ebd8-4abe-b9a4-465762e350bf

## Description

This change prevents race conditions between state updates and API operations by updating local state immediately before making async calls.

## Changes Made

- Refactored the `handleCheckboxOptionClick` function to consolidate API calls:
- Fixed a bug where `checkedValues` was being used in `toCheckboxValue` before being updated

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes


