### PR TITLE
fix: remove non-standard fields that would cause prisma validation er…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35722,6 +35722,21 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "packages/trpc/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.6.tgz",
+      "integrity": "sha512-hNukAxq7hu4o5/UjPp5jqoBEtrpCbOmnUqZSKNJG8GrUVzfq0ucdhQFVrHcLRMvQcwqqDh1a5AJN9ORnNDpgBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/lib/next-auth/auth-options.ts
+++ b/packages/lib/next-auth/auth-options.ts
@@ -193,7 +193,15 @@ export const NEXT_AUTH_OPTIONS: AuthOptions = {
       idToken: true,
       allowDangerousEmailAccountLinking: true,
 
-      profile(profile) {
+      profile(profile, tokens) {
+        if (tokens && 'refresh_expires_in' in tokens) {
+          delete tokens.refresh_expires_in;
+        }
+
+        if (tokens && 'not-before-policy' in tokens) {
+          delete tokens['not-before-policy'];
+        }
+
         return {
           id: profile.sub,
           email: profile.email || profile.preferred_username,


### PR DESCRIPTION
## Description
This PR removes non-standard fields that would cause Prisma validation errors and more maintainable as it doesn't require schema changes for provider-specific fields.

## Related Issue
#1342

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.
