### PR TITLE
fix: adjust desktop nav search button width and spacing

### DIFF
--- a/apps/web/src/components/(dashboard)/layout/desktop-nav.tsx
+++ b/apps/web/src/components/(dashboard)/layout/desktop-nav.tsx
@@ -73,7 +73,7 @@ export const DesktopNav = ({ className, setIsCommandMenuOpen, ...props }: Deskto
 
       <Button
         variant="outline"
-        className="text-muted-foreground flex w-96 items-center justify-between rounded-lg"
+        className="text-muted-foreground flex w-full items-center justify-between rounded-lg"
         onClick={() => setIsCommandMenuOpen(true)}
       >
         <div className="flex items-center">
@@ -82,7 +82,7 @@ export const DesktopNav = ({ className, setIsCommandMenuOpen, ...props }: Deskto
         </div>
 
         <div>
-          <div className="text-muted-foreground bg-muted flex items-center rounded-md px-1.5 py-0.5  text-xs tracking-wider">
+          <div className="text-muted-foreground bg-muted flex items-center rounded-md px-1.5 py-0.5 text-xs tracking-wider">
             {modifierKey}+K
           </div>
         </div>

--- a/apps/web/src/components/(dashboard)/layout/desktop-nav.tsx
+++ b/apps/web/src/components/(dashboard)/layout/desktop-nav.tsx
@@ -73,7 +73,7 @@ export const DesktopNav = ({ className, setIsCommandMenuOpen, ...props }: Deskto
 
       <Button
         variant="outline"
-        className="text-muted-foreground flex w-full items-center justify-between rounded-lg"
+        className="text-muted-foreground flex w-full max-w-96 items-center justify-between rounded-lg"
         onClick={() => setIsCommandMenuOpen(true)}
       >
         <div className="flex items-center">


### PR DESCRIPTION
## Description

This PR fixes a UI issue on the `https://app.documenso.com/documents` page where the Header gets cut off on small screens. The fix ensures the Header/Navbar remains fully visible by adjusting the layout and spacing for better responsiveness.

## Related Issue

Fixes: #1698 

## Changes Made

The width has been changed from 'w-96' to 'w-full.'

## Testing Performed

### Before

<img width="801" alt="Screenshot 2025-03-11 at 11 33 21 PM" src="https://github.com/user-attachments/assets/0c35bc64-99e9-4afb-9b0e-fae17b8a6337" />

### After

[documenso-1698.webm](https://github.com/user-attachments/assets/dcddc50c-27db-41d1-badf-59f83481785e)

## Checklist

- [X] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have updated the documentation to reflect these changes, if applicable.
- [X] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
