### PR TITLE
refactor: remove unused navigation and team context in folder dialogs

### DIFF
--- a/apps/remix/app/components/dialogs/document-move-to-folder-dialog.tsx
+++ b/apps/remix/app/components/dialogs/document-move-to-folder-dialog.tsx
@@ -7,12 +7,10 @@ import { Trans } from '@lingui/react/macro';
 import type * as DialogPrimitive from '@radix-ui/react-dialog';
 import { FolderIcon, HomeIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
 import { z } from 'zod';
 
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import { FolderType } from '@documenso/lib/types/folder-type';
-import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -32,8 +30,6 @@ import {
   FormMessage,
 } from '@documenso/ui/primitives/form/form';
 import { useToast } from '@documenso/ui/primitives/use-toast';
-
-import { useOptionalCurrentTeam } from '~/providers/team';
 
 export type DocumentMoveToFolderDialogProps = {
   documentId: number;
@@ -57,8 +53,6 @@ export const DocumentMoveToFolderDialog = ({
 }: DocumentMoveToFolderDialogProps) => {
   const { _ } = useLingui();
   const { toast } = useToast();
-  const navigate = useNavigate();
-  const team = useOptionalCurrentTeam();
 
   const form = useForm<TMoveDocumentFormSchema>({
     resolver: zodResolver(ZMoveDocumentFormSchema),
@@ -101,14 +95,6 @@ export const DocumentMoveToFolderDialog = ({
       });
 
       onOpenChange(false);
-
-      const documentsPath = formatDocumentsPath(team?.url);
-
-      if (data.folderId) {
-        void navigate(`${documentsPath}/f/${data.folderId}`);
-      } else {
-        void navigate(documentsPath);
-      }
     } catch (err) {
       const error = AppError.parseError(err);
 

--- a/apps/remix/app/components/dialogs/folder-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/folder-create-dialog.tsx
@@ -6,12 +6,11 @@ import { useLingui } from '@lingui/react';
 import type * as DialogPrimitive from '@radix-ui/react-dialog';
 import { FolderPlusIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import { z } from 'zod';
 
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import { FolderType } from '@documenso/lib/types/folder-type';
-import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -34,8 +33,6 @@ import {
 import { Input } from '@documenso/ui/primitives/input';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
-import { useOptionalCurrentTeam } from '~/providers/team';
-
 const ZCreateFolderFormSchema = z.object({
   name: z.string().min(1, { message: 'Folder name is required' }),
 });
@@ -50,9 +47,6 @@ export const CreateFolderDialog = ({ trigger, ...props }: CreateFolderDialogProp
   const { _ } = useLingui();
   const { toast } = useToast();
   const { folderId } = useParams();
-
-  const navigate = useNavigate();
-  const team = useOptionalCurrentTeam();
 
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
 
@@ -78,10 +72,6 @@ export const CreateFolderDialog = ({ trigger, ...props }: CreateFolderDialogProp
       toast({
         description: 'Folder created successfully',
       });
-
-      const documentsPath = formatDocumentsPath(team?.url);
-
-      void navigate(`${documentsPath}/f/${newFolder.id}`);
     } catch (err) {
       const error = AppError.parseError(err);
 


### PR DESCRIPTION
refactor: remove unused navigation and team context in folder dialogs

- Eliminated `useNavigate` and `useOptionalCurrentTeam` hooks from `DocumentMoveToFolderDialog` and `CreateFolderDialog`.
- Removed related logic for formatting document paths and navigation after folder operations.
- Streamlined component code for improved clarity and maintainability.