### PR TITLE
fix: duplicate fields and recipients when you duplicate a document

### DIFF
--- a/packages/lib/server-only/document/duplicate-document-by-id.ts
+++ b/packages/lib/server-only/document/duplicate-document-by-id.ts
@@ -47,7 +47,6 @@ export const duplicateDocument = async ({
       documentMeta: true,
       recipients: {
         select: {
-          id: true,
           email: true,
           name: true,
           role: true,

--- a/packages/lib/server-only/document/duplicate-document-by-id.ts
+++ b/packages/lib/server-only/document/duplicate-document-by-id.ts
@@ -153,13 +153,7 @@ export const duplicateDocument = async ({
       }
     }
 
-    return await tx.document.findUniqueOrThrow({
-      where: { id: newDocument.id },
-      include: {
-        recipients: true,
-        documentMeta: true,
-      },
-    });
+    return newDocument;
   });
 
   await triggerWebhook({

--- a/packages/lib/server-only/template/duplicate-template.ts
+++ b/packages/lib/server-only/template/duplicate-template.ts
@@ -23,8 +23,16 @@ export const duplicateTemplate = async ({
       team: buildTeamWhereQuery({ teamId, userId }),
     },
     include: {
-      recipients: true,
-      fields: true,
+      recipients: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+          signingOrder: true,
+          fields: true,
+        },
+      },
       templateDocumentData: true,
       templateMeta: true,
     },
@@ -59,13 +67,8 @@ export const duplicateTemplate = async ({
       teamId,
       title: template.title + ' (copy)',
       templateDocumentDataId: documentData.id,
-      recipients: {
-        create: template.recipients.map((recipient) => ({
-          email: recipient.email,
-          name: recipient.name,
-          token: nanoid(),
-        })),
-      },
+      authOptions: template.authOptions || undefined,
+      visibility: template.visibility,
       templateMeta,
     },
     include: {
@@ -73,33 +76,36 @@ export const duplicateTemplate = async ({
     },
   });
 
-  await prisma.field.createMany({
-    data: template.fields.map((field) => {
-      const recipient = template.recipients.find((recipient) => recipient.id === field.recipientId);
+  const recipientsToCreate = template.recipients.map((recipient) => ({
+    templateId: duplicatedTemplate.id,
+    email: recipient.email,
+    name: recipient.name,
+    role: recipient.role,
+    signingOrder: recipient.signingOrder,
+    token: nanoid(),
+    fields: {
+      createMany: {
+        data: recipient.fields.map((field) => ({
+          templateId: duplicatedTemplate.id,
+          type: field.type,
+          page: field.page,
+          positionX: field.positionX,
+          positionY: field.positionY,
+          width: field.width,
+          height: field.height,
+          customText: '',
+          inserted: false,
+          fieldMeta: field.fieldMeta as PrismaJson.FieldMeta,
+        })),
+      },
+    },
+  }));
 
-      const duplicatedTemplateRecipient = duplicatedTemplate.recipients.find(
-        (doc) => doc.email === recipient?.email,
-      );
-
-      if (!duplicatedTemplateRecipient) {
-        throw new Error('Recipient not found.');
-      }
-
-      return {
-        type: field.type,
-        page: field.page,
-        positionX: field.positionX,
-        positionY: field.positionY,
-        width: field.width,
-        height: field.height,
-        customText: field.customText,
-        inserted: field.inserted,
-        fieldMeta: field.fieldMeta as PrismaJson.FieldMeta,
-        templateId: duplicatedTemplate.id,
-        recipientId: duplicatedTemplateRecipient.id,
-      };
-    }),
-  });
+  for (const recipientData of recipientsToCreate) {
+    await prisma.recipient.create({
+      data: recipientData,
+    });
+  }
 
   return duplicatedTemplate;
 };

--- a/packages/lib/server-only/template/duplicate-template.ts
+++ b/packages/lib/server-only/template/duplicate-template.ts
@@ -94,6 +94,7 @@ export const duplicateTemplate = async ({
         height: field.height,
         customText: field.customText,
         inserted: field.inserted,
+        fieldMeta: field.fieldMeta as PrismaJson.FieldMeta,
         templateId: duplicatedTemplate.id,
         recipientId: duplicatedTemplateRecipient.id,
       };

--- a/packages/lib/server-only/template/duplicate-template.ts
+++ b/packages/lib/server-only/template/duplicate-template.ts
@@ -25,7 +25,6 @@ export const duplicateTemplate = async ({
     include: {
       recipients: {
         select: {
-          id: true,
           email: true,
           name: true,
           role: true,


### PR DESCRIPTION
## Description

Previously, duplicating documents created empty shells without fields or recipients, and template duplication lost all advanced field configurations. These changes implement proper deep cloning to create true functional copies.

## Changes Made

 - Create new recipients and fields for the new duplicated document
 - Added `fieldMeta` property to field creation in template duplication to preserve advanced settings