### PR TITLE
fix: create global settings on team creation

### DIFF
--- a/packages/lib/server-only/team/create-team.ts
+++ b/packages/lib/server-only/team/create-team.ts
@@ -231,6 +231,12 @@ export const createTeamFromPendingTeam = async ({
       },
     });
 
+    await tx.teamGlobalSettings.create({
+      data: {
+        teamId: team.id,
+      },
+    });
+
     await tx.subscription.upsert(
       mapStripeSubscriptionToPrismaUpsertAction(subscription, undefined, team.id),
     );

--- a/packages/lib/server-only/team/create-team.ts
+++ b/packages/lib/server-only/team/create-team.ts
@@ -112,8 +112,12 @@ export const createTeam = async ({
           },
         });
 
-        await tx.teamGlobalSettings.create({
-          data: {
+        await tx.teamGlobalSettings.upsert({
+          where: {
+            teamId: team.id,
+          },
+          update: {},
+          create: {
             teamId: team.id,
           },
         });
@@ -231,8 +235,12 @@ export const createTeamFromPendingTeam = async ({
       },
     });
 
-    await tx.teamGlobalSettings.create({
-      data: {
+    await tx.teamGlobalSettings.upsert({
+      where: {
+        teamId: team.id,
+      },
+      update: {},
+      create: {
         teamId: team.id,
       },
     });

--- a/packages/lib/server-only/team/create-team.ts
+++ b/packages/lib/server-only/team/create-team.ts
@@ -95,7 +95,7 @@ export const createTeam = async ({
           });
         }
 
-        await tx.team.create({
+        const team = await tx.team.create({
           data: {
             name: teamName,
             url: teamUrl,
@@ -104,11 +104,17 @@ export const createTeam = async ({
             members: {
               create: [
                 {
-                  userId,
+                  userId: user.id,
                   role: TeamMemberRole.ADMIN,
                 },
               ],
             },
+          },
+        });
+
+        await tx.teamGlobalSettings.create({
+          data: {
+            teamId: team.id,
           },
         });
       });


### PR DESCRIPTION
## Description

The global team settings weren't created when creating a new team.

## Changes Made

The global team settings are now created when a new team is created.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

