### PR TITLE
feat: dictate next signer

### DIFF
--- a/apps/remix/app/components/dialogs/assistant-confirmation-dialog.tsx
+++ b/apps/remix/app/components/dialogs/assistant-confirmation-dialog.tsx
@@ -1,4 +1,9 @@
+import { useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Trans } from '@lingui/react/macro';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -9,16 +14,39 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@documenso/ui/primitives/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@documenso/ui/primitives/form/form';
+import { Input } from '@documenso/ui/primitives/input';
 
 import { DocumentSigningDisclosure } from '../general/document-signing/document-signing-disclosure';
+
+export type NextSigner = {
+  name: string;
+  email: string;
+};
 
 type ConfirmationDialogProps = {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (nextSigner?: NextSigner) => void;
   hasUninsertedFields: boolean;
   isSubmitting: boolean;
+  allowDictateNextSigner?: boolean;
+  defaultNextSigner?: NextSigner;
 };
+
+const ZNextSignerFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+});
+
+type TNextSignerFormSchema = z.infer<typeof ZNextSignerFormSchema>;
 
 export function AssistantConfirmationDialog({
   isOpen,
@@ -26,47 +54,168 @@ export function AssistantConfirmationDialog({
   onConfirm,
   hasUninsertedFields,
   isSubmitting,
+  allowDictateNextSigner = false,
+  defaultNextSigner,
 }: ConfirmationDialogProps) {
+  const [isEditingNextSigner, setIsEditingNextSigner] = useState(false);
+
+  const form = useForm<TNextSignerFormSchema>({
+    resolver: zodResolver(ZNextSignerFormSchema),
+    defaultValues: {
+      name: defaultNextSigner?.name ?? '',
+      email: defaultNextSigner?.email ?? '',
+    },
+  });
+
   const onOpenChange = () => {
-    if (isSubmitting) {
+    if (form.formState.isSubmitting) {
       return;
     }
 
+    form.reset({
+      name: defaultNextSigner?.name ?? '',
+      email: defaultNextSigner?.email ?? '',
+    });
+
+    setIsEditingNextSigner(false);
     onClose();
   };
+
+  const onFormSubmit = async (data: TNextSignerFormSchema) => {
+    if (allowDictateNextSigner && data.name && data.email) {
+      await onConfirm({
+        name: data.name,
+        email: data.email,
+      });
+    } else {
+      await onConfirm();
+    }
+  };
+
+  const isNextSignerValid = !allowDictateNextSigner || (form.watch('name') && form.watch('email'));
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            <Trans>Complete Document</Trans>
-          </DialogTitle>
-          <DialogDescription>
-            <Trans>
-              Are you sure you want to complete the document? This action cannot be undone. Please
-              ensure that you have completed prefilling all relevant fields before proceeding.
-            </Trans>
-          </DialogDescription>
-        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onFormSubmit)}>
+            <fieldset
+              disabled={form.formState.isSubmitting || isSubmitting}
+              className="border-none p-0"
+            >
+              <DialogHeader>
+                <DialogTitle>
+                  <Trans>Complete Document</Trans>
+                </DialogTitle>
+                <DialogDescription>
+                  <Trans>
+                    Are you sure you want to complete the document? This action cannot be undone.
+                    Please ensure that you have completed prefilling all relevant fields before
+                    proceeding.
+                  </Trans>
+                </DialogDescription>
+              </DialogHeader>
 
-        <div className="flex flex-col gap-4">
-          <DocumentSigningDisclosure />
-        </div>
+              <div className="mt-4 flex flex-col gap-4">
+                {allowDictateNextSigner && (
+                  <div className="space-y-4">
+                    {!isEditingNextSigner && (
+                      <div>
+                        <p className="text-muted-foreground text-sm">
+                          The next recipient to sign this document will be{' '}
+                          <span className="font-semibold">{form.watch('name')}</span> (
+                          <span className="font-semibold">{form.watch('email')}</span>).
+                        </p>
 
-        <DialogFooter className="mt-4">
-          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
-            Cancel
-          </Button>
-          <Button
-            variant={hasUninsertedFields ? 'destructive' : 'default'}
-            onClick={onConfirm}
-            disabled={isSubmitting}
-            loading={isSubmitting}
-          >
-            {isSubmitting ? 'Submitting...' : hasUninsertedFields ? 'Proceed' : 'Continue'}
-          </Button>
-        </DialogFooter>
+                        <Button
+                          type="button"
+                          className="mt-2"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setIsEditingNextSigner((prev) => !prev)}
+                        >
+                          <Trans>Update Recipient</Trans>
+                        </Button>
+                      </div>
+                    )}
+
+                    {isEditingNextSigner && (
+                      <div className="flex flex-col gap-4 md:flex-row">
+                        <FormField
+                          control={form.control}
+                          name="name"
+                          render={({ field }) => (
+                            <FormItem className="flex-1">
+                              <FormLabel>
+                                <Trans>Name</Trans>
+                              </FormLabel>
+                              <FormControl>
+                                <Input
+                                  {...field}
+                                  className="mt-2"
+                                  placeholder="Enter the next signer's name"
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+
+                        <FormField
+                          control={form.control}
+                          name="email"
+                          render={({ field }) => (
+                            <FormItem className="flex-1">
+                              <FormLabel>
+                                <Trans>Email</Trans>
+                              </FormLabel>
+                              <FormControl>
+                                <Input
+                                  {...field}
+                                  type="email"
+                                  className="mt-2"
+                                  placeholder="Enter the next signer's email"
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                <DocumentSigningDisclosure className="mt-4" />
+              </div>
+
+              <DialogFooter className="mt-4">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={onClose}
+                  disabled={form.formState.isSubmitting}
+                >
+                  <Trans>Cancel</Trans>
+                </Button>
+                <Button
+                  type="submit"
+                  variant={hasUninsertedFields ? 'destructive' : 'default'}
+                  disabled={form.formState.isSubmitting || !isNextSignerValid}
+                  loading={form.formState.isSubmitting}
+                >
+                  {form.formState.isSubmitting ? (
+                    <Trans>Submitting...</Trans>
+                  ) : hasUninsertedFields ? (
+                    <Trans>Proceed</Trans>
+                  ) : (
+                    <Trans>Continue</Trans>
+                  )}
+                </Button>
+              </DialogFooter>
+            </fieldset>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/apps/remix/app/components/general/document-signing/document-signing-complete-dialog.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-complete-dialog.tsx
@@ -1,9 +1,12 @@
 import { useMemo, useState } from 'react';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Trans } from '@lingui/react/macro';
 import type { Field } from '@prisma/client';
 import { RecipientRole } from '@prisma/client';
+import { useForm } from 'react-hook-form';
 import { match } from 'ts-pattern';
+import { z } from 'zod';
 
 import { fieldsContainUnsignedRequiredField } from '@documenso/lib/utils/advanced-fields-helpers';
 import { Button } from '@documenso/ui/primitives/button';
@@ -14,6 +17,15 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@documenso/ui/primitives/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@documenso/ui/primitives/form/form';
+import { Input } from '@documenso/ui/primitives/input';
 
 import { DocumentSigningDisclosure } from '~/components/general/document-signing/document-signing-disclosure';
 
@@ -22,10 +34,22 @@ export type DocumentSigningCompleteDialogProps = {
   documentTitle: string;
   fields: Field[];
   fieldsValidated: () => void | Promise<void>;
-  onSignatureComplete: () => void | Promise<void>;
+  onSignatureComplete: (nextSigner?: { name: string; email: string }) => void | Promise<void>;
   role: RecipientRole;
   disabled?: boolean;
+  allowDictateNextSigner?: boolean;
+  defaultNextSigner?: {
+    name: string;
+    email: string;
+  };
 };
+
+const ZNextSignerFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+});
+
+type TNextSignerFormSchema = z.infer<typeof ZNextSignerFormSchema>;
 
 export const DocumentSigningCompleteDialog = ({
   isSubmitting,
@@ -35,18 +59,53 @@ export const DocumentSigningCompleteDialog = ({
   onSignatureComplete,
   role,
   disabled = false,
+  allowDictateNextSigner = false,
+  defaultNextSigner,
 }: DocumentSigningCompleteDialogProps) => {
   const [showDialog, setShowDialog] = useState(false);
+  const [isEditingNextSigner, setIsEditingNextSigner] = useState(false);
+
+  const form = useForm<TNextSignerFormSchema>({
+    resolver: allowDictateNextSigner ? zodResolver(ZNextSignerFormSchema) : undefined,
+    defaultValues: {
+      name: defaultNextSigner?.name ?? '',
+      email: defaultNextSigner?.email ?? '',
+    },
+  });
 
   const isComplete = useMemo(() => !fieldsContainUnsignedRequiredField(fields), [fields]);
 
   const handleOpenChange = (open: boolean) => {
-    if (isSubmitting || !isComplete) {
+    if (form.formState.isSubmitting || !isComplete) {
       return;
     }
 
+    if (open) {
+      form.reset({
+        name: defaultNextSigner?.name ?? '',
+        email: defaultNextSigner?.email ?? '',
+      });
+    }
+
+    setIsEditingNextSigner(false);
     setShowDialog(open);
   };
+
+  const onFormSubmit = async (data: TNextSignerFormSchema) => {
+    console.log('data', data);
+    console.log('form.formState.errors', form.formState.errors);
+    try {
+      if (allowDictateNextSigner && data.name && data.email) {
+        await onSignatureComplete({ name: data.name, email: data.email });
+      } else {
+        await onSignatureComplete();
+      }
+    } catch (error) {
+      console.error('Error completing signature:', error);
+    }
+  };
+
+  const isNextSignerValid = !allowDictateNextSigner || (form.watch('name') && form.watch('email'));
 
   return (
     <Dialog open={showDialog} onOpenChange={handleOpenChange}>
@@ -71,110 +130,184 @@ export const DocumentSigningCompleteDialog = ({
       </DialogTrigger>
 
       <DialogContent>
-        <DialogTitle>
-          <div className="text-foreground text-xl font-semibold">
-            {match(role)
-              .with(RecipientRole.VIEWER, () => <Trans>Complete Viewing</Trans>)
-              .with(RecipientRole.SIGNER, () => <Trans>Complete Signing</Trans>)
-              .with(RecipientRole.APPROVER, () => <Trans>Complete Approval</Trans>)
-              .with(RecipientRole.CC, () => <Trans>Complete Viewing</Trans>)
-              .with(RecipientRole.ASSISTANT, () => <Trans>Complete Assisting</Trans>)
-              .exhaustive()}
-          </div>
-        </DialogTitle>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onFormSubmit)}>
+            <fieldset disabled={form.formState.isSubmitting} className="border-none p-0">
+              <DialogTitle>
+                <div className="text-foreground text-xl font-semibold">
+                  {match(role)
+                    .with(RecipientRole.VIEWER, () => <Trans>Complete Viewing</Trans>)
+                    .with(RecipientRole.SIGNER, () => <Trans>Complete Signing</Trans>)
+                    .with(RecipientRole.APPROVER, () => <Trans>Complete Approval</Trans>)
+                    .with(RecipientRole.CC, () => <Trans>Complete Viewing</Trans>)
+                    .with(RecipientRole.ASSISTANT, () => <Trans>Complete Assisting</Trans>)
+                    .exhaustive()}
+                </div>
+              </DialogTitle>
 
-        <div className="text-muted-foreground max-w-[50ch]">
-          {match(role)
-            .with(RecipientRole.VIEWER, () => (
-              <span>
-                <Trans>
-                  <span className="inline-flex flex-wrap">
-                    You are about to complete viewing "
-                    <span className="inline-block max-w-[11rem] truncate align-baseline">
-                      {documentTitle}
+              <div className="text-muted-foreground max-w-[50ch]">
+                {match(role)
+                  .with(RecipientRole.VIEWER, () => (
+                    <span>
+                      <Trans>
+                        <span className="inline-flex flex-wrap">
+                          You are about to complete viewing "
+                          <span className="inline-block max-w-[11rem] truncate align-baseline">
+                            {documentTitle}
+                          </span>
+                          ".
+                        </span>
+                        <br /> Are you sure?
+                      </Trans>
                     </span>
-                    ".
-                  </span>
-                  <br /> Are you sure?
-                </Trans>
-              </span>
-            ))
-            .with(RecipientRole.SIGNER, () => (
-              <span>
-                <Trans>
-                  <span className="inline-flex flex-wrap">
-                    You are about to complete signing "
-                    <span className="inline-block max-w-[11rem] truncate align-baseline">
-                      {documentTitle}
+                  ))
+                  .with(RecipientRole.SIGNER, () => (
+                    <span>
+                      <Trans>
+                        <span className="inline-flex flex-wrap">
+                          You are about to complete signing "
+                          <span className="inline-block max-w-[11rem] truncate align-baseline">
+                            {documentTitle}
+                          </span>
+                          ".
+                        </span>
+                        <br /> Are you sure?
+                      </Trans>
                     </span>
-                    ".
-                  </span>
-                  <br /> Are you sure?
-                </Trans>
-              </span>
-            ))
-            .with(RecipientRole.APPROVER, () => (
-              <span>
-                <Trans>
-                  <span className="inline-flex flex-wrap">
-                    You are about to complete approving{' '}
-                    <span className="inline-block max-w-[11rem] truncate align-baseline">
-                      "{documentTitle}"
+                  ))
+                  .with(RecipientRole.APPROVER, () => (
+                    <span>
+                      <Trans>
+                        <span className="inline-flex flex-wrap">
+                          You are about to complete approving{' '}
+                          <span className="inline-block max-w-[11rem] truncate align-baseline">
+                            "{documentTitle}"
+                          </span>
+                          .
+                        </span>
+                        <br /> Are you sure?
+                      </Trans>
                     </span>
-                    .
-                  </span>
-                  <br /> Are you sure?
-                </Trans>
-              </span>
-            ))
-            .otherwise(() => (
-              <span>
-                <Trans>
-                  <span className="inline-flex flex-wrap">
-                    You are about to complete viewing "
-                    <span className="inline-block max-w-[11rem] truncate align-baseline">
-                      {documentTitle}
+                  ))
+                  .otherwise(() => (
+                    <span>
+                      <Trans>
+                        <span className="inline-flex flex-wrap">
+                          You are about to complete viewing "
+                          <span className="inline-block max-w-[11rem] truncate align-baseline">
+                            {documentTitle}
+                          </span>
+                          ".
+                        </span>
+                        <br /> Are you sure?
+                      </Trans>
                     </span>
-                    ".
-                  </span>
-                  <br /> Are you sure?
-                </Trans>
-              </span>
-            ))}
-        </div>
+                  ))}
+              </div>
 
-        <DocumentSigningDisclosure className="mt-4" />
+              {allowDictateNextSigner && (
+                <div className="mt-4 flex flex-col gap-4">
+                  {!isEditingNextSigner && (
+                    <div>
+                      <p className="text-muted-foreground text-sm">
+                        The next recipient to sign this document will be{' '}
+                        <span className="font-semibold">{form.watch('name')}</span> (
+                        <span className="font-semibold">{form.watch('email')}</span>).
+                      </p>
 
-        <DialogFooter>
-          <div className="flex w-full flex-1 flex-nowrap gap-4">
-            <Button
-              type="button"
-              className="dark:bg-muted dark:hover:bg-muted/80 flex-1 bg-black/5 hover:bg-black/10"
-              variant="secondary"
-              onClick={() => {
-                setShowDialog(false);
-              }}
-            >
-              <Trans>Cancel</Trans>
-            </Button>
+                      <Button
+                        type="button"
+                        className="mt-2"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setIsEditingNextSigner((prev) => !prev)}
+                      >
+                        <Trans>Update Recipient</Trans>
+                      </Button>
+                    </div>
+                  )}
 
-            <Button
-              type="button"
-              className="flex-1"
-              disabled={!isComplete}
-              loading={isSubmitting}
-              onClick={onSignatureComplete}
-            >
-              {match(role)
-                .with(RecipientRole.VIEWER, () => <Trans>Mark as Viewed</Trans>)
-                .with(RecipientRole.SIGNER, () => <Trans>Sign</Trans>)
-                .with(RecipientRole.APPROVER, () => <Trans>Approve</Trans>)
-                .with(RecipientRole.CC, () => <Trans>Mark as Viewed</Trans>)
-                .with(RecipientRole.ASSISTANT, () => <Trans>Complete</Trans>)
-                .exhaustive()}
-            </Button>
-          </div>
-        </DialogFooter>
+                  {isEditingNextSigner && (
+                    <div className="flex flex-col gap-4 md:flex-row">
+                      <FormField
+                        control={form.control}
+                        name="name"
+                        render={({ field }) => (
+                          <FormItem className="flex-1">
+                            <FormLabel>
+                              <Trans>Name</Trans>
+                            </FormLabel>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                className="mt-2"
+                                placeholder="Enter the next signer's name"
+                              />
+                            </FormControl>
+
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name="email"
+                        render={({ field }) => (
+                          <FormItem className="flex-1">
+                            <FormLabel>
+                              <Trans>Email</Trans>
+                            </FormLabel>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                type="email"
+                                className="mt-2"
+                                placeholder="Enter the next signer's email"
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <DocumentSigningDisclosure className="mt-4" />
+
+              <DialogFooter className="mt-4">
+                <div className="flex w-full flex-1 flex-nowrap gap-4">
+                  <Button
+                    type="button"
+                    className="dark:bg-muted dark:hover:bg-muted/80 flex-1 bg-black/5 hover:bg-black/10"
+                    variant="secondary"
+                    onClick={() => setShowDialog(false)}
+                    disabled={form.formState.isSubmitting}
+                  >
+                    <Trans>Cancel</Trans>
+                  </Button>
+
+                  <Button
+                    type="submit"
+                    className="flex-1"
+                    disabled={!isComplete || !isNextSignerValid}
+                    loading={form.formState.isSubmitting}
+                  >
+                    {match(role)
+                      .with(RecipientRole.VIEWER, () => <Trans>Mark as Viewed</Trans>)
+                      .with(RecipientRole.SIGNER, () => <Trans>Sign</Trans>)
+                      .with(RecipientRole.APPROVER, () => <Trans>Approve</Trans>)
+                      .with(RecipientRole.CC, () => <Trans>Mark as Viewed</Trans>)
+                      .with(RecipientRole.ASSISTANT, () => <Trans>Complete</Trans>)
+                      .exhaustive()}
+                  </Button>
+                </div>
+              </DialogFooter>
+            </fieldset>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/apps/remix/app/components/general/document-signing/document-signing-form.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-form.tsx
@@ -469,7 +469,7 @@ export const DocumentSigningForm = ({
                     documentTitle={document.title}
                     fields={fields}
                     fieldsValidated={fieldsValidated}
-                    disabled={isRecipientsTurn}
+                    disabled={!isRecipientsTurn}
                     onSignatureComplete={async (nextSigner) => {
                       await completeDocument(undefined, nextSigner);
                     }}

--- a/apps/remix/app/components/general/document-signing/document-signing-form.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-form.tsx
@@ -49,7 +49,6 @@ export type DocumentSigningFormProps = {
   isRecipientsTurn: boolean;
   allRecipients?: RecipientWithFields[];
   setSelectedSignerId?: (id: number | null) => void;
-  nextPendingRecipient?: Recipient | null;
 };
 
 export const DocumentSigningForm = ({
@@ -60,7 +59,6 @@ export const DocumentSigningForm = ({
   isRecipientsTurn,
   allRecipients = [],
   setSelectedSignerId,
-  nextPendingRecipient,
 }: DocumentSigningFormProps) => {
   const { sessionData } = useOptionalSession();
   const user = sessionData?.user;
@@ -467,10 +465,11 @@ export const DocumentSigningForm = ({
                   </Button>
 
                   <DocumentSigningCompleteDialog
-                    isSubmitting={isSubmitting}
+                    isSubmitting={isSubmitting || isAssistantSubmitting}
                     documentTitle={document.title}
                     fields={fields}
                     fieldsValidated={fieldsValidated}
+                    disabled={isRecipientsTurn}
                     onSignatureComplete={async (nextSigner) => {
                       await completeDocument(undefined, nextSigner);
                     }}

--- a/apps/remix/app/components/general/document-signing/document-signing-form.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-form.tsx
@@ -1,11 +1,13 @@
 import { useId, useMemo, useState } from 'react';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
 import { type Field, FieldType, type Recipient, RecipientRole } from '@prisma/client';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
+import { z } from 'zod';
 
 import { useAnalytics } from '@documenso/lib/client-only/hooks/use-analytics';
 import { useOptionalSession } from '@documenso/lib/client-only/providers/session';
@@ -25,9 +27,19 @@ import { RadioGroup, RadioGroupItem } from '@documenso/ui/primitives/radio-group
 import { SignaturePad } from '@documenso/ui/primitives/signature-pad';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
-import { AssistantConfirmationDialog } from '../../dialogs/assistant-confirmation-dialog';
+import {
+  AssistantConfirmationDialog,
+  type NextSigner,
+} from '../../dialogs/assistant-confirmation-dialog';
 import { DocumentSigningCompleteDialog } from './document-signing-complete-dialog';
 import { useRequiredDocumentSigningContext } from './document-signing-provider';
+
+export const ZSigningFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').optional(),
+  email: z.string().email('Invalid email address').optional(),
+});
+
+export type TSigningFormSchema = z.infer<typeof ZSigningFormSchema>;
 
 export type DocumentSigningFormProps = {
   document: DocumentAndSender;
@@ -37,6 +49,7 @@ export type DocumentSigningFormProps = {
   isRecipientsTurn: boolean;
   allRecipients?: RecipientWithFields[];
   setSelectedSignerId?: (id: number | null) => void;
+  nextPendingRecipient?: Recipient | null;
 };
 
 export const DocumentSigningForm = ({
@@ -47,6 +60,7 @@ export const DocumentSigningForm = ({
   isRecipientsTurn,
   allRecipients = [],
   setSelectedSignerId,
+  nextPendingRecipient,
 }: DocumentSigningFormProps) => {
   const { sessionData } = useOptionalSession();
   const user = sessionData?.user;
@@ -75,7 +89,9 @@ export const DocumentSigningForm = ({
     },
   });
 
-  const { handleSubmit, formState } = useForm();
+  const { handleSubmit, formState } = useForm<TSigningFormSchema>({
+    resolver: zodResolver(ZSigningFormSchema),
+  });
 
   // Keep the loading state going if successful since the redirect may take some time.
   const isSubmitting = formState.isSubmitting || formState.isSubmitSuccessful;
@@ -100,20 +116,36 @@ export const DocumentSigningForm = ({
     validateFieldsInserted(fieldsRequiringValidation);
   };
 
-  const onFormSubmit = async () => {
-    setValidateUninsertedFields(true);
+  const onFormSubmit = async (data: TSigningFormSchema) => {
+    try {
+      setValidateUninsertedFields(true);
 
-    const isFieldsValid = validateFieldsInserted(fieldsRequiringValidation);
+      const isFieldsValid = validateFieldsInserted(fieldsRequiringValidation);
 
-    if (hasSignatureField && !signatureValid) {
-      return;
+      if (hasSignatureField && !signatureValid) {
+        return;
+      }
+
+      if (!isFieldsValid) {
+        return;
+      }
+
+      const nextSigner =
+        data.email && data.name
+          ? {
+              email: data.email,
+              name: data.name,
+            }
+          : undefined;
+
+      await completeDocument(undefined, nextSigner);
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'An error occurred while signing',
+        variant: 'destructive',
+      });
     }
-
-    if (!isFieldsValid) {
-      return;
-    }
-
-    await completeDocument();
   };
 
   const onAssistantFormSubmit = () => {
@@ -124,11 +156,11 @@ export const DocumentSigningForm = ({
     setIsConfirmationDialogOpen(true);
   };
 
-  const handleAssistantConfirmDialogSubmit = async () => {
+  const handleAssistantConfirmDialogSubmit = async (nextSigner?: NextSigner) => {
     setIsAssistantSubmitting(true);
 
     try {
-      await completeDocument();
+      await completeDocument(undefined, nextSigner);
     } catch (err) {
       toast({
         title: 'Error',
@@ -141,12 +173,18 @@ export const DocumentSigningForm = ({
     }
   };
 
-  const completeDocument = async (authOptions?: TRecipientActionAuth) => {
-    await completeDocumentWithToken({
+  const completeDocument = async (
+    authOptions?: TRecipientActionAuth,
+    nextSigner?: { email: string; name: string },
+  ) => {
+    const payload = {
       token: recipient.token,
       documentId: document.id,
       authOptions,
-    });
+      ...(nextSigner?.email && nextSigner?.name ? { nextSigner } : {}),
+    };
+
+    await completeDocumentWithToken(payload);
 
     analytics.capture('App: Recipient has completed signing', {
       signerId: recipient.id,
@@ -160,6 +198,31 @@ export const DocumentSigningForm = ({
       await navigate(`/sign/${recipient.token}/complete`);
     }
   };
+
+  const nextRecipient = useMemo(() => {
+    if (
+      !document.documentMeta?.signingOrder ||
+      document.documentMeta.signingOrder !== 'SEQUENTIAL'
+    ) {
+      return undefined;
+    }
+
+    const sortedRecipients = allRecipients.sort((a, b) => {
+      // Sort by signingOrder first (nulls last), then by id
+      if (a.signingOrder === null && b.signingOrder === null) return a.id - b.id;
+      if (a.signingOrder === null) return 1;
+      if (b.signingOrder === null) return -1;
+      if (a.signingOrder === b.signingOrder) return a.id - b.id;
+      return a.signingOrder - b.signingOrder;
+    });
+
+    const currentIndex = sortedRecipients.findIndex((r) => r.id === recipient.id);
+    return currentIndex !== -1 && currentIndex < sortedRecipients.length - 1
+      ? sortedRecipients[currentIndex + 1]
+      : undefined;
+  }, [document.documentMeta?.signingOrder, allRecipients, recipient.id]);
+
+  console.log('nextRecipient', nextRecipient);
 
   return (
     <div
@@ -210,12 +273,19 @@ export const DocumentSigningForm = ({
 
                   <DocumentSigningCompleteDialog
                     isSubmitting={isSubmitting}
-                    onSignatureComplete={handleSubmit(onFormSubmit)}
                     documentTitle={document.title}
                     fields={fields}
                     fieldsValidated={fieldsValidated}
+                    onSignatureComplete={async (nextSigner) => {
+                      await completeDocument(undefined, nextSigner);
+                    }}
                     role={recipient.role}
-                    disabled={!isRecipientsTurn}
+                    allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
+                    defaultNextSigner={
+                      nextRecipient
+                        ? { name: nextRecipient.name, email: nextRecipient.email }
+                        : undefined
+                    }
                   />
                 </div>
               </div>
@@ -306,6 +376,12 @@ export const DocumentSigningForm = ({
                   onClose={() => !isAssistantSubmitting && setIsConfirmationDialogOpen(false)}
                   onConfirm={handleAssistantConfirmDialogSubmit}
                   isSubmitting={isAssistantSubmitting}
+                  allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
+                  defaultNextSigner={
+                    nextRecipient
+                      ? { name: nextRecipient.name, email: nextRecipient.email }
+                      : undefined
+                  }
                 />
               </form>
             </>
@@ -376,30 +452,37 @@ export const DocumentSigningForm = ({
                       </div>
                     )}
                   </div>
-
-                  <div className="flex flex-col gap-4 md:flex-row">
-                    <Button
-                      type="button"
-                      className="dark:bg-muted dark:hover:bg-muted/80 w-full bg-black/5 hover:bg-black/10"
-                      variant="secondary"
-                      size="lg"
-                      disabled={typeof window !== 'undefined' && window.history.length <= 1}
-                      onClick={async () => navigate(-1)}
-                    >
-                      <Trans>Cancel</Trans>
-                    </Button>
-
-                    <DocumentSigningCompleteDialog
-                      isSubmitting={isSubmitting}
-                      onSignatureComplete={handleSubmit(onFormSubmit)}
-                      documentTitle={document.title}
-                      fields={fields}
-                      fieldsValidated={fieldsValidated}
-                      role={recipient.role}
-                      disabled={!isRecipientsTurn}
-                    />
-                  </div>
                 </fieldset>
+
+                <div className="mt-6 flex flex-col gap-4 md:flex-row">
+                  <Button
+                    type="button"
+                    className="dark:bg-muted dark:hover:bg-muted/80 w-full bg-black/5 hover:bg-black/10"
+                    variant="secondary"
+                    size="lg"
+                    disabled={typeof window !== 'undefined' && window.history.length <= 1}
+                    onClick={async () => navigate(-1)}
+                  >
+                    <Trans>Cancel</Trans>
+                  </Button>
+
+                  <DocumentSigningCompleteDialog
+                    isSubmitting={isSubmitting}
+                    documentTitle={document.title}
+                    fields={fields}
+                    fieldsValidated={fieldsValidated}
+                    onSignatureComplete={async (nextSigner) => {
+                      await completeDocument(undefined, nextSigner);
+                    }}
+                    role={recipient.role}
+                    allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
+                    defaultNextSigner={
+                      nextRecipient
+                        ? { name: nextRecipient.name, email: nextRecipient.email }
+                        : undefined
+                    }
+                  />
+                </div>
               </form>
             </>
           )}

--- a/apps/remix/app/components/general/document-signing/document-signing-page-view.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Trans } from '@lingui/react/macro';
-import type { Field } from '@prisma/client';
+import type { Field, Recipient } from '@prisma/client';
 import { FieldType, RecipientRole } from '@prisma/client';
 import { match } from 'ts-pattern';
 
@@ -40,23 +40,25 @@ import { DocumentReadOnlyFields } from '~/components/general/document/document-r
 
 import { DocumentSigningRecipientProvider } from './document-signing-recipient-provider';
 
-export type SigningPageViewProps = {
-  document: DocumentAndSender;
+export type DocumentSigningPageViewProps = {
   recipient: RecipientWithFields;
+  document: DocumentAndSender;
   fields: Field[];
   completedFields: CompletedField[];
   isRecipientsTurn: boolean;
   allRecipients?: RecipientWithFields[];
+  nextPendingRecipient?: Recipient | null;
 };
 
 export const DocumentSigningPageView = ({
-  document,
   recipient,
+  document,
   fields,
   completedFields,
   isRecipientsTurn,
   allRecipients = [],
-}: SigningPageViewProps) => {
+  nextPendingRecipient,
+}: DocumentSigningPageViewProps) => {
   const { documentData, documentMeta } = document;
 
   const [selectedSignerId, setSelectedSignerId] = useState<number | null>(allRecipients?.[0]?.id);
@@ -152,6 +154,7 @@ export const DocumentSigningPageView = ({
               redirectUrl={documentMeta?.redirectUrl}
               isRecipientsTurn={isRecipientsTurn}
               allRecipients={allRecipients}
+              nextPendingRecipient={nextPendingRecipient}
               setSelectedSignerId={setSelectedSignerId}
             />
           </div>

--- a/apps/remix/app/components/general/document-signing/document-signing-page-view.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Trans } from '@lingui/react/macro';
-import type { Field, Recipient } from '@prisma/client';
+import type { Field } from '@prisma/client';
 import { FieldType, RecipientRole } from '@prisma/client';
 import { match } from 'ts-pattern';
 
@@ -47,7 +47,6 @@ export type DocumentSigningPageViewProps = {
   completedFields: CompletedField[];
   isRecipientsTurn: boolean;
   allRecipients?: RecipientWithFields[];
-  nextPendingRecipient?: Recipient | null;
 };
 
 export const DocumentSigningPageView = ({
@@ -57,7 +56,6 @@ export const DocumentSigningPageView = ({
   completedFields,
   isRecipientsTurn,
   allRecipients = [],
-  nextPendingRecipient,
 }: DocumentSigningPageViewProps) => {
   const { documentData, documentMeta } = document;
 
@@ -154,7 +152,6 @@ export const DocumentSigningPageView = ({
               redirectUrl={documentMeta?.redirectUrl}
               isRecipientsTurn={isRecipientsTurn}
               allRecipients={allRecipients}
-              nextPendingRecipient={nextPendingRecipient}
               setSelectedSignerId={setSelectedSignerId}
             />
           </div>

--- a/apps/remix/app/components/general/document/document-edit-form.tsx
+++ b/apps/remix/app/components/general/document/document-edit-form.tsx
@@ -71,7 +71,7 @@ export const DocumentEditForm = ({
 
   const { recipients, fields } = document;
 
-  const { mutateAsync: updateDocument } = trpc.document.setSettingsForDocument.useMutation({
+  const { mutateAsync: updateDocumentSettings } = trpc.document.setSettingsForDocument.useMutation({
     ...DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
     onSuccess: (newData) => {
       utils.document.getDocumentWithDetailsById.setData(
@@ -176,7 +176,7 @@ export const DocumentEditForm = ({
     try {
       const { timezone, dateFormat, redirectUrl, language } = data.meta;
 
-      await updateDocument({
+      await updateDocumentSettings({
         documentId: document.id,
         data: {
           title: data.title,
@@ -213,6 +213,13 @@ export const DocumentEditForm = ({
           signingOrder: data.signingOrder,
         }),
 
+        updateDocumentSettings({
+          documentId: document.id,
+          meta: {
+            allowDictateNextSigner: data.allowDictateNextSigner,
+          },
+        }),
+
         setRecipients({
           documentId: document.id,
           recipients: data.signers.map((signer) => ({
@@ -242,7 +249,7 @@ export const DocumentEditForm = ({
         fields: data.fields,
       });
 
-      await updateDocument({
+      await updateDocumentSettings({
         documentId: document.id,
 
         meta: {
@@ -365,6 +372,7 @@ export const DocumentEditForm = ({
               documentFlow={documentFlow.signers}
               recipients={recipients}
               signingOrder={document.documentMeta?.signingOrder}
+              allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
               fields={fields}
               isDocumentEnterprise={isDocumentEnterprise}
               onSubmit={onAddSignersFormSubmit}

--- a/apps/remix/app/components/general/template/template-edit-form.tsx
+++ b/apps/remix/app/components/general/template/template-edit-form.tsx
@@ -161,6 +161,7 @@ export const TemplateEditForm = ({
           templateId: template.id,
           meta: {
             signingOrder: data.signingOrder,
+            allowDictateNextSigner: data.allowDictateNextSigner,
           },
         }),
 
@@ -271,6 +272,7 @@ export const TemplateEditForm = ({
               recipients={recipients}
               fields={fields}
               signingOrder={template.templateMeta?.signingOrder}
+              allowDictateNextSigner={template.templateMeta?.allowDictateNextSigner}
               templateDirectLink={template.directLink}
               onSubmit={onAddTemplatePlaceholderFormSubmit}
               isEnterprise={isEnterprise}

--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -323,6 +323,7 @@ export const ApiContractV1Implementation = tsr.router(ApiContractV1, {
         dateFormat: dateFormat?.value,
         redirectUrl: body.meta.redirectUrl,
         signingOrder: body.meta.signingOrder,
+        allowDictateNextSigner: body.meta.allowDictateNextSigner,
         language: body.meta.language,
         typedSignatureEnabled: body.meta.typedSignatureEnabled,
         distributionMethod: body.meta.distributionMethod,

--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -155,6 +155,7 @@ export const ZCreateDocumentMutationSchema = z.object({
         }),
       redirectUrl: z.string(),
       signingOrder: z.nativeEnum(DocumentSigningOrder).optional(),
+      allowDictateNextSigner: z.boolean().optional(),
       language: z.enum(SUPPORTED_LANGUAGE_CODES).optional(),
       typedSignatureEnabled: z.boolean().optional().default(true),
       distributionMethod: z.nativeEnum(DocumentDistributionMethod).optional(),
@@ -218,6 +219,7 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
       dateFormat: z.string(),
       redirectUrl: z.string(),
       signingOrder: z.nativeEnum(DocumentSigningOrder).optional(),
+      allowDictateNextSigner: z.boolean().optional(),
       language: z.enum(SUPPORTED_LANGUAGE_CODES).optional(),
     })
     .partial()
@@ -285,6 +287,7 @@ export const ZGenerateDocumentFromTemplateMutationSchema = z.object({
       dateFormat: z.string(),
       redirectUrl: ZUrlSchema,
       signingOrder: z.nativeEnum(DocumentSigningOrder),
+      allowDictateNextSigner: z.boolean(),
       language: z.enum(SUPPORTED_LANGUAGE_CODES),
       distributionMethod: z.nativeEnum(DocumentDistributionMethod),
       typedSignatureEnabled: z.boolean(),

--- a/packages/app-tests/e2e/document-auth/action-auth.spec.ts
+++ b/packages/app-tests/e2e/document-auth/action-auth.spec.ts
@@ -210,7 +210,7 @@ test('[DOCUMENT_AUTH]: should allow field signing when required for recipient au
         }),
       },
     ],
-    fields: [FieldType.DATE],
+    fields: [FieldType.DATE, FieldType.SIGNATURE],
   });
 
   for (const recipient of recipients) {
@@ -307,7 +307,7 @@ test('[DOCUMENT_AUTH]: should allow field signing when required for recipient an
         }),
       },
     ],
-    fields: [FieldType.DATE],
+    fields: [FieldType.DATE, FieldType.SIGNATURE],
     updateDocumentOptions: {
       authOptions: createDocumentAuthOptions({
         globalAccessAuth: null,

--- a/packages/app-tests/e2e/document-auth/next-recipient-dictation.spec.ts
+++ b/packages/app-tests/e2e/document-auth/next-recipient-dictation.spec.ts
@@ -1,0 +1,390 @@
+import { expect, test } from '@playwright/test';
+import {
+  DocumentSigningOrder,
+  DocumentStatus,
+  FieldType,
+  RecipientRole,
+  SigningStatus,
+} from '@prisma/client';
+
+import { prisma } from '@documenso/prisma';
+import { seedPendingDocumentWithFullFields } from '@documenso/prisma/seed/documents';
+import { seedUser } from '@documenso/prisma/seed/users';
+
+import { signSignaturePad } from '../fixtures/signature';
+
+test('[NEXT_RECIPIENT_DICTATION]: should allow updating next recipient when dictation is enabled', async ({
+  page,
+}) => {
+  const user = await seedUser();
+  const firstSigner = await seedUser();
+  const secondSigner = await seedUser();
+  const thirdSigner = await seedUser();
+
+  const { recipients, document } = await seedPendingDocumentWithFullFields({
+    owner: user,
+    recipients: [firstSigner, secondSigner, thirdSigner],
+    recipientsCreateOptions: [{ signingOrder: 1 }, { signingOrder: 2 }, { signingOrder: 3 }],
+    updateDocumentOptions: {
+      documentMeta: {
+        upsert: {
+          create: {
+            allowDictateNextSigner: true,
+            signingOrder: DocumentSigningOrder.SEQUENTIAL,
+          },
+          update: {
+            allowDictateNextSigner: true,
+            signingOrder: DocumentSigningOrder.SEQUENTIAL,
+          },
+        },
+      },
+    },
+  });
+
+  const firstRecipient = recipients[0];
+  const { token, fields } = firstRecipient;
+
+  const signUrl = `/sign/${token}`;
+
+  await page.goto(signUrl);
+  await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+
+  await signSignaturePad(page);
+
+  // Fill in all fields
+  for (const field of fields) {
+    await page.locator(`#field-${field.id}`).getByRole('button').click();
+
+    if (field.type === FieldType.TEXT) {
+      await page.locator('#custom-text').fill('TEXT');
+      await page.getByRole('button', { name: 'Save' }).click();
+    }
+
+    await expect(page.locator(`#field-${field.id}`)).toHaveAttribute('data-inserted', 'true');
+  }
+
+  // Complete signing and update next recipient
+  await page.getByRole('button', { name: 'Complete' }).click();
+
+  // Verify next recipient info is shown
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByText('The next recipient to sign this document will be')).toBeVisible();
+
+  // Update next recipient
+  await page.locator('button').filter({ hasText: 'Update Recipient' }).click();
+  await page.waitForTimeout(1000);
+
+  // Use dialog context to ensure we're targeting the correct form fields
+  const dialog = page.getByRole('dialog');
+  await dialog.getByLabel('Name').fill('New Recipient');
+  await dialog.getByLabel('Email').fill('new.recipient@example.com');
+
+  // Submit and verify completion
+  await page.getByRole('button', { name: 'Sign' }).click();
+  await page.waitForURL(`${signUrl}/complete`);
+
+  // Verify document and recipient states
+  const updatedDocument = await prisma.document.findUniqueOrThrow({
+    where: { id: document.id },
+    include: {
+      recipients: {
+        orderBy: { signingOrder: 'asc' },
+      },
+    },
+  });
+
+  // Document should still be pending as there are more recipients
+  expect(updatedDocument.status).toBe(DocumentStatus.PENDING);
+
+  // First recipient should be completed
+  const updatedFirstRecipient = updatedDocument.recipients[0];
+  expect(updatedFirstRecipient.signingStatus).toBe(SigningStatus.SIGNED);
+
+  // Second recipient should be the new recipient
+  const updatedSecondRecipient = updatedDocument.recipients[1];
+  expect(updatedSecondRecipient.name).toBe('New Recipient');
+  expect(updatedSecondRecipient.email).toBe('new.recipient@example.com');
+  expect(updatedSecondRecipient.signingOrder).toBe(2);
+  expect(updatedSecondRecipient.signingStatus).toBe(SigningStatus.NOT_SIGNED);
+});
+
+test('[NEXT_RECIPIENT_DICTATION]: should not show dictation UI when disabled', async ({ page }) => {
+  const user = await seedUser();
+  const firstSigner = await seedUser();
+  const secondSigner = await seedUser();
+
+  const { recipients, document } = await seedPendingDocumentWithFullFields({
+    owner: user,
+    recipients: [firstSigner, secondSigner],
+    recipientsCreateOptions: [{ signingOrder: 1 }, { signingOrder: 2 }],
+    updateDocumentOptions: {
+      documentMeta: {
+        upsert: {
+          create: {
+            allowDictateNextSigner: false,
+            signingOrder: DocumentSigningOrder.SEQUENTIAL,
+          },
+          update: {
+            allowDictateNextSigner: false,
+            signingOrder: DocumentSigningOrder.SEQUENTIAL,
+          },
+        },
+      },
+    },
+  });
+
+  const firstRecipient = recipients[0];
+  const { token, fields } = firstRecipient;
+
+  const signUrl = `/sign/${token}`;
+
+  await page.goto(signUrl);
+  await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+
+  await signSignaturePad(page);
+
+  // Fill in all fields
+  for (const field of fields) {
+    await page.locator(`#field-${field.id}`).getByRole('button').click();
+
+    if (field.type === FieldType.TEXT) {
+      await page.locator('#custom-text').fill('TEXT');
+      await page.getByRole('button', { name: 'Save' }).click();
+    }
+
+    await expect(page.locator(`#field-${field.id}`)).toHaveAttribute('data-inserted', 'true');
+  }
+
+  // Complete signing
+  await page.getByRole('button', { name: 'Complete' }).click();
+
+  // Verify next recipient UI is not shown
+  await expect(
+    page.getByText('The next recipient to sign this document will be'),
+  ).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'Update Recipient' })).not.toBeVisible();
+
+  // Submit and verify completion
+  await page.getByRole('button', { name: 'Sign' }).click();
+  await page.waitForURL(`${signUrl}/complete`);
+
+  // Verify document and recipient states
+
+  const updatedDocument = await prisma.document.findUniqueOrThrow({
+    where: { id: document.id },
+    include: {
+      recipients: {
+        orderBy: { signingOrder: 'asc' },
+      },
+    },
+  });
+
+  // Document should still be pending as there are more recipients
+  expect(updatedDocument.status).toBe(DocumentStatus.PENDING);
+
+  // First recipient should be completed
+  const updatedFirstRecipient = updatedDocument.recipients[0];
+  expect(updatedFirstRecipient.signingStatus).toBe(SigningStatus.SIGNED);
+
+  // Second recipient should remain unchanged
+  const updatedSecondRecipient = updatedDocument.recipients[1];
+  expect(updatedSecondRecipient.email).toBe(secondSigner.email);
+  expect(updatedSecondRecipient.signingOrder).toBe(2);
+  expect(updatedSecondRecipient.signingStatus).toBe(SigningStatus.NOT_SIGNED);
+});
+
+test('[NEXT_RECIPIENT_DICTATION]: should work with parallel signing flow', async ({ page }) => {
+  const user = await seedUser();
+  const firstSigner = await seedUser();
+  const secondSigner = await seedUser();
+
+  const { recipients, document } = await seedPendingDocumentWithFullFields({
+    owner: user,
+    recipients: [firstSigner, secondSigner],
+    recipientsCreateOptions: [{ signingOrder: 1 }, { signingOrder: 2 }],
+    updateDocumentOptions: {
+      documentMeta: {
+        upsert: {
+          create: {
+            allowDictateNextSigner: false,
+            signingOrder: DocumentSigningOrder.PARALLEL,
+          },
+          update: {
+            allowDictateNextSigner: false,
+            signingOrder: DocumentSigningOrder.PARALLEL,
+          },
+        },
+      },
+    },
+  });
+
+  // Test both recipients can sign in parallel
+  for (const recipient of recipients) {
+    const { token, fields } = recipient;
+    const signUrl = `/sign/${token}`;
+
+    await page.goto(signUrl);
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+
+    await signSignaturePad(page);
+
+    // Fill in all fields
+    for (const field of fields) {
+      await page.locator(`#field-${field.id}`).getByRole('button').click();
+
+      if (field.type === FieldType.TEXT) {
+        await page.locator('#custom-text').fill('TEXT');
+        await page.getByRole('button', { name: 'Save' }).click();
+      }
+
+      await expect(page.locator(`#field-${field.id}`)).toHaveAttribute('data-inserted', 'true');
+    }
+
+    // Complete signing
+    await page.getByRole('button', { name: 'Complete' }).click();
+
+    // Verify next recipient UI is not shown in parallel flow
+    await expect(
+      page.getByText('The next recipient to sign this document will be'),
+    ).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Update Recipient' })).not.toBeVisible();
+
+    // Submit and verify completion
+    await page.getByRole('button', { name: 'Sign' }).click();
+    await page.waitForURL(`${signUrl}/complete`);
+  }
+
+  // Verify final document and recipient states
+  await expect(async () => {
+    const updatedDocument = await prisma.document.findUniqueOrThrow({
+      where: { id: document.id },
+      include: {
+        recipients: {
+          orderBy: { signingOrder: 'asc' },
+        },
+      },
+    });
+
+    // Document should be completed since all recipients have signed
+    expect(updatedDocument.status).toBe(DocumentStatus.COMPLETED);
+
+    // All recipients should be completed
+    for (const recipient of updatedDocument.recipients) {
+      expect(recipient.signingStatus).toBe(SigningStatus.SIGNED);
+    }
+  }).toPass();
+});
+
+test('[NEXT_RECIPIENT_DICTATION]: should allow assistant to dictate next signer', async ({
+  page,
+}) => {
+  const user = await seedUser();
+  const assistant = await seedUser();
+  const signer = await seedUser();
+  const thirdSigner = await seedUser();
+
+  const { recipients, document } = await seedPendingDocumentWithFullFields({
+    owner: user,
+    recipients: [assistant, signer, thirdSigner],
+    recipientsCreateOptions: [
+      { signingOrder: 1, role: RecipientRole.ASSISTANT },
+      { signingOrder: 2, role: RecipientRole.SIGNER },
+      { signingOrder: 3, role: RecipientRole.SIGNER },
+    ],
+    updateDocumentOptions: {
+      documentMeta: {
+        upsert: {
+          create: {
+            allowDictateNextSigner: true,
+            signingOrder: DocumentSigningOrder.SEQUENTIAL,
+          },
+          update: {
+            allowDictateNextSigner: true,
+            signingOrder: DocumentSigningOrder.SEQUENTIAL,
+          },
+        },
+      },
+    },
+  });
+
+  const assistantRecipient = recipients[0];
+  const { token, fields } = assistantRecipient;
+
+  const signUrl = `/sign/${token}`;
+
+  await page.goto(signUrl);
+  await expect(page.getByRole('heading', { name: 'Assist Document' })).toBeVisible();
+
+  await page.getByRole('radio', { name: assistantRecipient.name }).click();
+
+  // Fill in all fields
+  for (const field of fields) {
+    await page.locator(`#field-${field.id}`).getByRole('button').click();
+
+    if (field.type === FieldType.SIGNATURE) {
+      await signSignaturePad(page);
+      await page.getByRole('button', { name: 'Sign', exact: true }).click();
+    }
+
+    if (field.type === FieldType.TEXT) {
+      await page.locator('#custom-text').fill('TEXT');
+      await page.getByRole('button', { name: 'Save' }).click();
+    }
+
+    await expect(page.locator(`#field-${field.id}`)).toHaveAttribute('data-inserted', 'true');
+  }
+
+  // Complete assisting and update next recipient
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Verify next recipient info is shown
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByText('The next recipient to sign this document will be')).toBeVisible();
+
+  // Update next recipient
+  await page.locator('button').filter({ hasText: 'Update Recipient' }).click();
+
+  // Use dialog context to ensure we're targeting the correct form fields
+  const dialog = page.getByRole('dialog');
+  await dialog.getByLabel('Name').fill('New Signer');
+  await dialog.getByLabel('Email').fill('new.signer@example.com');
+
+  // Submit and verify completion
+  await page.getByRole('button', { name: /Continue|Proceed/i }).click();
+  await page.waitForURL(`${signUrl}/complete`);
+
+  // Verify document and recipient states
+  await expect(async () => {
+    const updatedDocument = await prisma.document.findUniqueOrThrow({
+      where: { id: document.id },
+      include: {
+        recipients: {
+          orderBy: { signingOrder: 'asc' },
+        },
+      },
+    });
+
+    // Document should still be pending as there are more recipients
+    expect(updatedDocument.status).toBe(DocumentStatus.PENDING);
+
+    // Assistant should be completed
+    const updatedAssistant = updatedDocument.recipients[0];
+    expect(updatedAssistant.signingStatus).toBe(SigningStatus.SIGNED);
+    expect(updatedAssistant.role).toBe(RecipientRole.ASSISTANT);
+
+    // Second recipient should be the new signer
+    const updatedSigner = updatedDocument.recipients[1];
+    expect(updatedSigner.name).toBe('New Signer');
+    expect(updatedSigner.email).toBe('new.signer@example.com');
+    expect(updatedSigner.signingOrder).toBe(2);
+    expect(updatedSigner.signingStatus).toBe(SigningStatus.NOT_SIGNED);
+    expect(updatedSigner.role).toBe(RecipientRole.SIGNER);
+
+    // Third recipient should remain unchanged
+    const thirdRecipient = updatedDocument.recipients[2];
+    expect(thirdRecipient.email).toBe(thirdSigner.email);
+    expect(thirdRecipient.signingOrder).toBe(3);
+    expect(thirdRecipient.signingStatus).toBe(SigningStatus.NOT_SIGNED);
+    expect(thirdRecipient.role).toBe(RecipientRole.SIGNER);
+  }).toPass();
+});

--- a/packages/app-tests/e2e/public-profiles/public-profiles.spec.ts
+++ b/packages/app-tests/e2e/public-profiles/public-profiles.spec.ts
@@ -56,6 +56,7 @@ test('[PUBLIC_PROFILE]: create profile', async ({ page }) => {
   // Go back to public profile page.
   await page.goto(`${NEXT_PUBLIC_WEBAPP_URL()}/settings/public-profile`);
   await page.getByRole('switch').click();
+  await page.waitForTimeout(1000);
 
   // Assert values.
   await page.goto(`${NEXT_PUBLIC_WEBAPP_URL()}/p/${publicProfileUrl}`);
@@ -127,6 +128,7 @@ test('[PUBLIC_PROFILE]: create team profile', async ({ page }) => {
   // Go back to public profile page.
   await page.goto(`${NEXT_PUBLIC_WEBAPP_URL()}/t/${team.url}/settings/public-profile`);
   await page.getByRole('switch').click();
+  await page.waitForTimeout(1000);
 
   // Assert values.
   await page.goto(`${NEXT_PUBLIC_WEBAPP_URL()}/p/${publicProfileUrl}`);

--- a/packages/lib/server-only/document-meta/upsert-document-meta.ts
+++ b/packages/lib/server-only/document-meta/upsert-document-meta.ts
@@ -24,6 +24,7 @@ export type CreateDocumentMetaOptions = {
   redirectUrl?: string;
   emailSettings?: TDocumentEmailSettings;
   signingOrder?: DocumentSigningOrder;
+  allowDictateNextSigner?: boolean;
   distributionMethod?: DocumentDistributionMethod;
   typedSignatureEnabled?: boolean;
   language?: SupportedLanguageCodes;
@@ -41,6 +42,7 @@ export const upsertDocumentMeta = async ({
   password,
   redirectUrl,
   signingOrder,
+  allowDictateNextSigner,
   emailSettings,
   distributionMethod,
   typedSignatureEnabled,
@@ -93,6 +95,7 @@ export const upsertDocumentMeta = async ({
         documentId,
         redirectUrl,
         signingOrder,
+        allowDictateNextSigner,
         emailSettings,
         distributionMethod,
         typedSignatureEnabled,
@@ -106,6 +109,7 @@ export const upsertDocumentMeta = async ({
         timezone,
         redirectUrl,
         signingOrder,
+        allowDictateNextSigner,
         emailSettings,
         distributionMethod,
         typedSignatureEnabled,

--- a/packages/lib/server-only/recipient/get-next-pending-recipient.ts
+++ b/packages/lib/server-only/recipient/get-next-pending-recipient.ts
@@ -1,0 +1,37 @@
+import { prisma } from '@documenso/prisma';
+
+export const getNextPendingRecipient = async ({
+  documentId,
+  currentRecipientId,
+}: {
+  documentId: number;
+  currentRecipientId: number;
+}) => {
+  const recipients = await prisma.recipient.findMany({
+    where: {
+      documentId,
+    },
+    orderBy: [
+      {
+        signingOrder: {
+          sort: 'asc',
+          nulls: 'last',
+        },
+      },
+      {
+        id: 'asc',
+      },
+    ],
+  });
+
+  const currentIndex = recipients.findIndex((r) => r.id === currentRecipientId);
+
+  if (currentIndex === -1 || currentIndex === recipients.length - 1) {
+    return null;
+  }
+
+  return {
+    ...recipients[currentIndex + 1],
+    token: '',
+  };
+};

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -83,6 +83,7 @@ export type CreateDocumentFromTemplateOptions = {
     language?: SupportedLanguageCodes;
     distributionMethod?: DocumentDistributionMethod;
     typedSignatureEnabled?: boolean;
+    allowDictateNextSigner?: boolean;
     emailSettings?: TDocumentEmailSettings;
   };
   requestMetadata: ApiRequestMetadata;
@@ -404,6 +405,10 @@ export const createDocumentFromTemplate = async ({
               template.team?.teamGlobalSettings?.documentLanguage,
             typedSignatureEnabled:
               override?.typedSignatureEnabled ?? template.templateMeta?.typedSignatureEnabled,
+            allowDictateNextSigner:
+              override?.allowDictateNextSigner ??
+              template.templateMeta?.allowDictateNextSigner ??
+              false,
           },
         },
         recipients: {

--- a/packages/lib/types/document.ts
+++ b/packages/lib/types/document.ts
@@ -51,6 +51,7 @@ export const ZDocumentSchema = DocumentSchema.pick({
     documentId: true,
     redirectUrl: true,
     typedSignatureEnabled: true,
+    allowDictateNextSigner: true,
     language: true,
     emailSettings: true,
   }).nullable(),

--- a/packages/lib/types/template.ts
+++ b/packages/lib/types/template.ts
@@ -45,6 +45,7 @@ export const ZTemplateSchema = TemplateSchema.pick({
     dateFormat: true,
     signingOrder: true,
     typedSignatureEnabled: true,
+    allowDictateNextSigner: true,
     distributionMethod: true,
     templateId: true,
     redirectUrl: true,

--- a/packages/lib/types/webhook-payload.ts
+++ b/packages/lib/types/webhook-payload.ts
@@ -46,6 +46,7 @@ export const ZWebhookDocumentMetaSchema = z.object({
   dateFormat: z.string(),
   redirectUrl: z.string().nullable(),
   signingOrder: z.nativeEnum(DocumentSigningOrder),
+  allowDictateNextSigner: z.boolean(),
   typedSignatureEnabled: z.boolean(),
   language: z.string(),
   distributionMethod: z.nativeEnum(DocumentDistributionMethod),

--- a/packages/prisma/migrations/20250320113205_add_dictate_signing_order_meta_field/migration.sql
+++ b/packages/prisma/migrations/20250320113205_add_dictate_signing_order_meta_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DocumentMeta" ADD COLUMN     "allowDictateNextSigner" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/migrations/20250320113413_add_signing_order_dictate_meta_field_to_templates/migration.sql
+++ b/packages/prisma/migrations/20250320113413_add_signing_order_dictate_meta_field_to_templates/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TemplateMeta" ADD COLUMN     "allowDictateNextSigner" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -390,20 +390,21 @@ enum DocumentDistributionMethod {
 
 /// @zod.import(["import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';"])
 model DocumentMeta {
-  id                    String                     @id @default(cuid())
-  subject               String?
-  message               String?
-  timezone              String?                    @default("Etc/UTC") @db.Text
-  password              String?
-  dateFormat            String?                    @default("yyyy-MM-dd hh:mm a") @db.Text
-  documentId            Int                        @unique
-  document              Document                   @relation(fields: [documentId], references: [id], onDelete: Cascade)
-  redirectUrl           String?
-  signingOrder          DocumentSigningOrder       @default(PARALLEL)
-  typedSignatureEnabled Boolean                    @default(true)
-  language              String                     @default("en")
-  distributionMethod    DocumentDistributionMethod @default(EMAIL)
-  emailSettings         Json? /// [DocumentEmailSettings] @zod.custom.use(ZDocumentEmailSettingsSchema)
+  id                     String                     @id @default(cuid())
+  subject                String?
+  message                String?
+  timezone               String?                    @default("Etc/UTC") @db.Text
+  password               String?
+  dateFormat             String?                    @default("yyyy-MM-dd hh:mm a") @db.Text
+  documentId             Int                        @unique
+  document               Document                   @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  redirectUrl            String?
+  signingOrder           DocumentSigningOrder       @default(PARALLEL)
+  allowDictateNextSigner Boolean                    @default(false)
+  typedSignatureEnabled  Boolean                    @default(true)
+  language               String                     @default("en")
+  distributionMethod     DocumentDistributionMethod @default(EMAIL)
+  emailSettings          Json? /// [DocumentEmailSettings] @zod.custom.use(ZDocumentEmailSettingsSchema)
 }
 
 enum ReadStatus {
@@ -660,15 +661,16 @@ enum TemplateType {
 
 /// @zod.import(["import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';"])
 model TemplateMeta {
-  id                    String                     @id @default(cuid())
-  subject               String?
-  message               String?
-  timezone              String?                    @default("Etc/UTC") @db.Text
-  password              String?
-  dateFormat            String?                    @default("yyyy-MM-dd hh:mm a") @db.Text
-  signingOrder          DocumentSigningOrder?      @default(PARALLEL)
-  typedSignatureEnabled Boolean                    @default(true)
-  distributionMethod    DocumentDistributionMethod @default(EMAIL)
+  id                     String                     @id @default(cuid())
+  subject                String?
+  message                String?
+  timezone               String?                    @default("Etc/UTC") @db.Text
+  password               String?
+  dateFormat             String?                    @default("yyyy-MM-dd hh:mm a") @db.Text
+  signingOrder           DocumentSigningOrder?      @default(PARALLEL)
+  allowDictateNextSigner Boolean                    @default(false)
+  typedSignatureEnabled  Boolean                    @default(true)
+  distributionMethod     DocumentDistributionMethod @default(EMAIL)
 
   templateId    Int      @unique
   template      Template @relation(fields: [templateId], references: [id], onDelete: Cascade)

--- a/packages/trpc/server/document-router/router.ts
+++ b/packages/trpc/server/document-router/router.ts
@@ -371,6 +371,7 @@ export const documentRouter = router({
           redirectUrl: meta.redirectUrl,
           distributionMethod: meta.distributionMethod,
           signingOrder: meta.signingOrder,
+          allowDictateNextSigner: meta.allowDictateNextSigner,
           emailSettings: meta.emailSettings,
           requestMetadata: ctx.metadata,
         });

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -268,6 +268,7 @@ export const ZUpdateDocumentRequestSchema = z.object({
       dateFormat: ZDocumentMetaDateFormatSchema.optional(),
       distributionMethod: ZDocumentMetaDistributionMethodSchema.optional(),
       signingOrder: z.nativeEnum(DocumentSigningOrder).optional(),
+      allowDictateNextSigner: z.boolean().optional(),
       redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
       language: ZDocumentMetaLanguageSchema.optional(),
       typedSignatureEnabled: ZDocumentMetaTypedSignatureEnabledSchema.optional(),

--- a/packages/trpc/server/recipient-router/router.ts
+++ b/packages/trpc/server/recipient-router/router.ts
@@ -436,12 +436,13 @@ export const recipientRouter = router({
   completeDocumentWithToken: procedure
     .input(ZCompleteDocumentWithTokenMutationSchema)
     .mutation(async ({ input, ctx }) => {
-      const { token, documentId, authOptions } = input;
+      const { token, documentId, authOptions, nextSigner } = input;
 
       return await completeDocumentWithToken({
         token,
         documentId,
         authOptions,
+        nextSigner,
         userId: ctx.user?.id,
         requestMetadata: ctx.metadata.requestMetadata,
       });

--- a/packages/trpc/server/recipient-router/schema.ts
+++ b/packages/trpc/server/recipient-router/schema.ts
@@ -212,6 +212,12 @@ export const ZCompleteDocumentWithTokenMutationSchema = z.object({
   token: z.string(),
   documentId: z.number(),
   authOptions: ZRecipientActionAuthSchema.optional(),
+  nextSigner: z
+    .object({
+      email: z.string().email(),
+      name: z.string().min(1),
+    })
+    .optional(),
 });
 
 export type TCompleteDocumentWithTokenMutationSchema = z.infer<

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -165,6 +165,7 @@ export const ZUpdateTemplateRequestSchema = z.object({
       language: ZDocumentMetaLanguageSchema.optional(),
       typedSignatureEnabled: ZDocumentMetaTypedSignatureEnabledSchema.optional(),
       signingOrder: z.nativeEnum(DocumentSigningOrder).optional(),
+      allowDictateNextSigner: z.boolean().optional(),
     })
     .optional(),
 });

--- a/packages/ui/primitives/document-flow/add-signers.types.ts
+++ b/packages/ui/primitives/document-flow/add-signers.types.ts
@@ -25,6 +25,7 @@ export const ZAddSignersFormSchema = z
       }),
     ),
     signingOrder: z.nativeEnum(DocumentSigningOrder),
+    allowDictateNextSigner: z.boolean().default(false),
   })
   .refine(
     (schema) => {

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
@@ -9,7 +9,7 @@ import { Trans } from '@lingui/react/macro';
 import type { TemplateDirectLink } from '@prisma/client';
 import { DocumentSigningOrder, type Field, type Recipient, RecipientRole } from '@prisma/client';
 import { motion } from 'framer-motion';
-import { GripVerticalIcon, Link2Icon, Plus, Trash } from 'lucide-react';
+import { GripVerticalIcon, HelpCircle, Link2Icon, Plus, Trash } from 'lucide-react';
 import { useFieldArray, useForm } from 'react-hook-form';
 
 import { useSession } from '@documenso/lib/client-only/providers/session';
@@ -47,10 +47,11 @@ export type AddTemplatePlaceholderRecipientsFormProps = {
   recipients: Recipient[];
   fields: Field[];
   signingOrder?: DocumentSigningOrder | null;
-  templateDirectLink: TemplateDirectLink | null;
+  allowDictateNextSigner?: boolean;
+  templateDirectLink?: TemplateDirectLink | null;
   isEnterprise: boolean;
-  isDocumentPdfLoaded: boolean;
   onSubmit: (_data: TAddTemplatePlacholderRecipientsFormSchema) => void;
+  isDocumentPdfLoaded: boolean;
 };
 
 export const AddTemplatePlaceholderRecipientsFormPartial = ({
@@ -60,6 +61,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
   templateDirectLink,
   fields,
   signingOrder,
+  allowDictateNextSigner,
   isDocumentPdfLoaded,
   onSubmit,
 }: AddTemplatePlaceholderRecipientsFormProps) => {
@@ -112,6 +114,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
     defaultValues: {
       signers: generateDefaultFormSigners(),
       signingOrder: signingOrder || DocumentSigningOrder.PARALLEL,
+      allowDictateNextSigner: allowDictateNextSigner ?? false,
     },
   });
 
@@ -119,6 +122,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
     form.reset({
       signers: generateDefaultFormSigners(),
       signingOrder: signingOrder || DocumentSigningOrder.PARALLEL,
+      allowDictateNextSigner: allowDictateNextSigner ?? false,
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -377,6 +381,7 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
 
     form.setValue('signers', updatedSigners);
     form.setValue('signingOrder', DocumentSigningOrder.PARALLEL);
+    form.setValue('allowDictateNextSigner', false);
   }, [form]);
 
   return (
@@ -416,6 +421,11 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
                         field.onChange(
                           checked ? DocumentSigningOrder.SEQUENTIAL : DocumentSigningOrder.PARALLEL,
                         );
+
+                        // If sequential signing is turned off, disable dictate next signer
+                        if (!checked) {
+                          form.setValue('allowDictateNextSigner', false);
+                        }
                       }}
                       disabled={isSubmitting}
                     />
@@ -427,6 +437,49 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
                   >
                     <Trans>Enable signing order</Trans>
                   </FormLabel>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="allowDictateNextSigner"
+              render={({ field: { value, ...field } }) => (
+                <FormItem className="mb-6 flex flex-row items-center space-x-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      {...field}
+                      id="allowDictateNextSigner"
+                      checked={value}
+                      onCheckedChange={field.onChange}
+                      disabled={isSubmitting || !isSigningOrderSequential}
+                    />
+                  </FormControl>
+
+                  <div className="flex items-center">
+                    <FormLabel
+                      htmlFor="allowDictateNextSigner"
+                      className="text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                    >
+                      <Trans>Allow signers to dictate next signer</Trans>
+                    </FormLabel>
+
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="text-muted-foreground ml-1 cursor-help">
+                          <HelpCircle className="h-3.5 w-3.5" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-80 p-4">
+                        <p>
+                          <Trans>
+                            When enabled, signers can choose who should sign next in the sequence
+                            instead of following the predefined order.
+                          </Trans>
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
                 </FormItem>
               )}
             />

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.types.ts
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.types.ts
@@ -21,6 +21,7 @@ export const ZAddTemplatePlacholderRecipientsFormSchema = z
       }),
     ),
     signingOrder: z.nativeEnum(DocumentSigningOrder),
+    allowDictateNextSigner: z.boolean().default(false),
   })
   .refine(
     (schema) => {


### PR DESCRIPTION
## Description

Adds next recipient dictation functionality to document signing flow, allowing assistants and signers to update the next recipient's information during the signing process.

## Related Issue

N/A

## Changes Made

- Added form handling for next recipient dictation in signing dialogs
- Implemented UI for updating next recipient information
- Added e2e tests covering dictation scenarios:
  - Regular signing with dictation enabled
  - Assistant role with dictation
  - Parallel signing flow
  - Disabled dictation state

## Testing Performed

- Added comprehensive e2e tests covering:
  - Sequential signing with dictation
  - Assistant role dictation
  - Parallel signing without dictation
  - Form validation and state management
- Tested on Chrome and Firefox
- Verified recipient state updates in database