### PR TITLE
feat(oidc): disable login and redirect directly to OIDC (#1643)

### DIFF
--- a/apps/web/src/app/(unauthenticated)/signin/page.tsx
+++ b/apps/web/src/app/(unauthenticated)/signin/page.tsx
@@ -38,6 +38,7 @@ export default async function SignInPage() {
           isGoogleSSOEnabled={IS_GOOGLE_SSO_ENABLED}
           isOIDCSSOEnabled={IS_OIDC_SSO_ENABLED}
           oidcProviderLabel={OIDC_PROVIDER_LABEL}
+          //Need to pass isOIDCDefault prop for enabling default OIDC login
         />
 
         {NEXT_PUBLIC_DISABLE_SIGNUP !== 'true' && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -35722,6 +35722,21 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "packages/trpc/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.6.tgz",
+      "integrity": "sha512-hNukAxq7hu4o5/UjPp5jqoBEtrpCbOmnUqZSKNJG8GrUVzfq0ucdhQFVrHcLRMvQcwqqDh1a5AJN9ORnNDpgBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
---
name: FEATURE REQUEST: disable Login Option and directly direct to OIDC #1643
about: Made changes for passing the login process for OIDC login
---

## Description

-  Implemented the logic for bypass the login screen and directly redirect users to OIDC when it is set as the default authentication method.
-  If the OIDC is enabled and it is default for login than no login page render instead it directly take the user to OIDC workflow. 


## Changes Made

- Add a prop name  isOIDCDefault which will define if  OIDC is default or not.
- Add useEffect  which will take user to OIDC page if no session will be there or to OIDC login workflow. If isOIDCDefault and  OIDC is enabled.


