### PR TITLE
chore: update render build command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     runtime: node
     name: documenso-app
     plan: free
-    buildCommand: npm i && npm run build:web
+    buildCommand: npm i && npm run build
     startCommand: npx prisma migrate deploy --schema packages/prisma/schema.prisma && npx turbo run start --filter=@documenso/web
     healthCheckPath: /api/health
 


### PR DESCRIPTION
The `build:web` command doesn't exist anymore in the new repo, so the Render deployment fails.