### PR TITLE
Issue when setting a different schema instead of public

### DIFF
--- a/packages/prisma/migrations/20240205120648_create_delete_account/migration.sql
+++ b/packages/prisma/migrations/20240205120648_create_delete_account/migration.sql
@@ -3,7 +3,7 @@ DO $$
 BEGIN  
   IF NOT EXISTS (SELECT 1 FROM "User" WHERE "email" = 'deleted-account@documenso.com') THEN  
     INSERT INTO
-      "public"."User" (
+      "User" (
         "email",
         "emailVerified",
         "password",

--- a/packages/prisma/migrations/20240205120648_create_delete_account/migration.sql
+++ b/packages/prisma/migrations/20240205120648_create_delete_account/migration.sql
@@ -1,7 +1,7 @@
 -- Create deleted@documenso.com
 DO $$
 BEGIN  
-  IF NOT EXISTS (SELECT 1 FROM "public"."User" WHERE "email" = 'deleted-account@documenso.com') THEN  
+  IF NOT EXISTS (SELECT 1 FROM "User" WHERE "email" = 'deleted-account@documenso.com') THEN  
     INSERT INTO
       "public"."User" (
         "email",
@@ -22,8 +22,8 @@ BEGIN
         NOW(),
         NOW(),
         NOW(),
-        ARRAY['USER'::TEXT]::"public"."Role" [],
-        CAST('GOOGLE'::TEXT AS "public"."IdentityProvider"),
+        ARRAY['USER'::TEXT]::"Role" [],
+        CAST('GOOGLE'::TEXT AS "IdentityProvider"),
         FALSE
       );
   END IF;  


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the project for review and inclusion
---

## Description
When setting a postgresql schema with url like postgres://USER:PASS@localhost/dbname?schema=documenso, iam getting this error because of a faulty migration.sql

Error: P3018
A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
 Migration name: 20240205120648_create_delete_account
Database error code: 42P01
 Database error:
  relation "public.User" does not exist

## Changes Made
Changes made to packages/prisma/migrations/20240205120648_create_delete_account/migration.sql

## Testing Performed
Tested on a new docker build
