### PR TITLE
fix: pass NODE_ENV to the client side of remix application to load language files

### DIFF
--- a/apps/remix/app/root.tsx
+++ b/apps/remix/app/root.tsx
@@ -93,7 +93,7 @@ export async function loader({ request }: Route.LoaderArgs) {
             teams,
           }
         : null,
-      publicEnv: createPublicEnv(),
+      publicEnv: { ...createPublicEnv(), NODE_ENV: env('NODE_ENV') },
     },
     {
       headers: {


### PR DESCRIPTION
---
name: pass NODE_ENV to the client side of remix application to load language files
---

## Description

<!--- Describe the changes introduced by this pull request. -->
<!--- Explain what problem it solves or what feature/fix it adds. -->
When running the application in development through the [guidelines](https://github.com/documenso/documenso?tab=readme-ov-file#developer-quickstart), the app doesn't load correctly with an error on the console saying:

![image](https://github.com/user-attachments/assets/38fe08f7-6496-4c7a-bbc2-e83aef5d0f2c)

This is fine when we run 
```
npm run d
```

But for manual installation and installation with `npm run dx` we see this issue and below explains what is happening:
In development mode, the i18n translation files search for `.po` extension files. However due to the `NODE_ENV` not being set to `development` in client side of the application(not being properly passed in the env), the translation files default to `.mjs` files. 
But we have not yet compiled the language files and we don't have any `.mjs` files yet. Thus the application throws an error and nothing works.

## Related Issue

Fixes #1761 

## Changes Made

- Adds `NODE_ENV` on the client side of the remix application when app is initialized

## Testing Performed

**Before the changes:**
- Tested the application with `npm run d`: Works as expected
- Tested the application with `npm run dx` followed by `npm run dev`: Issue is seen
- Tested the application with manual installation steps: Issue is seen

**After the changes:**
- Tested the application with `npm run dx` followed by `npm run dev`: Issue is resolved
- Tested the application with manual installation steps: Issue is resolved

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x ] I have followed the project's coding style guidelines.

## Additional Notes

There are other ways of making this work.
- Option 1:
Setting `NEXT_PUBLIC_NODE_ENV` on the .env file, which exposes a new key to the client side. 

- Option 2:
Checking for condition `NODE_ENV==='production'` instead of development in all the places.

Among the alternatives, I believe the current implementation makes more sense, because if there ever is another environment setting that needs to be called out on the development, it will be accessible on the client side as well.
