### PR TITLE
fix: handle unauthorized document move error

### DIFF
--- a/apps/remix/app/components/dialogs/document-move-to-folder-dialog.tsx
+++ b/apps/remix/app/components/dialogs/document-move-to-folder-dialog.tsx
@@ -127,6 +127,16 @@ export const DocumentMoveToFolderDialog = ({
         return;
       }
 
+      if (error.code === AppErrorCode.UNAUTHORIZED) {
+        toast({
+          title: _(msg`Error`),
+          description: _(msg`You are not allowed to move this document.`),
+          variant: 'destructive',
+        });
+
+        return;
+      }
+
       toast({
         title: _(msg`Error`),
         description: _(msg`An error occurred while moving the document.`),

--- a/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
+++ b/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
@@ -188,12 +188,8 @@ export const DocumentsTableActionDropdown = ({
           <Trans>Duplicate</Trans>
         </DropdownMenuItem>
 
-        {onMoveDocument && (
-          <DropdownMenuItem
-            onClick={onMoveDocument}
-            disabled={!isOwner}
-            onSelect={(e) => e.preventDefault()}
-          >
+        {onMoveDocument && canManageDocument && (
+          <DropdownMenuItem onClick={onMoveDocument} onSelect={(e) => e.preventDefault()}>
             <FolderInput className="mr-2 h-4 w-4" />
             <Trans>Move to Folder</Trans>
           </DropdownMenuItem>

--- a/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
+++ b/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
@@ -189,7 +189,11 @@ export const DocumentsTableActionDropdown = ({
         </DropdownMenuItem>
 
         {onMoveDocument && (
-          <DropdownMenuItem onClick={onMoveDocument} onSelect={(e) => e.preventDefault()}>
+          <DropdownMenuItem
+            onClick={onMoveDocument}
+            disabled={!isOwner}
+            onSelect={(e) => e.preventDefault()}
+          >
             <FolderInput className="mr-2 h-4 w-4" />
             <Trans>Move to Folder</Trans>
           </DropdownMenuItem>

--- a/packages/lib/server-only/folder/move-document-to-folder.ts
+++ b/packages/lib/server-only/folder/move-document-to-folder.ts
@@ -54,6 +54,12 @@ export const moveDocumentToFolder = async ({
     where: documentWhereClause,
   });
 
+  if (document?.userId !== userId || document?.teamId !== teamId) {
+    throw new AppError(AppErrorCode.UNAUTHORIZED, {
+      message: 'You are not allowed to move this document',
+    });
+  }
+
   if (!document) {
     throw new AppError(AppErrorCode.NOT_FOUND, {
       message: 'Document not found',

--- a/packages/lib/server-only/folder/move-document-to-folder.ts
+++ b/packages/lib/server-only/folder/move-document-to-folder.ts
@@ -54,7 +54,7 @@ export const moveDocumentToFolder = async ({
     where: documentWhereClause,
   });
 
-  if (document?.userId !== userId || document?.teamId !== teamId) {
+  if (document?.userId !== userId && document?.teamId !== teamId) {
     throw new AppError(AppErrorCode.UNAUTHORIZED, {
       message: 'You are not allowed to move this document',
     });

--- a/packages/lib/server-only/folder/move-document-to-folder.ts
+++ b/packages/lib/server-only/folder/move-document-to-folder.ts
@@ -54,12 +54,6 @@ export const moveDocumentToFolder = async ({
     where: documentWhereClause,
   });
 
-  if (document?.userId !== userId && document?.teamId !== teamId) {
-    throw new AppError(AppErrorCode.UNAUTHORIZED, {
-      message: 'You are not allowed to move this document',
-    });
-  }
-
   if (!document) {
     throw new AppError(AppErrorCode.NOT_FOUND, {
       message: 'Document not found',


### PR DESCRIPTION
## Description

- Adds error handling for unauthorized document moving in the `DocumentMoveToFolderDialog` component.
- Displays a toast notification when the recipient tries to move a document. 
- Updates the `DocumentsTableActionDropdown` to disable the move option if the user is not the owner of the document.
- Ensures server-side validation checks for user permissions before moving documents.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.