### PR TITLE
fix: autosigning fields with direct links

### DIFF
--- a/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
+++ b/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
@@ -17,6 +17,7 @@ import {
   ZTextFieldMeta,
 } from '@documenso/lib/types/field-meta';
 import type { TTemplate } from '@documenso/lib/types/template';
+import { toCheckboxValue } from '@documenso/lib/universal/field-checkbox';
 import { sortFieldsByPosition, validateFieldsInserted } from '@documenso/lib/utils/fields';
 import type {
   TRemovedSignedFieldWithTokenMutationSchema,
@@ -201,31 +202,29 @@ export const DirectTemplateSigningForm = ({
             ?.filter((item) => item.checked)
             .map((item) => item.value);
 
-          console.log('checkedValues', checkedValues);
-
-          console.log(checkedValues);
-
           if (checkedValues && checkedValues.length > 0) {
-            value = checkedValues.join(', ');
+            value = toCheckboxValue(checkedValues);
           }
         });
 
-      const signedValue = {
-        token: directRecipient.token,
-        fieldId: field.id,
-        value,
-      };
+      if (value) {
+        const signedValue = {
+          token: directRecipient.token,
+          fieldId: field.id,
+          value,
+        };
 
-      updatedFields[index] = {
-        ...field,
-        customText: value,
-        inserted: true,
-        signedValue,
-      };
+        updatedFields[index] = {
+          ...field,
+          customText: value,
+          inserted: true,
+          signedValue,
+        };
+      }
     });
 
     setLocalFields(updatedFields);
-  }, []);
+  }, [directRecipient.token]);
 
   return (
     <DocumentSigningRecipientProvider recipient={directRecipient}>

--- a/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
+++ b/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
@@ -174,9 +174,9 @@ export const DirectTemplateSigningForm = ({
   useEffect(() => {
     const updatedFields = [...localFields];
 
-    const fieldsToAutoSign = localFields.filter((field) => field.fieldMeta?.readOnly);
+    // const fieldsToAutoSign = localFields.filter((field) => field.fieldMeta?.readOnly);
 
-    fieldsToAutoSign.forEach((field) => {
+    localFields.forEach((field) => {
       const index = updatedFields.findIndex((f) => f.id === field.id);
       let value = '';
 
@@ -204,6 +204,13 @@ export const DirectTemplateSigningForm = ({
 
           if (checkedValues && checkedValues.length > 0) {
             value = toCheckboxValue(checkedValues);
+          }
+        })
+        .with(FieldType.DROPDOWN, () => {
+          const meta = field.fieldMeta ? ZDropdownFieldMeta.safeParse(field.fieldMeta) : null;
+
+          if (meta?.success) {
+            value = meta.data.defaultValue ?? '';
           }
         });
 

--- a/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
+++ b/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
@@ -173,8 +173,6 @@ export const DirectTemplateSigningForm = ({
   useEffect(() => {
     const updatedFields = [...localFields];
 
-    // const fieldsToAutoSign = localFields.filter((field) => field.fieldMeta?.readOnly);
-
     localFields.forEach((field) => {
       const index = updatedFields.findIndex((f) => f.id === field.id);
       let value = '';
@@ -219,7 +217,7 @@ export const DirectTemplateSigningForm = ({
     });
 
     setLocalFields(updatedFields);
-  }, [directRecipient.token]);
+  }, []);
 
   return (
     <DocumentSigningRecipientProvider recipient={directRecipient}>

--- a/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
+++ b/apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
@@ -17,7 +17,6 @@ import {
   ZTextFieldMeta,
 } from '@documenso/lib/types/field-meta';
 import type { TTemplate } from '@documenso/lib/types/template';
-import { toCheckboxValue } from '@documenso/lib/universal/field-checkbox';
 import { sortFieldsByPosition, validateFieldsInserted } from '@documenso/lib/utils/fields';
 import type {
   TRemovedSignedFieldWithTokenMutationSchema,
@@ -193,17 +192,6 @@ export const DirectTemplateSigningForm = ({
 
           if (meta?.success) {
             value = meta.data.value ?? '';
-          }
-        })
-        .with(FieldType.CHECKBOX, () => {
-          const meta = field.fieldMeta ? ZCheckboxFieldMeta.safeParse(field.fieldMeta) : null;
-
-          const checkedValues = meta?.data?.values
-            ?.filter((item) => item.checked)
-            .map((item) => item.value);
-
-          if (checkedValues && checkedValues.length > 0) {
-            value = toCheckboxValue(checkedValues);
           }
         })
         .with(FieldType.DROPDOWN, () => {

--- a/apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
@@ -194,18 +194,30 @@ export const DocumentSigningCheckboxField = ({
 
       setCheckedValues(updatedValues);
 
-      await removeSignedFieldWithToken({
+      const removePayload: TRemovedSignedFieldWithTokenMutationSchema = {
         token: recipient.token,
         fieldId: field.id,
-      });
+      };
+
+      if (onUnsignField) {
+        await onUnsignField(removePayload);
+      } else {
+        await removeSignedFieldWithToken(removePayload);
+      }
 
       if (updatedValues.length > 0) {
-        await signFieldWithToken({
+        const signPayload: TSignFieldWithTokenMutationSchema = {
           token: recipient.token,
           fieldId: field.id,
           value: toCheckboxValue(updatedValues),
           isBase64: true,
-        });
+        };
+
+        if (onSignField) {
+          await onSignField(signPayload);
+        } else {
+          await signFieldWithToken(signPayload);
+        }
       }
     } catch (err) {
       console.error(err);

--- a/apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
@@ -97,6 +97,10 @@ export const DocumentSigningCheckboxField = ({
 
   const onSign = async (authOptions?: TRecipientActionAuth) => {
     try {
+      if (!isLengthConditionMet) {
+        return;
+      }
+
       const payload: TSignFieldWithTokenMutationSchema = {
         token: recipient.token,
         fieldId: field.id,
@@ -205,7 +209,7 @@ export const DocumentSigningCheckboxField = ({
         await removeSignedFieldWithToken(removePayload);
       }
 
-      if (updatedValues.length > 0) {
+      if (updatedValues.length > 0 && shouldAutoSignField) {
         const signPayload: TSignFieldWithTokenMutationSchema = {
           token: recipient.token,
           fieldId: field.id,


### PR DESCRIPTION
## Description

The changes in `sign-direct-template.tsx` automatically fill in field values for text, number, and dropdown fields when default values are present or if the fields are read-only. In `checkbox-field.tsx`, the changes fix the checkbox signing by checking if the validation is met and improving how it saves or removes checkbox choices.

## Testing Performed

I tested the code locally with a variety of documents/fields.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

