### PR TITLE
feat: Allow team member selection in signing flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+docker-compose.yml
 packages/prisma/generated/types.ts
 
 # dependencies

--- a/apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-member-select-dialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+
+import { msg } from '@lingui/core/macro';
+import { Trans } from '@lingui/react/macro';
+import type * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { useIsMounted } from '@documenso/lib/client-only/hooks/use-is-mounted';
+import { trpc } from '@documenso/trpc/react';
+import { Button } from '@documenso/ui/primitives/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@documenso/ui/primitives/dialog';
+import { MultiSelectCombobox } from '@documenso/ui/primitives/multi-select-combobox';
+
+export interface Member {
+  email: string;
+  name: string;
+}
+
+export type TeamMemberSelectDialogProps = {
+  trigger?: React.ReactNode;
+  onSubmit: (members: Member[]) => void;
+  teamId: number;
+} & Omit<DialogPrimitive.DialogProps, 'children'>;
+
+export const TeamMemberSelectDialog = ({
+  trigger,
+  teamId,
+  ...props
+}: TeamMemberSelectDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const [selectedMemberIds, setSelectedMemberIds] = useState<number[]>([]);
+
+  const isMounted = useIsMounted();
+
+  const { data, isLoading } = trpc.team.getTeamMembers.useQuery({
+    teamId,
+  });
+
+  const comboBoxOptions = (data ?? []).map((member) => ({
+    label: member.user.name ?? member.user.email,
+    value: member.user.id,
+  }));
+
+  const onSubmit = () => {
+    props.onSubmit(
+      selectedMemberIds
+        .map((mid) => {
+          const m = (data ?? []).find((member) => member.user.id === mid);
+          return m ? { email: m.user.email, name: m.user.name || '' } : null;
+        })
+        .filter((v) => v !== null),
+    );
+    setOpen(false);
+  };
+
+  return (
+    <Dialog {...props} open={open} onOpenChange={(value) => setOpen(value)}>
+      <DialogTrigger onClick={(e) => e.stopPropagation()} asChild>
+        {trigger ?? (
+          <Button variant="secondary">
+            <Trans>Select team member</Trans>
+          </Button>
+        )}
+      </DialogTrigger>
+
+      <DialogContent position="center">
+        <DialogHeader>
+          <DialogTitle>
+            <Trans>Select team member</Trans>
+          </DialogTitle>
+        </DialogHeader>
+
+        <fieldset className="flex h-full flex-col">
+          <MultiSelectCombobox
+            emptySelectionPlaceholder={
+              <p className="text-muted-foreground font-normal">
+                <Trans>
+                  <span className="text-muted-foreground/70">Member:</span> All
+                </Trans>
+              </p>
+            }
+            className="flex w-full flex-col"
+            enableClearAllButton={true}
+            inputPlaceholder={msg`Search`}
+            loading={!isMounted || isLoading}
+            options={comboBoxOptions}
+            selectedValues={selectedMemberIds}
+            onChange={setSelectedMemberIds}
+          />
+
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="secondary" onClick={() => setOpen(false)}>
+              <Trans>Cancel</Trans>
+            </Button>
+
+            <Button type="submit" onClick={() => onSubmit()}>
+              <Trans>Add</Trans>
+            </Button>
+          </DialogFooter>
+        </fieldset>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-member-select-dialog.tsx
@@ -81,7 +81,7 @@ export const TeamMemberSelectDialog = ({
             emptySelectionPlaceholder={
               <p className="text-muted-foreground font-normal">
                 <Trans>
-                  <span className="text-muted-foreground/70">Member:</span> All
+                  <span className="text-muted-foreground/70">Member:</span>
                 </Trans>
               </p>
             }

--- a/packages/lib/translations/de/web.po
+++ b/packages/lib/translations/de/web.po
@@ -438,6 +438,10 @@ msgstr "<0>E-Mail</0> - Der Empfänger erhält das Dokument zur Unterschrift, Ge
 msgid "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 msgstr "<0>Authentifizierungsmethode erben</0> - Verwenden Sie die in den \"Allgemeinen Einstellungen\" konfigurierte globale Aktionssignatur-Authentifizierungsmethode"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "<0>Member:</0>"
+msgstr "<0>Mitglieder:</0>"
+
 #: packages/ui/components/document/document-global-auth-action-select.tsx
 msgid "<0>No restrictions</0> - No authentication required"
 msgstr "<0>Keine Einschränkungen</0> - Keine Authentifizierung erforderlich"
@@ -726,6 +730,7 @@ msgstr "Aktiv"
 msgid "Active Subscriptions"
 msgstr "Aktive Abonnements"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-email-add-dialog.tsx
 msgid "Add"
 msgstr "Hinzufügen"
@@ -782,6 +787,10 @@ msgstr "E-Mail hinzufügen"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 msgid "Add Fields"
 msgstr "Felder hinzufügen"
+
+#: packages/ui/primitives/document-flow/add-signers.tsx
+msgid "Add member"
+msgstr "Mitglieder hinzufügen"
 
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 msgid "Add more"
@@ -892,6 +901,10 @@ msgstr "Alle"
 #: apps/remix/app/components/general/app-command-menu.tsx
 msgid "All documents"
 msgstr "Alle Dokumente"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "All documents have been completed!"
+msgstr ""
 
 #: apps/remix/app/components/tables/documents-table-empty-state.tsx
 msgid "All documents have been processed. Any new documents that are sent or received will show here."
@@ -1113,6 +1126,7 @@ msgstr "Beim Unterschreiben als Assistent ist ein Fehler aufgetreten."
 #: apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-date-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "An error occurred while signing the document."
 msgstr "Ein Fehler ist aufgetreten, während das Dokument unterzeichnet wurde."
 
@@ -1296,6 +1310,10 @@ msgstr "Die Rolle des Assistenten ist nur verfügbar, wenn das Dokument im seque
 #: packages/lib/constants/recipient-roles.ts
 msgid "Assistants"
 msgstr "Assistenten"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Assistants and Copy roles are currently not compatible with the multi-sign experience."
+msgstr ""
 
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
 #: packages/lib/constants/recipient-roles.ts
@@ -1504,6 +1522,7 @@ msgstr "Kann vorbereiten"
 #: apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
 #: apps/remix/app/components/dialogs/team-transfer-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-delete-dialog.tsx
 #: apps/remix/app/components/dialogs/team-leave-dialog.tsx
@@ -1644,6 +1663,7 @@ msgstr "Klicken Sie, um den Signatur-Link zu kopieren, um ihn an den Empfänger 
 #: apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Click to insert field"
 msgstr "Klicken, um das Feld auszufüllen"
 
@@ -1670,6 +1690,7 @@ msgstr ""
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Complete"
 msgstr "Abschließen"
 
@@ -1701,6 +1722,7 @@ msgstr "Betrachten abschließen"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/template/template-page-view-documents-table.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 #: packages/email/template-components/template-document-self-signed.tsx
 #: packages/email/template-components/template-document-recipient-signed.tsx
@@ -2772,6 +2794,7 @@ msgstr "Offenlegung der elektronischen Unterschrift"
 #: apps/remix/app/components/forms/forgot-password.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-advanced-settings.tsx
@@ -2954,6 +2977,7 @@ msgstr "Geben Sie hier Ihren Text ein"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-drop-zone-wrapper.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/dialogs/webhook-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 #: apps/remix/app/components/dialogs/template-move-to-folder-dialog.tsx
@@ -3008,6 +3032,10 @@ msgstr "Externe ID"
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 msgid "Failed to create folder"
+msgstr ""
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
+msgid "Failed to load document"
 msgstr ""
 
 #: apps/remix/app/routes/_authenticated+/admin+/documents.$id.tsx
@@ -3153,6 +3181,7 @@ msgstr "Freie Unterschrift"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Full Name"
 msgstr "Vollständiger Name"
 
@@ -3435,6 +3464,10 @@ msgstr "Es ist entscheidend, dass Sie Ihre Kontaktinformationen, insbesondere Ih
 msgid "It looks like {0} hasn't added any documents to their profile yet."
 msgstr "Es sieht so aus, als ob {0} noch keine Dokumente zu ihrem Profil hinzugefügt hat."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "It looks like we ran into an issue!"
+msgstr ""
+
 #: apps/remix/app/routes/_unauthenticated+/verify-email.$token.tsx
 msgid "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
 msgstr "Es scheint, dass das bereitgestellte Token abgelaufen ist. Wir haben Ihnen gerade ein weiteres Token gesendet, bitte überprüfen Sie Ihre E-Mails und versuchen Sie es erneut."
@@ -3553,6 +3586,7 @@ msgid "Load older activity"
 msgstr "Ältere Aktivitäten laden"
 
 #: apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/pdf-viewer.tsx
 msgid "Loading document..."
 msgstr "Lade Dokument..."
@@ -3839,6 +3873,7 @@ msgstr "Neue Vorlage"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
 msgid "Next"
 msgstr "Nächster"
@@ -4004,6 +4039,10 @@ msgstr "Sobald Sie den QR-Code gescannt oder den Code manuell eingegeben haben, 
 #: packages/lib/constants/template.ts
 msgid "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
 msgstr "Sobald Ihre Vorlage eingerichtet ist, teilen Sie den Link überall, wo Sie möchten. Die Person, die den Link öffnet, kann ihre Informationen im Feld für direkte Empfänger eingeben und alle anderen ihr zugewiesenen Felder ausfüllen."
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
+msgstr ""
 
 #: apps/remix/app/components/forms/team-document-preferences-form.tsx
 msgid "Only admins can access and view the document"
@@ -4256,6 +4295,10 @@ msgstr "Bitte bestätige deine E-Mail-Adresse"
 msgid "Please contact support if you would like to revert this action."
 msgstr "Bitte kontaktieren Sie den Support, wenn Sie diese Aktion rückgängig machen möchten."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Please contact the site owner for further assistance."
+msgstr ""
+
 #: apps/remix/app/components/forms/token.tsx
 msgid "Please enter a meaningful name for your token. This will help you identify it later."
 msgstr "Bitte geben Sie einen aussagekräftigen Namen für Ihr Token ein. Dies wird Ihnen helfen, es später zu identifizieren."
@@ -4391,6 +4434,10 @@ msgstr "Profil ist derzeit <0>sichtbar</0>."
 #: apps/remix/app/components/forms/profile.tsx
 msgid "Profile updated"
 msgstr "Profil aktualisiert"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Progress"
+msgstr ""
 
 #: apps/remix/app/components/tables/templates-table.tsx
 #: apps/remix/app/components/general/template/template-type.tsx
@@ -4562,6 +4609,7 @@ msgstr "Dokument Ablehnen"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 msgid "Rejected"
 msgstr "Abgelehnt"
@@ -4768,6 +4816,7 @@ msgstr "Vorlage speichern"
 #: apps/remix/app/components/tables/user-settings-teams-page-table.tsx
 #: apps/remix/app/components/tables/documents-table-sender-filter.tsx
 #: apps/remix/app/components/general/app-nav-desktop.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 msgid "Search"
 msgstr "Suchen"
 
@@ -4849,6 +4898,11 @@ msgstr "Standardoption auswählen"
 #: apps/remix/app/components/general/document-signing/document-signing-auth-passkey.tsx
 msgid "Select passkey"
 msgstr "Passkey auswählen"
+
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "Select team member"
+msgstr "Team Mitglied auswählen"
 
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
@@ -5030,6 +5084,7 @@ msgstr "Unterzeichnen als<0>{0} <1>({1})</1></0>"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign document"
 msgstr "Dokument unterschreiben"
 
@@ -5037,6 +5092,10 @@ msgstr "Dokument unterschreiben"
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Sign Document"
 msgstr "Dokument signieren"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Sign Documents"
+msgstr ""
 
 #: apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx
 msgid "Sign field"
@@ -5063,6 +5122,7 @@ msgstr "Ausloggen"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign the document to complete the process."
 msgstr "Unterschreiben Sie das Dokument, um den Vorgang abzuschließen."
 
@@ -5086,6 +5146,7 @@ msgstr "Registrieren mit OIDC"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/template-flow/add-template-fields.tsx
 #: packages/ui/primitives/document-flow/types.ts
 #: packages/ui/primitives/document-flow/add-fields.tsx
@@ -5640,6 +5701,10 @@ msgstr "Textausrichtung"
 #: apps/remix/app/routes/_authenticated+/admin+/site-settings.tsx
 msgid "Text Color"
 msgstr "Textfarbe"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Thank you for completing the signing process."
+msgstr ""
 
 #: apps/remix/app/routes/_unauthenticated+/articles.signature-disclosure.tsx
 msgid "Thank you for using Documenso to perform your electronic document signing. The purpose of this disclosure is to inform you about the process, legality, and your rights regarding the use of electronic signatures on our platform. By opting to use an electronic signature, you are agreeing to the terms and conditions outlined below."
@@ -6716,6 +6781,7 @@ msgstr "Versionsverlauf"
 #: apps/remix/app/components/tables/documents-table-action-button.tsx
 #: apps/remix/app/components/general/document/document-page-view-button.tsx
 #: apps/remix/app/components/forms/2fa/view-recovery-codes-dialog.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "View"
 msgstr "Betrachten"
@@ -6773,6 +6839,10 @@ msgstr "Einladungen ansehen"
 msgid "View more"
 msgstr "Mehr anzeigen"
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "View next document"
+msgstr ""
+
 #: apps/remix/app/routes/_recipient+/sign.$token+/complete.tsx
 msgid "View Original Document"
 msgstr "Originaldokument ansehen"
@@ -6792,6 +6862,7 @@ msgstr "Teams ansehen"
 
 #: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "Viewed"
 msgstr "Betrachtet"
@@ -7339,6 +7410,10 @@ msgstr "Du wurdest eingeladen, dem folgenden Team beizutreten"
 #: packages/lib/server-only/recipient/delete-document-recipient.ts
 msgid "You have been removed from a document"
 msgstr "Du wurdest von einem Dokument entfernt"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
+msgstr ""
 
 #. placeholder {0}: team.name
 #: packages/lib/server-only/team/request-team-ownership-transfer.ts

--- a/packages/lib/translations/en/web.po
+++ b/packages/lib/translations/en/web.po
@@ -433,6 +433,10 @@ msgstr "<0>Email</0> - The recipient will be emailed the document to sign, appro
 msgid "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 msgstr "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "<0>Member:</0>"
+msgstr "<0>Member:</0>"
+
 #: packages/ui/components/document/document-global-auth-action-select.tsx
 msgid "<0>No restrictions</0> - No authentication required"
 msgstr "<0>No restrictions</0> - No authentication required"
@@ -721,6 +725,7 @@ msgstr "Active"
 msgid "Active Subscriptions"
 msgstr "Active Subscriptions"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-email-add-dialog.tsx
 msgid "Add"
 msgstr "Add"
@@ -777,6 +782,10 @@ msgstr "Add email"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 msgid "Add Fields"
 msgstr "Add Fields"
+
+#: packages/ui/primitives/document-flow/add-signers.tsx
+msgid "Add member"
+msgstr "Add member"
 
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 msgid "Add more"
@@ -887,6 +896,10 @@ msgstr "All"
 #: apps/remix/app/components/general/app-command-menu.tsx
 msgid "All documents"
 msgstr "All documents"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "All documents have been completed!"
+msgstr "All documents have been completed!"
 
 #: apps/remix/app/components/tables/documents-table-empty-state.tsx
 msgid "All documents have been processed. Any new documents that are sent or received will show here."
@@ -1108,6 +1121,7 @@ msgstr "An error occurred while signing as assistant."
 #: apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-date-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "An error occurred while signing the document."
 msgstr "An error occurred while signing the document."
 
@@ -1291,6 +1305,10 @@ msgstr "Assistant role is only available when the document is in sequential sign
 #: packages/lib/constants/recipient-roles.ts
 msgid "Assistants"
 msgstr "Assistants"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Assistants and Copy roles are currently not compatible with the multi-sign experience."
+msgstr "Assistants and Copy roles are currently not compatible with the multi-sign experience."
 
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
 #: packages/lib/constants/recipient-roles.ts
@@ -1499,6 +1517,7 @@ msgstr "Can prepare"
 #: apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
 #: apps/remix/app/components/dialogs/team-transfer-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-delete-dialog.tsx
 #: apps/remix/app/components/dialogs/team-leave-dialog.tsx
@@ -1639,6 +1658,7 @@ msgstr "Click to copy signing link for sending to recipient"
 #: apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Click to insert field"
 msgstr "Click to insert field"
 
@@ -1665,6 +1685,7 @@ msgstr "Communication"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Complete"
 msgstr "Complete"
 
@@ -1696,6 +1717,7 @@ msgstr "Complete Viewing"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/template/template-page-view-documents-table.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 #: packages/email/template-components/template-document-self-signed.tsx
 #: packages/email/template-components/template-document-recipient-signed.tsx
@@ -2767,6 +2789,7 @@ msgstr "Electronic Signature Disclosure"
 #: apps/remix/app/components/forms/forgot-password.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-advanced-settings.tsx
@@ -2949,6 +2972,7 @@ msgstr "Enter your text here"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-drop-zone-wrapper.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/dialogs/webhook-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 #: apps/remix/app/components/dialogs/template-move-to-folder-dialog.tsx
@@ -3004,6 +3028,10 @@ msgstr "External ID"
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 msgid "Failed to create folder"
 msgstr "Failed to create folder"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
+msgid "Failed to load document"
+msgstr "Failed to load document"
 
 #: apps/remix/app/routes/_authenticated+/admin+/documents.$id.tsx
 msgid "Failed to reseal document"
@@ -3148,6 +3176,7 @@ msgstr "Free Signature"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Full Name"
 msgstr "Full Name"
 
@@ -3430,6 +3459,10 @@ msgstr "It is crucial to keep your contact information, especially your email ad
 msgid "It looks like {0} hasn't added any documents to their profile yet."
 msgstr "It looks like {0} hasn't added any documents to their profile yet."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "It looks like we ran into an issue!"
+msgstr "It looks like we ran into an issue!"
+
 #: apps/remix/app/routes/_unauthenticated+/verify-email.$token.tsx
 msgid "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
 msgstr "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
@@ -3548,6 +3581,7 @@ msgid "Load older activity"
 msgstr "Load older activity"
 
 #: apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/pdf-viewer.tsx
 msgid "Loading document..."
 msgstr "Loading document..."
@@ -3834,6 +3868,7 @@ msgstr "New Template"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
 msgid "Next"
 msgstr "Next"
@@ -3999,6 +4034,10 @@ msgstr "Once you have scanned the QR code or entered the code manually, enter th
 #: packages/lib/constants/template.ts
 msgid "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
 msgstr "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
+msgstr "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
 
 #: apps/remix/app/components/forms/team-document-preferences-form.tsx
 msgid "Only admins can access and view the document"
@@ -4251,6 +4290,10 @@ msgstr "Please confirm your email address"
 msgid "Please contact support if you would like to revert this action."
 msgstr "Please contact support if you would like to revert this action."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Please contact the site owner for further assistance."
+msgstr "Please contact the site owner for further assistance."
+
 #: apps/remix/app/components/forms/token.tsx
 msgid "Please enter a meaningful name for your token. This will help you identify it later."
 msgstr "Please enter a meaningful name for your token. This will help you identify it later."
@@ -4386,6 +4429,10 @@ msgstr "Profile is currently <0>visible</0>."
 #: apps/remix/app/components/forms/profile.tsx
 msgid "Profile updated"
 msgstr "Profile updated"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Progress"
+msgstr "Progress"
 
 #: apps/remix/app/components/tables/templates-table.tsx
 #: apps/remix/app/components/general/template/template-type.tsx
@@ -4557,6 +4604,7 @@ msgstr "Reject Document"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 msgid "Rejected"
 msgstr "Rejected"
@@ -4763,6 +4811,7 @@ msgstr "Save Template"
 #: apps/remix/app/components/tables/user-settings-teams-page-table.tsx
 #: apps/remix/app/components/tables/documents-table-sender-filter.tsx
 #: apps/remix/app/components/general/app-nav-desktop.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 msgid "Search"
 msgstr "Search"
 
@@ -4844,6 +4893,11 @@ msgstr "Select default option"
 #: apps/remix/app/components/general/document-signing/document-signing-auth-passkey.tsx
 msgid "Select passkey"
 msgstr "Select passkey"
+
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "Select team member"
+msgstr "Select team member"
 
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
@@ -5025,6 +5079,7 @@ msgstr "Sign as<0>{0} <1>({1})</1></0>"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign document"
 msgstr "Sign document"
 
@@ -5032,6 +5087,10 @@ msgstr "Sign document"
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Sign Document"
 msgstr "Sign Document"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Sign Documents"
+msgstr "Sign Documents"
 
 #: apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx
 msgid "Sign field"
@@ -5058,6 +5117,7 @@ msgstr "Sign Out"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign the document to complete the process."
 msgstr "Sign the document to complete the process."
 
@@ -5081,6 +5141,7 @@ msgstr "Sign Up with OIDC"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/template-flow/add-template-fields.tsx
 #: packages/ui/primitives/document-flow/types.ts
 #: packages/ui/primitives/document-flow/add-fields.tsx
@@ -5635,6 +5696,10 @@ msgstr "Text Align"
 #: apps/remix/app/routes/_authenticated+/admin+/site-settings.tsx
 msgid "Text Color"
 msgstr "Text Color"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Thank you for completing the signing process."
+msgstr "Thank you for completing the signing process."
 
 #: apps/remix/app/routes/_unauthenticated+/articles.signature-disclosure.tsx
 msgid "Thank you for using Documenso to perform your electronic document signing. The purpose of this disclosure is to inform you about the process, legality, and your rights regarding the use of electronic signatures on our platform. By opting to use an electronic signature, you are agreeing to the terms and conditions outlined below."
@@ -6713,6 +6778,7 @@ msgstr "Version History"
 #: apps/remix/app/components/tables/documents-table-action-button.tsx
 #: apps/remix/app/components/general/document/document-page-view-button.tsx
 #: apps/remix/app/components/forms/2fa/view-recovery-codes-dialog.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "View"
 msgstr "View"
@@ -6770,6 +6836,10 @@ msgstr "View invites"
 msgid "View more"
 msgstr "View more"
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "View next document"
+msgstr "View next document"
+
 #: apps/remix/app/routes/_recipient+/sign.$token+/complete.tsx
 msgid "View Original Document"
 msgstr "View Original Document"
@@ -6789,6 +6859,7 @@ msgstr "View teams"
 
 #: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "Viewed"
 msgstr "Viewed"
@@ -7336,6 +7407,10 @@ msgstr "You have been invited to join the following team"
 #: packages/lib/server-only/recipient/delete-document-recipient.ts
 msgid "You have been removed from a document"
 msgstr "You have been removed from a document"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
+msgstr "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
 
 #. placeholder {0}: team.name
 #: packages/lib/server-only/team/request-team-ownership-transfer.ts

--- a/packages/lib/translations/es/web.po
+++ b/packages/lib/translations/es/web.po
@@ -438,6 +438,10 @@ msgstr "<0>Correo electrónico</0> - Al destinatario se le enviará el documento
 msgid "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 msgstr "<0>Heredar método de autenticación</0> - Use el método de autenticación de firma de acción global configurado en el paso \"Configuración General\""
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "<0>Member:</0>"
+msgstr ""
+
 #: packages/ui/components/document/document-global-auth-action-select.tsx
 msgid "<0>No restrictions</0> - No authentication required"
 msgstr "<0>Sin restricciones</0> - No se requiere autenticación"
@@ -726,6 +730,7 @@ msgstr "Activo"
 msgid "Active Subscriptions"
 msgstr "Suscripciones Activas"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-email-add-dialog.tsx
 msgid "Add"
 msgstr "Agregar"
@@ -782,6 +787,10 @@ msgstr "Agregar correo electrónico"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 msgid "Add Fields"
 msgstr "Agregar Campos"
+
+#: packages/ui/primitives/document-flow/add-signers.tsx
+msgid "Add member"
+msgstr ""
 
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 msgid "Add more"
@@ -892,6 +901,10 @@ msgstr "Todos"
 #: apps/remix/app/components/general/app-command-menu.tsx
 msgid "All documents"
 msgstr "Todos los documentos"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "All documents have been completed!"
+msgstr ""
 
 #: apps/remix/app/components/tables/documents-table-empty-state.tsx
 msgid "All documents have been processed. Any new documents that are sent or received will show here."
@@ -1113,6 +1126,7 @@ msgstr "Ocurrió un error al firmar como asistente."
 #: apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-date-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "An error occurred while signing the document."
 msgstr "Ocurrió un error al firmar el documento."
 
@@ -1296,6 +1310,10 @@ msgstr "El rol de asistente solo está disponible cuando el documento está en m
 #: packages/lib/constants/recipient-roles.ts
 msgid "Assistants"
 msgstr "Asistentes"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Assistants and Copy roles are currently not compatible with the multi-sign experience."
+msgstr ""
 
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
 #: packages/lib/constants/recipient-roles.ts
@@ -1504,6 +1522,7 @@ msgstr "Puede preparar"
 #: apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
 #: apps/remix/app/components/dialogs/team-transfer-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-delete-dialog.tsx
 #: apps/remix/app/components/dialogs/team-leave-dialog.tsx
@@ -1644,6 +1663,7 @@ msgstr "Haga clic para copiar el enlace de firma para enviar al destinatario"
 #: apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Click to insert field"
 msgstr "Haga clic para insertar campo"
 
@@ -1670,6 +1690,7 @@ msgstr ""
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Complete"
 msgstr "Completo"
 
@@ -1701,6 +1722,7 @@ msgstr "Completar Visualización"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/template/template-page-view-documents-table.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 #: packages/email/template-components/template-document-self-signed.tsx
 #: packages/email/template-components/template-document-recipient-signed.tsx
@@ -2772,6 +2794,7 @@ msgstr "Divulgación de Firma Electrónica"
 #: apps/remix/app/components/forms/forgot-password.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-advanced-settings.tsx
@@ -2954,6 +2977,7 @@ msgstr "Ingresa tu texto aquí"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-drop-zone-wrapper.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/dialogs/webhook-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 #: apps/remix/app/components/dialogs/template-move-to-folder-dialog.tsx
@@ -3008,6 +3032,10 @@ msgstr "ID externo"
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 msgid "Failed to create folder"
+msgstr ""
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
+msgid "Failed to load document"
 msgstr ""
 
 #: apps/remix/app/routes/_authenticated+/admin+/documents.$id.tsx
@@ -3153,6 +3181,7 @@ msgstr "Firma gratuita"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Full Name"
 msgstr "Nombre completo"
 
@@ -3435,6 +3464,10 @@ msgstr "Es crucial mantener su información de contacto, especialmente su direcc
 msgid "It looks like {0} hasn't added any documents to their profile yet."
 msgstr "Parece que {0} aún no ha agregado documentos a su perfil."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "It looks like we ran into an issue!"
+msgstr ""
+
 #: apps/remix/app/routes/_unauthenticated+/verify-email.$token.tsx
 msgid "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
 msgstr "Parece que el token proporcionado ha expirado. Te hemos enviado otro token, por favor revisa tu correo electrónico y vuelve a intentarlo."
@@ -3553,6 +3586,7 @@ msgid "Load older activity"
 msgstr "Cargar actividad anterior"
 
 #: apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/pdf-viewer.tsx
 msgid "Loading document..."
 msgstr "Cargando documento..."
@@ -3839,6 +3873,7 @@ msgstr "Nueva plantilla"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
 msgid "Next"
 msgstr "Siguiente"
@@ -4004,6 +4039,10 @@ msgstr "Una vez que hayas escaneado el código QR o ingresado el código manualm
 #: packages/lib/constants/template.ts
 msgid "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
 msgstr "Una vez que su plantilla esté configurada, comparta el enlace donde desee. La persona que abra el enlace podrá ingresar su información en el campo de destinatario de enlace directo y completar cualquier otro campo que se le haya asignado."
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
+msgstr ""
 
 #: apps/remix/app/components/forms/team-document-preferences-form.tsx
 msgid "Only admins can access and view the document"
@@ -4256,6 +4295,10 @@ msgstr "Por favor confirma tu dirección de correo electrónico"
 msgid "Please contact support if you would like to revert this action."
 msgstr "Por favor, contacta al soporte si deseas revertir esta acción."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Please contact the site owner for further assistance."
+msgstr ""
+
 #: apps/remix/app/components/forms/token.tsx
 msgid "Please enter a meaningful name for your token. This will help you identify it later."
 msgstr "Por favor, ingresa un nombre significativo para tu token. Esto te ayudará a identificarlo más tarde."
@@ -4391,6 +4434,10 @@ msgstr "El perfil está actualmente <0>visible</0>."
 #: apps/remix/app/components/forms/profile.tsx
 msgid "Profile updated"
 msgstr "Perfil actualizado"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Progress"
+msgstr ""
 
 #: apps/remix/app/components/tables/templates-table.tsx
 #: apps/remix/app/components/general/template/template-type.tsx
@@ -4562,6 +4609,7 @@ msgstr "Rechazar Documento"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 msgid "Rejected"
 msgstr "Rejected"
@@ -4768,6 +4816,7 @@ msgstr "Guardar plantilla"
 #: apps/remix/app/components/tables/user-settings-teams-page-table.tsx
 #: apps/remix/app/components/tables/documents-table-sender-filter.tsx
 #: apps/remix/app/components/general/app-nav-desktop.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 msgid "Search"
 msgstr "Buscar"
 
@@ -4849,6 +4898,11 @@ msgstr "Seleccionar opción predeterminada"
 #: apps/remix/app/components/general/document-signing/document-signing-auth-passkey.tsx
 msgid "Select passkey"
 msgstr "Seleccionar clave de acceso"
+
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "Select team member"
+msgstr ""
 
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
@@ -5030,6 +5084,7 @@ msgstr "Firmar como<0>{0} <1>({1})</1></0>"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign document"
 msgstr "Firmar documento"
 
@@ -5037,6 +5092,10 @@ msgstr "Firmar documento"
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Sign Document"
 msgstr "Firmar Documento"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Sign Documents"
+msgstr ""
 
 #: apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx
 msgid "Sign field"
@@ -5063,6 +5122,7 @@ msgstr "Cerrar sesión"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign the document to complete the process."
 msgstr "Firma el documento para completar el proceso."
 
@@ -5086,6 +5146,7 @@ msgstr "Regístrate con OIDC"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/template-flow/add-template-fields.tsx
 #: packages/ui/primitives/document-flow/types.ts
 #: packages/ui/primitives/document-flow/add-fields.tsx
@@ -5640,6 +5701,10 @@ msgstr "Alineación de texto"
 #: apps/remix/app/routes/_authenticated+/admin+/site-settings.tsx
 msgid "Text Color"
 msgstr "Color de texto"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Thank you for completing the signing process."
+msgstr ""
 
 #: apps/remix/app/routes/_unauthenticated+/articles.signature-disclosure.tsx
 msgid "Thank you for using Documenso to perform your electronic document signing. The purpose of this disclosure is to inform you about the process, legality, and your rights regarding the use of electronic signatures on our platform. By opting to use an electronic signature, you are agreeing to the terms and conditions outlined below."
@@ -6718,6 +6783,7 @@ msgstr "Historial de Versiones"
 #: apps/remix/app/components/tables/documents-table-action-button.tsx
 #: apps/remix/app/components/general/document/document-page-view-button.tsx
 #: apps/remix/app/components/forms/2fa/view-recovery-codes-dialog.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "View"
 msgstr "Ver"
@@ -6775,6 +6841,10 @@ msgstr "Ver invitaciones"
 msgid "View more"
 msgstr "Ver más"
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "View next document"
+msgstr ""
+
 #: apps/remix/app/routes/_recipient+/sign.$token+/complete.tsx
 msgid "View Original Document"
 msgstr "Ver Documento Original"
@@ -6794,6 +6864,7 @@ msgstr "Ver equipos"
 
 #: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "Viewed"
 msgstr "Visto"
@@ -7341,6 +7412,10 @@ msgstr "Te han invitado a unirte al siguiente equipo"
 #: packages/lib/server-only/recipient/delete-document-recipient.ts
 msgid "You have been removed from a document"
 msgstr "Te han eliminado de un documento"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
+msgstr ""
 
 #. placeholder {0}: team.name
 #: packages/lib/server-only/team/request-team-ownership-transfer.ts

--- a/packages/lib/translations/fr/web.po
+++ b/packages/lib/translations/fr/web.po
@@ -438,6 +438,10 @@ msgstr "<0>Email</0> - Le destinataire recevra le document par e-mail pour signe
 msgid "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 msgstr "<0>Hériter de la méthode d'authentification</0> - Utilisez la méthode globale d'authentification de signature d'action configurée dans l'étape \"Paramètres généraux\""
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "<0>Member:</0>"
+msgstr ""
+
 #: packages/ui/components/document/document-global-auth-action-select.tsx
 msgid "<0>No restrictions</0> - No authentication required"
 msgstr "<0>Aucune restriction</0> - Aucune authentification requise"
@@ -726,6 +730,7 @@ msgstr "Actif"
 msgid "Active Subscriptions"
 msgstr "Abonnements actifs"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-email-add-dialog.tsx
 msgid "Add"
 msgstr "Ajouter"
@@ -782,6 +787,10 @@ msgstr "Ajouter un e-mail"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 msgid "Add Fields"
 msgstr "Ajouter des champs"
+
+#: packages/ui/primitives/document-flow/add-signers.tsx
+msgid "Add member"
+msgstr ""
 
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 msgid "Add more"
@@ -892,6 +901,10 @@ msgstr "Tout"
 #: apps/remix/app/components/general/app-command-menu.tsx
 msgid "All documents"
 msgstr "Tous les documents"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "All documents have been completed!"
+msgstr ""
 
 #: apps/remix/app/components/tables/documents-table-empty-state.tsx
 msgid "All documents have been processed. Any new documents that are sent or received will show here."
@@ -1113,6 +1126,7 @@ msgstr "Une erreur s'est produite lors de la signature en tant qu'assistant."
 #: apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-date-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "An error occurred while signing the document."
 msgstr "Une erreur est survenue lors de la signature du document."
 
@@ -1296,6 +1310,10 @@ msgstr "Le rôle d'assistant est uniquement disponible lorsque le document est e
 #: packages/lib/constants/recipient-roles.ts
 msgid "Assistants"
 msgstr "\"\""
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Assistants and Copy roles are currently not compatible with the multi-sign experience."
+msgstr ""
 
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
 #: packages/lib/constants/recipient-roles.ts
@@ -1504,6 +1522,7 @@ msgstr "Peut préparer"
 #: apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
 #: apps/remix/app/components/dialogs/team-transfer-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-delete-dialog.tsx
 #: apps/remix/app/components/dialogs/team-leave-dialog.tsx
@@ -1644,6 +1663,7 @@ msgstr "Cliquez pour copier le lien de signature à envoyer au destinataire"
 #: apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Click to insert field"
 msgstr "Cliquez pour insérer un champ"
 
@@ -1670,6 +1690,7 @@ msgstr ""
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Complete"
 msgstr "Compléter"
 
@@ -1701,6 +1722,7 @@ msgstr "Compléter la visualisation"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/template/template-page-view-documents-table.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 #: packages/email/template-components/template-document-self-signed.tsx
 #: packages/email/template-components/template-document-recipient-signed.tsx
@@ -2772,6 +2794,7 @@ msgstr "Divulgation de signature électronique"
 #: apps/remix/app/components/forms/forgot-password.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-advanced-settings.tsx
@@ -2954,6 +2977,7 @@ msgstr "Entrez votre texte ici"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-drop-zone-wrapper.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/dialogs/webhook-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 #: apps/remix/app/components/dialogs/template-move-to-folder-dialog.tsx
@@ -3008,6 +3032,10 @@ msgstr "ID externe"
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 msgid "Failed to create folder"
+msgstr ""
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
+msgid "Failed to load document"
 msgstr ""
 
 #: apps/remix/app/routes/_authenticated+/admin+/documents.$id.tsx
@@ -3153,6 +3181,7 @@ msgstr "Signature gratuite"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Full Name"
 msgstr "Nom complet"
 
@@ -3435,6 +3464,10 @@ msgstr "Il est crucial de maintenir vos coordonnées, en particulier votre adres
 msgid "It looks like {0} hasn't added any documents to their profile yet."
 msgstr "Il semble que {0} n'ait pas encore ajouté de documents à son profil."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "It looks like we ran into an issue!"
+msgstr ""
+
 #: apps/remix/app/routes/_unauthenticated+/verify-email.$token.tsx
 msgid "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
 msgstr "Il semble que le token fourni ait expiré. Nous venons de vous envoyer un autre token, veuillez vérifier votre email et réessayer."
@@ -3553,6 +3586,7 @@ msgid "Load older activity"
 msgstr "Charger l'activité plus ancienne"
 
 #: apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/pdf-viewer.tsx
 msgid "Loading document..."
 msgstr "Chargement du document..."
@@ -3839,6 +3873,7 @@ msgstr "Nouveau modèle"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
 msgid "Next"
 msgstr "Suivant"
@@ -4004,6 +4039,10 @@ msgstr "Une fois que vous avez scanné le code QR ou saisi le code manuellement,
 #: packages/lib/constants/template.ts
 msgid "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
 msgstr "Une fois votre modèle configuré, partagez le lien où vous le souhaitez. La personne qui ouvre le lien pourra saisir ses informations dans le champ de destinataire de lien direct et remplir tout autre champ qui lui est attribué."
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
+msgstr ""
 
 #: apps/remix/app/components/forms/team-document-preferences-form.tsx
 msgid "Only admins can access and view the document"
@@ -4256,6 +4295,10 @@ msgstr "Veuillez confirmer votre adresse email"
 msgid "Please contact support if you would like to revert this action."
 msgstr "Veuillez contacter le support si vous souhaitez annuler cette action."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Please contact the site owner for further assistance."
+msgstr ""
+
 #: apps/remix/app/components/forms/token.tsx
 msgid "Please enter a meaningful name for your token. This will help you identify it later."
 msgstr "Veuillez entrer un nom significatif pour votre token. Cela vous aidera à l'identifier plus tard."
@@ -4391,6 +4434,10 @@ msgstr "Le profil est actuellement <0>visible</0>."
 #: apps/remix/app/components/forms/profile.tsx
 msgid "Profile updated"
 msgstr "Profil mis à jour"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Progress"
+msgstr ""
 
 #: apps/remix/app/components/tables/templates-table.tsx
 #: apps/remix/app/components/general/template/template-type.tsx
@@ -4562,6 +4609,7 @@ msgstr "Rejeter le Document"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 msgid "Rejected"
 msgstr "Rejeté"
@@ -4768,6 +4816,7 @@ msgstr "Sauvegarder le modèle"
 #: apps/remix/app/components/tables/user-settings-teams-page-table.tsx
 #: apps/remix/app/components/tables/documents-table-sender-filter.tsx
 #: apps/remix/app/components/general/app-nav-desktop.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 msgid "Search"
 msgstr "Recherche"
 
@@ -4849,6 +4898,11 @@ msgstr "Sélectionner l'option par défaut"
 #: apps/remix/app/components/general/document-signing/document-signing-auth-passkey.tsx
 msgid "Select passkey"
 msgstr "Sélectionner la clé d'authentification"
+
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "Select team member"
+msgstr ""
 
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
@@ -5030,6 +5084,7 @@ msgstr "Signer comme<0>{0} <1>({1})</1></0>"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign document"
 msgstr "Signer le document"
 
@@ -5037,6 +5092,10 @@ msgstr "Signer le document"
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Sign Document"
 msgstr "Signer le document"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Sign Documents"
+msgstr ""
 
 #: apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx
 msgid "Sign field"
@@ -5063,6 +5122,7 @@ msgstr "Déconnexion"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign the document to complete the process."
 msgstr "Signez le document pour terminer le processus."
 
@@ -5086,6 +5146,7 @@ msgstr "S'inscrire avec OIDC"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/template-flow/add-template-fields.tsx
 #: packages/ui/primitives/document-flow/types.ts
 #: packages/ui/primitives/document-flow/add-fields.tsx
@@ -5640,6 +5701,10 @@ msgstr "Alignement du texte"
 #: apps/remix/app/routes/_authenticated+/admin+/site-settings.tsx
 msgid "Text Color"
 msgstr "Couleur du texte"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Thank you for completing the signing process."
+msgstr ""
 
 #: apps/remix/app/routes/_unauthenticated+/articles.signature-disclosure.tsx
 msgid "Thank you for using Documenso to perform your electronic document signing. The purpose of this disclosure is to inform you about the process, legality, and your rights regarding the use of electronic signatures on our platform. By opting to use an electronic signature, you are agreeing to the terms and conditions outlined below."
@@ -6716,6 +6781,7 @@ msgstr "Historique des versions"
 #: apps/remix/app/components/tables/documents-table-action-button.tsx
 #: apps/remix/app/components/general/document/document-page-view-button.tsx
 #: apps/remix/app/components/forms/2fa/view-recovery-codes-dialog.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "View"
 msgstr "Voir"
@@ -6773,6 +6839,10 @@ msgstr "Voir les invitations"
 msgid "View more"
 msgstr "Voir plus"
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "View next document"
+msgstr ""
+
 #: apps/remix/app/routes/_recipient+/sign.$token+/complete.tsx
 msgid "View Original Document"
 msgstr "Voir le document original"
@@ -6792,6 +6862,7 @@ msgstr "Voir les équipes"
 
 #: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "Viewed"
 msgstr "Vu"
@@ -7339,6 +7410,10 @@ msgstr "Vous avez été invité à rejoindre l'équipe suivante"
 #: packages/lib/server-only/recipient/delete-document-recipient.ts
 msgid "You have been removed from a document"
 msgstr "Vous avez été supprimé d'un document"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
+msgstr ""
 
 #. placeholder {0}: team.name
 #: packages/lib/server-only/team/request-team-ownership-transfer.ts

--- a/packages/lib/translations/it/web.po
+++ b/packages/lib/translations/it/web.po
@@ -438,6 +438,10 @@ msgstr "<0>Email</0> - Al destinatario verrà inviato il documento tramite email
 msgid "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 msgstr "<0>Eredita metodo di autenticazione</0> - Usa il metodo globale di autenticazione della firma configurato nel passaggio \"Impostazioni generali\""
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "<0>Member:</0>"
+msgstr ""
+
 #: packages/ui/components/document/document-global-auth-action-select.tsx
 msgid "<0>No restrictions</0> - No authentication required"
 msgstr "<0>Nessuna restrizione</0> - Non è richiesta autenticazione"
@@ -726,6 +730,7 @@ msgstr "Attivo"
 msgid "Active Subscriptions"
 msgstr "Abbonamenti attivi"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-email-add-dialog.tsx
 msgid "Add"
 msgstr "Aggiungi"
@@ -782,6 +787,10 @@ msgstr "Aggiungi email"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 msgid "Add Fields"
 msgstr "Aggiungi campi"
+
+#: packages/ui/primitives/document-flow/add-signers.tsx
+msgid "Add member"
+msgstr ""
 
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 msgid "Add more"
@@ -892,6 +901,10 @@ msgstr "Tutto"
 #: apps/remix/app/components/general/app-command-menu.tsx
 msgid "All documents"
 msgstr "Tutti i documenti"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "All documents have been completed!"
+msgstr ""
 
 #: apps/remix/app/components/tables/documents-table-empty-state.tsx
 msgid "All documents have been processed. Any new documents that are sent or received will show here."
@@ -1113,6 +1126,7 @@ msgstr "Si è verificato un errore durante la firma come assistente."
 #: apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-date-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "An error occurred while signing the document."
 msgstr "Si è verificato un errore durante la firma del documento."
 
@@ -1296,6 +1310,10 @@ msgstr "Il ruolo di assistente è disponibile solo quando il documento è in mod
 #: packages/lib/constants/recipient-roles.ts
 msgid "Assistants"
 msgstr "Assistenti"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Assistants and Copy roles are currently not compatible with the multi-sign experience."
+msgstr ""
 
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
 #: packages/lib/constants/recipient-roles.ts
@@ -1504,6 +1522,7 @@ msgstr "Può preparare"
 #: apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
 #: apps/remix/app/components/dialogs/team-transfer-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-delete-dialog.tsx
 #: apps/remix/app/components/dialogs/team-leave-dialog.tsx
@@ -1644,6 +1663,7 @@ msgstr "Clicca per copiare il link di firma da inviare al destinatario"
 #: apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Click to insert field"
 msgstr "Clicca per inserire il campo"
 
@@ -1670,6 +1690,7 @@ msgstr ""
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Complete"
 msgstr "Completa"
 
@@ -1701,6 +1722,7 @@ msgstr "Completa la Visualizzazione"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/template/template-page-view-documents-table.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 #: packages/email/template-components/template-document-self-signed.tsx
 #: packages/email/template-components/template-document-recipient-signed.tsx
@@ -2772,6 +2794,7 @@ msgstr "Divulgazione della firma elettronica"
 #: apps/remix/app/components/forms/forgot-password.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-advanced-settings.tsx
@@ -2954,6 +2977,7 @@ msgstr "Inserisci il tuo testo qui"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-drop-zone-wrapper.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/dialogs/webhook-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 #: apps/remix/app/components/dialogs/template-move-to-folder-dialog.tsx
@@ -3008,6 +3032,10 @@ msgstr "ID esterno"
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 msgid "Failed to create folder"
+msgstr ""
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
+msgid "Failed to load document"
 msgstr ""
 
 #: apps/remix/app/routes/_authenticated+/admin+/documents.$id.tsx
@@ -3153,6 +3181,7 @@ msgstr "Firma gratuita"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Full Name"
 msgstr "Nome completo"
 
@@ -3435,6 +3464,10 @@ msgstr "È fondamentale mantenere aggiornate le tue informazioni di contatto, in
 msgid "It looks like {0} hasn't added any documents to their profile yet."
 msgstr "Sembra che {0} non abbia ancora aggiunto documenti al proprio profilo."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "It looks like we ran into an issue!"
+msgstr ""
+
 #: apps/remix/app/routes/_unauthenticated+/verify-email.$token.tsx
 msgid "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
 msgstr "Sembra che il token fornito sia scaduto. Ti abbiamo appena inviato un altro token, controlla la tua email e riprova."
@@ -3553,6 +3586,7 @@ msgid "Load older activity"
 msgstr "Carica attività precedente"
 
 #: apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/pdf-viewer.tsx
 msgid "Loading document..."
 msgstr "Caricamento del documento..."
@@ -3839,6 +3873,7 @@ msgstr "Nuovo modello"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
 msgid "Next"
 msgstr "Successivo"
@@ -4004,6 +4039,10 @@ msgstr "Una volta scansionato il codice QR o inserito manualmente il codice, ins
 #: packages/lib/constants/template.ts
 msgid "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
 msgstr "Una volta configurato il tuo modello, condividi il link ovunque tu voglia. La persona che apre il link potrà inserire le proprie informazioni nel campo destinatario del link diretto e completare qualsiasi altro campo assegnato a loro."
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
+msgstr ""
 
 #: apps/remix/app/components/forms/team-document-preferences-form.tsx
 msgid "Only admins can access and view the document"
@@ -4256,6 +4295,10 @@ msgstr "Per favore conferma il tuo indirizzo email"
 msgid "Please contact support if you would like to revert this action."
 msgstr "Si prega di contattare il supporto se si desidera annullare questa azione."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Please contact the site owner for further assistance."
+msgstr ""
+
 #: apps/remix/app/components/forms/token.tsx
 msgid "Please enter a meaningful name for your token. This will help you identify it later."
 msgstr "Si prega di inserire un nome significativo per il proprio token. Questo ti aiuterà a identificarlo più tardi."
@@ -4391,6 +4434,10 @@ msgstr "Il profilo è attualmente <0>visibile</0>."
 #: apps/remix/app/components/forms/profile.tsx
 msgid "Profile updated"
 msgstr "Profilo aggiornato"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Progress"
+msgstr ""
 
 #: apps/remix/app/components/tables/templates-table.tsx
 #: apps/remix/app/components/general/template/template-type.tsx
@@ -4562,6 +4609,7 @@ msgstr "Rifiuta Documento"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 msgid "Rejected"
 msgstr "Rifiutato"
@@ -4768,6 +4816,7 @@ msgstr "Salva modello"
 #: apps/remix/app/components/tables/user-settings-teams-page-table.tsx
 #: apps/remix/app/components/tables/documents-table-sender-filter.tsx
 #: apps/remix/app/components/general/app-nav-desktop.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 msgid "Search"
 msgstr "Cerca"
 
@@ -4849,6 +4898,11 @@ msgstr "Seleziona opzione predefinita"
 #: apps/remix/app/components/general/document-signing/document-signing-auth-passkey.tsx
 msgid "Select passkey"
 msgstr "Seleziona una chiave di accesso"
+
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "Select team member"
+msgstr ""
 
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
@@ -5030,6 +5084,7 @@ msgstr "Firma come<0>{0} <1>({1})</1></0>"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign document"
 msgstr "Firma il documento"
 
@@ -5037,6 +5092,10 @@ msgstr "Firma il documento"
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Sign Document"
 msgstr "Firma documento"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Sign Documents"
+msgstr ""
 
 #: apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx
 msgid "Sign field"
@@ -5063,6 +5122,7 @@ msgstr "Disconnetti"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign the document to complete the process."
 msgstr "Firma il documento per completare il processo."
 
@@ -5086,6 +5146,7 @@ msgstr "Iscriviti con OIDC"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/template-flow/add-template-fields.tsx
 #: packages/ui/primitives/document-flow/types.ts
 #: packages/ui/primitives/document-flow/add-fields.tsx
@@ -5640,6 +5701,10 @@ msgstr "Allineamento del testo"
 #: apps/remix/app/routes/_authenticated+/admin+/site-settings.tsx
 msgid "Text Color"
 msgstr "Colore del testo"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Thank you for completing the signing process."
+msgstr ""
 
 #: apps/remix/app/routes/_unauthenticated+/articles.signature-disclosure.tsx
 msgid "Thank you for using Documenso to perform your electronic document signing. The purpose of this disclosure is to inform you about the process, legality, and your rights regarding the use of electronic signatures on our platform. By opting to use an electronic signature, you are agreeing to the terms and conditions outlined below."
@@ -6718,6 +6783,7 @@ msgstr "Cronologia delle versioni"
 #: apps/remix/app/components/tables/documents-table-action-button.tsx
 #: apps/remix/app/components/general/document/document-page-view-button.tsx
 #: apps/remix/app/components/forms/2fa/view-recovery-codes-dialog.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "View"
 msgstr "Visualizza"
@@ -6775,6 +6841,10 @@ msgstr "Visualizza inviti"
 msgid "View more"
 msgstr "Vedi di più"
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "View next document"
+msgstr ""
+
 #: apps/remix/app/routes/_recipient+/sign.$token+/complete.tsx
 msgid "View Original Document"
 msgstr "Visualizza Documento Originale"
@@ -6794,6 +6864,7 @@ msgstr "Visualizza squadre"
 
 #: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "Viewed"
 msgstr "Visualizzato"
@@ -7341,6 +7412,10 @@ msgstr "Sei stato invitato a unirti al seguente team"
 #: packages/lib/server-only/recipient/delete-document-recipient.ts
 msgid "You have been removed from a document"
 msgstr "Sei stato rimosso da un documento"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
+msgstr ""
 
 #. placeholder {0}: team.name
 #: packages/lib/server-only/team/request-team-ownership-transfer.ts

--- a/packages/lib/translations/pl/web.po
+++ b/packages/lib/translations/pl/web.po
@@ -438,6 +438,10 @@ msgstr "<0>E-mail</0> - Odbiorca otrzyma e-mail z dokumentem do podpisania, zatw
 msgid "<0>Inherit authentication method</0> - Use the global action signing authentication method configured in the \"General Settings\" step"
 msgstr "<0>Przechwyć metodę uwierzytelniania</0> - Użyj globalnej metody uwierzytelniania podpisywania akcji skonfigurowanej w kroku \"Ustawienia ogólne\""
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "<0>Member:</0>"
+msgstr ""
+
 #: packages/ui/components/document/document-global-auth-action-select.tsx
 msgid "<0>No restrictions</0> - No authentication required"
 msgstr "<0>Brak ograniczeń</0> - Uwierzytelnianie nie jest wymagane"
@@ -726,6 +730,7 @@ msgstr "Aktywne"
 msgid "Active Subscriptions"
 msgstr "Aktywne subskrypcje"
 
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-email-add-dialog.tsx
 msgid "Add"
 msgstr "Dodaj"
@@ -782,6 +787,10 @@ msgstr "Dodaj adres e-mail"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 msgid "Add Fields"
 msgstr "Dodaj pola"
+
+#: packages/ui/primitives/document-flow/add-signers.tsx
+msgid "Add member"
+msgstr ""
 
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 msgid "Add more"
@@ -892,6 +901,10 @@ msgstr "Wszystko"
 #: apps/remix/app/components/general/app-command-menu.tsx
 msgid "All documents"
 msgstr "Wszystkie dokumenty"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "All documents have been completed!"
+msgstr ""
 
 #: apps/remix/app/components/tables/documents-table-empty-state.tsx
 msgid "All documents have been processed. Any new documents that are sent or received will show here."
@@ -1113,6 +1126,7 @@ msgstr "Wystąpił błąd podczas podpisywania jako asystent."
 #: apps/remix/app/components/general/document-signing/document-signing-dropdown-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-date-field.tsx
 #: apps/remix/app/components/general/document-signing/document-signing-checkbox-field.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "An error occurred while signing the document."
 msgstr "Wystąpił błąd podczas podpisywania dokumentu."
 
@@ -1296,6 +1310,10 @@ msgstr "Rola asystenta jest dostępna tylko w trybie sekwencyjnego podpisywania 
 #: packages/lib/constants/recipient-roles.ts
 msgid "Assistants"
 msgstr "Asystenci"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Assistants and Copy roles are currently not compatible with the multi-sign experience."
+msgstr ""
 
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
 #: packages/lib/constants/recipient-roles.ts
@@ -1504,6 +1522,7 @@ msgstr "Może przygotować"
 #: apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
 #: apps/remix/app/components/dialogs/team-transfer-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-invite-dialog.tsx
 #: apps/remix/app/components/dialogs/team-member-delete-dialog.tsx
 #: apps/remix/app/components/dialogs/team-leave-dialog.tsx
@@ -1644,6 +1663,7 @@ msgstr "Kliknij, aby skopiować link podpisu do wysłania do odbiorcy"
 #: apps/remix/app/components/general/direct-template/direct-template-signing-form.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Click to insert field"
 msgstr "Kliknij, aby wstawić pole"
 
@@ -1670,6 +1690,7 @@ msgstr ""
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Complete"
 msgstr "Zakończono"
 
@@ -1701,6 +1722,7 @@ msgstr "Zakończ wyświetlanie"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/template/template-page-view-documents-table.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 #: packages/email/template-components/template-document-self-signed.tsx
 #: packages/email/template-components/template-document-recipient-signed.tsx
@@ -2772,6 +2794,7 @@ msgstr "Ujawnienie podpisu elektronicznego"
 #: apps/remix/app/components/forms/forgot-password.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-recipients.tsx
 #: apps/remix/app/components/embed/authoring/configure-document-advanced-settings.tsx
@@ -2954,6 +2977,7 @@ msgstr "Wprowadź swój tekst tutaj"
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-edit-form.tsx
 #: apps/remix/app/components/general/document/document-drop-zone-wrapper.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: apps/remix/app/components/dialogs/webhook-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 #: apps/remix/app/components/dialogs/template-move-to-folder-dialog.tsx
@@ -3008,6 +3032,10 @@ msgstr "Zewnętrzny ID"
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 #: apps/remix/app/components/dialogs/template-folder-create-dialog.tsx
 msgid "Failed to create folder"
+msgstr ""
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
+msgid "Failed to load document"
 msgstr ""
 
 #: apps/remix/app/routes/_authenticated+/admin+/documents.$id.tsx
@@ -3153,6 +3181,7 @@ msgstr "Podpis wolny"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Full Name"
 msgstr "Imię i nazwisko"
 
@@ -3435,6 +3464,10 @@ msgstr "Konieczne jest, aby mieć aktualne informacje kontaktowe, szczególnie s
 msgid "It looks like {0} hasn't added any documents to their profile yet."
 msgstr "Wygląda na to, że {0} jeszcze nie dodał żadnych dokumentów do swojego profilu."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "It looks like we ran into an issue!"
+msgstr ""
+
 #: apps/remix/app/routes/_unauthenticated+/verify-email.$token.tsx
 msgid "It seems that the provided token has expired. We've just sent you another token, please check your email and try again."
 msgstr "Wydaje się, że podany token wygasł. Właśnie wysłaliśmy Ci nowy token, proszę sprawdź swoją pocztę i spróbuj ponownie."
@@ -3553,6 +3586,7 @@ msgid "Load older activity"
 msgstr "Załaduj starszą aktywność"
 
 #: apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/pdf-viewer.tsx
 msgid "Loading document..."
 msgstr "Ładowanie dokumentu..."
@@ -3839,6 +3873,7 @@ msgstr "Nowy szablon"
 #: apps/remix/app/components/forms/signup.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
 msgid "Next"
 msgstr "Dalej"
@@ -4004,6 +4039,10 @@ msgstr "Po zeskanowaniu kodu QR lub ręcznym wpisaniu kodu, wprowadź poniżej k
 #: packages/lib/constants/template.ts
 msgid "Once your template is set up, share the link anywhere you want. The person who opens the link will be able to enter their information in the direct link recipient field and complete any other fields assigned to them."
 msgstr "Po skonfigurowaniu szablonu udostępnij link wszędzie, gdzie chcesz. Osoba, która otworzy link, będzie mogła wprowadzić swoje dane w polu odbiorcy linku bezpośredniego i wypełnić wszelkie inne przypisane jej pola."
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "One of the documents in the current bundle has a signing role that is not compatible with the current signing experience."
+msgstr ""
 
 #: apps/remix/app/components/forms/team-document-preferences-form.tsx
 msgid "Only admins can access and view the document"
@@ -4256,6 +4295,10 @@ msgstr "Proszę potwierdzić swój adres email"
 msgid "Please contact support if you would like to revert this action."
 msgstr "Proszę skontaktować się z pomocą techniczną, jeśli chcesz cofnąć tę akcję."
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Please contact the site owner for further assistance."
+msgstr ""
+
 #: apps/remix/app/components/forms/token.tsx
 msgid "Please enter a meaningful name for your token. This will help you identify it later."
 msgstr "Wpisz nazwę tokena. Pomoże to później w jego identyfikacji."
@@ -4391,6 +4434,10 @@ msgstr "Profil jest obecnie <0>widoczny</0>."
 #: apps/remix/app/components/forms/profile.tsx
 msgid "Profile updated"
 msgstr "Profil zaktualizowano"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Progress"
+msgstr ""
 
 #: apps/remix/app/components/tables/templates-table.tsx
 #: apps/remix/app/components/general/template/template-type.tsx
@@ -4562,6 +4609,7 @@ msgstr "Odrzuć dokument"
 #: apps/remix/app/components/general/stack-avatars-with-tooltip.tsx
 #: apps/remix/app/components/general/document/document-status.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/document.ts
 msgid "Rejected"
 msgstr "Odrzucony"
@@ -4768,6 +4816,7 @@ msgstr "Zapisz szablon"
 #: apps/remix/app/components/tables/user-settings-teams-page-table.tsx
 #: apps/remix/app/components/tables/documents-table-sender-filter.tsx
 #: apps/remix/app/components/general/app-nav-desktop.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
 msgid "Search"
 msgstr "Szukaj"
 
@@ -4849,6 +4898,11 @@ msgstr "Wybierz domyślną opcję"
 #: apps/remix/app/components/general/document-signing/document-signing-auth-passkey.tsx
 msgid "Select passkey"
 msgstr "Wybierz klucz uwierzytelniający"
+
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+#: apps/remix/app/components/dialogs/team-member-select-dialog.tsx
+msgid "Select team member"
+msgstr ""
 
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
 #: apps/remix/app/components/general/webhook-multiselect-combobox.tsx
@@ -5030,6 +5084,7 @@ msgstr "Podpisz jako<0>{0} <1>({1})</1></0>"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign document"
 msgstr "Podpisz dokument"
 
@@ -5037,6 +5092,10 @@ msgstr "Podpisz dokument"
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Sign Document"
 msgstr "Podpisz dokument"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Sign Documents"
+msgstr ""
 
 #: apps/remix/app/components/general/document-signing/document-signing-auth-dialog.tsx
 msgid "Sign field"
@@ -5063,6 +5122,7 @@ msgstr "Wyloguj"
 
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 msgid "Sign the document to complete the process."
 msgstr "Podpisz dokument, aby zakończyć proces."
 
@@ -5086,6 +5146,7 @@ msgstr "Zarejestruj się za pomocą OIDC"
 #: apps/remix/app/components/forms/profile.tsx
 #: apps/remix/app/components/embed/embed-document-signing-page.tsx
 #: apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-signing-view.tsx
 #: packages/ui/primitives/template-flow/add-template-fields.tsx
 #: packages/ui/primitives/document-flow/types.ts
 #: packages/ui/primitives/document-flow/add-fields.tsx
@@ -5640,6 +5701,10 @@ msgstr "Wyrównanie tekstu"
 #: apps/remix/app/routes/_authenticated+/admin+/site-settings.tsx
 msgid "Text Color"
 msgstr "Kolor tekstu"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "Thank you for completing the signing process."
+msgstr ""
 
 #: apps/remix/app/routes/_unauthenticated+/articles.signature-disclosure.tsx
 msgid "Thank you for using Documenso to perform your electronic document signing. The purpose of this disclosure is to inform you about the process, legality, and your rights regarding the use of electronic signatures on our platform. By opting to use an electronic signature, you are agreeing to the terms and conditions outlined below."
@@ -6716,6 +6781,7 @@ msgstr "Historia wersji"
 #: apps/remix/app/components/tables/documents-table-action-button.tsx
 #: apps/remix/app/components/general/document/document-page-view-button.tsx
 #: apps/remix/app/components/forms/2fa/view-recovery-codes-dialog.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "View"
 msgstr "Widok"
@@ -6773,6 +6839,10 @@ msgstr "Wyświetl zaproszenia"
 msgid "View more"
 msgstr "Zobacz więcej"
 
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "View next document"
+msgstr ""
+
 #: apps/remix/app/routes/_recipient+/sign.$token+/complete.tsx
 msgid "View Original Document"
 msgstr "Wyświetl oryginalny dokument"
@@ -6792,6 +6862,7 @@ msgstr "Wyświetl zespoły"
 
 #: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
 #: apps/remix/app/components/general/document/document-page-view-recipients.tsx
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 #: packages/lib/constants/recipient-roles.ts
 msgid "Viewed"
 msgstr "Wyświetlono"
@@ -7339,6 +7410,10 @@ msgstr "Zostałeś zaproszony do dołączenia do następującego zespołu"
 #: packages/lib/server-only/recipient/delete-document-recipient.ts
 msgid "You have been removed from a document"
 msgstr "Zostałeś usunięty z dokumentu"
+
+#: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
+msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
+msgstr ""
 
 #. placeholder {0}: team.name
 #: packages/lib/server-only/team/request-team-ownership-transfer.ts

--- a/packages/ui/primitives/document-flow/add-signers.tsx
+++ b/packages/ui/primitives/document-flow/add-signers.tsx
@@ -18,6 +18,9 @@ import { useSession } from '@documenso/lib/client-only/providers/session';
 import { ZRecipientAuthOptionsSchema } from '@documenso/lib/types/document-auth';
 import { nanoid } from '@documenso/lib/universal/id';
 import { canRecipientBeModified as utilCanRecipientBeModified } from '@documenso/lib/utils/recipients';
+import type { Member } from '@documenso/remix/app/components/dialogs/team-member-select-dialog';
+import { TeamMemberSelectDialog } from '@documenso/remix/app/components/dialogs/team-member-select-dialog';
+import { useOptionalCurrentTeam } from '@documenso/remix/app/providers/team';
 import { AnimateGenericFadeInOut } from '@documenso/ui/components/animate/animate-generic-fade-in-out';
 import { RecipientActionAuthSelect } from '@documenso/ui/components/recipient/recipient-action-auth-select';
 import { RecipientRoleSelect } from '@documenso/ui/components/recipient/recipient-role-select';
@@ -72,6 +75,7 @@ export const AddSignersFormPartial = ({
   const { toast } = useToast();
   const { remaining } = useLimits();
   const { user } = useSession();
+  const team = useOptionalCurrentTeam();
 
   const initialId = useId();
   const $sensorApi = useRef<SensorAPI | null>(null);
@@ -193,6 +197,19 @@ export const AddSignersFormPartial = ({
       actionAuth: undefined,
       signingOrder: signers.length > 0 ? (signers[signers.length - 1]?.signingOrder ?? 0) + 1 : 1,
     });
+  };
+
+  const onAddTeamMembers = (members: Member[]) => {
+    members.map((member) =>
+      appendSigner({
+        formId: nanoid(12),
+        name: member.name,
+        email: member.email,
+        role: RecipientRole.SIGNER,
+        actionAuth: undefined,
+        signingOrder: signers.length > 0 ? (signers[signers.length - 1]?.signingOrder ?? 0) + 1 : 1,
+      }),
+    );
   };
 
   const onRemoveSigner = (index: number) => {
@@ -743,6 +760,23 @@ export const AddSignersFormPartial = ({
                 <Plus className="-ml-1 mr-2 h-5 w-5" />
                 <Trans>Add Signer</Trans>
               </Button>
+
+              {team && (
+                <TeamMemberSelectDialog
+                  teamId={team.id}
+                  onSubmit={(members) => onAddTeamMembers(members)}
+                  trigger={
+                    <Button
+                      type="button"
+                      className="flex-1"
+                      disabled={isSubmitting || signers.length >= remaining.recipients}
+                    >
+                      <Plus className="-ml-1 mr-2 h-5 w-5" />
+                      <Trans>Add member</Trans>
+                    </Button>
+                  }
+                />
+              )}
 
               <Button
                 type="button"


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the project for review and inclusion
---

## Description

I found it strange that, although I had my team members invited, I had to type their email addresses and names.

So I added a new button next to "Add signer" that opens a dialog to select available team member and add them as signers.

![image](https://github.com/user-attachments/assets/1ab3aa0f-6a26-4d96-ab35-bb2157b0d6a9)
![image](https://github.com/user-attachments/assets/73b16b23-5615-4165-91ae-e95748015d3d)
![image](https://github.com/user-attachments/assets/5c84a596-dc4a-46cc-bb50-b3aa3decc7a5)

## Guidance needed

I need some guidance on:
- There have been many translations added that are unrelated to my change. Should I remove them or keep?
- Did I follow your code guidelines well enough?
- Are further changes needed?


## Changes Made

- Added a new dialog that uses the multiselect combobox
- Add a button to the add signers step
- Change z-index of combobox menu to be usable inside dialogs
- Added playwright test
- Added translations

## Testing Performed

- nothing special beside the playwright test

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines. (I hope...)
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

