### PR TITLE
fix: stripe price fetch

### DIFF
--- a/packages/ee/server-only/stripe/get-prices-by-plan.ts
+++ b/packages/ee/server-only/stripe/get-prices-by-plan.ts
@@ -4,15 +4,14 @@ import { stripe } from '@documenso/lib/server-only/stripe';
 type PlanType = (typeof STRIPE_PLAN_TYPE)[keyof typeof STRIPE_PLAN_TYPE];
 
 export const getPricesByPlan = async (plan: PlanType | PlanType[]) => {
-  const planTypes = typeof plan === 'string' ? [plan] : plan;
+  const planTypes: string[] = typeof plan === 'string' ? [plan] : plan;
 
-  const query = planTypes.map((planType) => `metadata['plan']:'${planType}'`).join(' OR ');
-
-  const { data: prices } = await stripe.prices.search({
-    query,
+  const prices = await stripe.prices.list({
     expand: ['data.product'],
     limit: 100,
   });
 
-  return prices.filter((price) => price.type === 'recurring');
+  return prices.data.filter(
+    (price) => price.type === 'recurring' && planTypes.includes(price.metadata.plan),
+  );
 };


### PR DESCRIPTION
## Description

Currently Stripe prices search is omitting a price for an unknown reason.

Changed our fetch logic to use `list` instead of `search` allows us to work around the issue.

It's unknown on the performance impact of using `list` vs `search`

## Testing

1. Ran old and new fetches
2. Diffed results
3. New result showed the missing price

Simplified testing:

```typescript
const oldResult = await oldGetPricesByPlan(['regular', 'community', 'platform', 'enterprise']);
const newResult = await newGetPricesByPlan(['regular', 'community', 'platform', 'enterprise']);

console.log({
  oldResultPriceLength: oldResult.length, // 13
  newResultPriceLength: newResult.length, // 14
});

```