### PR TITLE
fix: improve layout and truncate document information in logs page

### DIFF
--- a/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
+++ b/apps/web/src/app/(dashboard)/documents/[id]/logs/document-logs-page-view.tsx
@@ -119,7 +119,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
         <Trans>Document</Trans>
       </Link>
 
-      <div className="flex flex-col justify-between truncate sm:flex-row">
+      <div className="flex flex-col">
         <div>
           <h1
             className="mt-4 block max-w-[20rem] truncate text-2xl font-semibold md:max-w-[30rem] md:text-3xl"
@@ -127,7 +127,8 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
           >
             {document.title}
           </h1>
-
+        </div>
+        <div className="mt-1 flex flex-col justify-between sm:flex-row">
           <div className="mt-2.5 flex items-center gap-x-6">
             <DocumentStatusComponent
               inheritColor
@@ -135,17 +136,16 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
               className="text-muted-foreground"
             />
           </div>
-        </div>
+          <div className="mt-4 flex w-full flex-row sm:mt-0 sm:w-auto sm:self-end">
+            <DownloadCertificateButton
+              className="mr-2"
+              documentId={document.id}
+              documentStatus={document.status}
+              teamId={team?.id}
+            />
 
-        <div className="mt-4 flex w-full flex-row sm:mt-0 sm:w-auto sm:self-end">
-          <DownloadCertificateButton
-            className="mr-2"
-            documentId={document.id}
-            documentStatus={document.status}
-            teamId={team?.id}
-          />
-
-          <DownloadAuditLogButton teamId={team?.id} documentId={document.id} />
+            <DownloadAuditLogButton teamId={team?.id} documentId={document.id} />
+          </div>
         </div>
       </div>
 
@@ -154,7 +154,7 @@ export const DocumentLogsPageView = async ({ params, team }: DocumentLogsPageVie
           {documentInformation.map((info, i) => (
             <div className="text-foreground text-sm" key={i}>
               <h3 className="font-semibold">{_(info.description)}</h3>
-              <p className="text-muted-foreground">{info.value}</p>
+              <p className="text-muted-foreground truncate">{info.value}</p>
             </div>
           ))}
 


### PR DESCRIPTION
## Description

This PR fixes a UI issue on the document logs page where the download button gets cut off on small screens. The fix ensures the button remains fully visible by adjusting the layout and spacing for better responsiveness.

## Related Issue

Fixes #1627 

## Changes Made

- Removing `justify-between` from the outer div – ensuring that elements are no longer forcefully spaced apart.
- Separating `title` into its own div – preventing layout shifts.
- Wrapping the status and buttons in a flex container – ensuring they align properly in a row for larger screens and stack on smaller ones.
- Adding `truncate` to document information values – ensuring long values don’t overflow.

## Testing Performed
### Before
[documenso-1627-before.webm](https://github.com/user-attachments/assets/f161fa1b-3d88-4011-b171-b25c66baa06f)
### After
[documenso-1627.webm](https://github.com/user-attachments/assets/34278bd5-5086-4b2f-bab6-5338fbc498a2)

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

