### PR TITLE
fix: direct template redirects

### DIFF
--- a/apps/remix/app/components/general/direct-template/direct-template-page.tsx
+++ b/apps/remix/app/components/general/direct-template/direct-template-page.tsx
@@ -113,7 +113,11 @@ export const DirectTemplatePageView = ({
 
       const redirectUrl = template.templateMeta?.redirectUrl;
 
-      await (redirectUrl ? navigate(redirectUrl) : navigate(`/sign/${token}/complete`));
+      if (redirectUrl) {
+        window.location.href = redirectUrl;
+      } else {
+        await navigate(`/sign/${token}/complete`);
+      }
     } catch (err) {
       toast({
         title: _(msg`Something went wrong`),


### PR DESCRIPTION
## Description

Currently direct template redirects are broken because we are incorrectly using `navigate` to redirect to an external website.

## Testing Performed

Tested both redirects and no redirects for direct templates, both work as intended.
