### PR TITLE
feat: Add support for disabling sending emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ NEXT_PRIVATE_UPLOAD_ACCESS_KEY_ID="documenso"
 NEXT_PRIVATE_UPLOAD_SECRET_ACCESS_KEY="password"
 
 # [[SMTP]]
-# OPTIONAL: Defines the transport to use for sending emails. Available options: smtp-auth (default) | smtp-api | mailchannels
+# OPTIONAL: Defines the transport to use for sending emails. Available options: smtp-auth (default) | smtp-api | mailchannels | disabled
 NEXT_PRIVATE_SMTP_TRANSPORT="smtp-auth"
 # OPTIONAL: Defines the host to use for sending emails.
 NEXT_PRIVATE_SMTP_HOST="127.0.0.1"

--- a/packages/email/mailer.ts
+++ b/packages/email/mailer.ts
@@ -4,6 +4,7 @@ import { createTransport } from 'nodemailer';
 import { ResendTransport } from '@documenso/nodemailer-resend';
 
 import { MailChannelsTransport } from './transports/mailchannels';
+import { DisabledTransport } from './transports/disabled';
 
 /**
  * Creates a Nodemailer transport object for sending emails.
@@ -86,6 +87,13 @@ const getTransport = (): Transporter => {
         pass: process.env.NEXT_PRIVATE_SMTP_APIKEY ?? '',
       },
     });
+  }
+
+  if (transport === 'disabled') {
+    // This provides a way to disable the email sending by creating a stub transport
+    return createTransport(
+      DisabledTransport.makeTransport(),
+    );
   }
 
   return createTransport({

--- a/packages/email/transports/disabled.ts
+++ b/packages/email/transports/disabled.ts
@@ -1,0 +1,17 @@
+import { SentMessageInfo, Transport } from 'nodemailer';
+import type MailMessage from 'nodemailer/lib/mailer/mail-message';
+
+const VERSION = '1.0.0';
+
+export class DisabledTransport implements Transport<SentMessageInfo> {
+  public name = 'DisabledTransport';
+  public version = VERSION;
+
+  public static makeTransport() {
+    return new DisabledTransport();
+  }
+
+  public send(_mail: MailMessage, callback: (_err: Error | null, _info: SentMessageInfo) => void) {
+    return callback(null, null);
+  }
+}

--- a/packages/tsconfig/process-env.d.ts
+++ b/packages/tsconfig/process-env.d.ts
@@ -43,7 +43,7 @@ declare namespace NodeJS {
     NEXT_PRIVATE_SIGNING_GCLOUD_HSM_PUBLIC_CRT_FILE_CONTENTS?: string;
     NEXT_PRIVATE_SIGNING_GCLOUD_APPLICATION_CREDENTIALS_CONTENTS?: string;
 
-    NEXT_PRIVATE_SMTP_TRANSPORT?: 'mailchannels' | 'resend' | 'smtp-auth' | 'smtp-api';
+    NEXT_PRIVATE_SMTP_TRANSPORT?: 'mailchannels' | 'resend' | 'smtp-auth' | 'smtp-api' | 'disabled';
 
     NEXT_PRIVATE_RESEND_API_KEY?: string;
 


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the project for review and inclusion
---

## Description

This adds the ability to disable sending emails altogether. This can be useful for cases where you're wanting to use the API and embed directly, and take care of your own notifications.

Please let me know of any changes needed here.

## Related Issue

N/A

## Changes Made

* Added an additional "disabled" option to the NEXT_PRIVATE_SMTP_TRANSPORT variable
* Created a disabled transport, which mainly is a stub around the sendmail which does nothing

## Testing Performed

Was able to verify with a docker build that no emails are being sent. Without this change, I did not have any email settings, and was getting errors when trying to sign a document.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [X] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have updated the documentation to reflect these changes, if applicable.
- [X] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
