### PR TITLE
feat: enable the text and annotation layer in the pdf-viewer

### DIFF
--- a/packages/ui/primitives/pdf-viewer.tsx
+++ b/packages/ui/primitives/pdf-viewer.tsx
@@ -226,8 +226,6 @@ export const PDFViewer = ({
                     <PDFPage
                       pageNumber={i + 1}
                       width={width}
-                      renderAnnotationLayer={false}
-                      renderTextLayer={false}
                       loading={() => ''}
                       onClick={(e) => onDocumentPageClick(e, i + 1)}
                     />


### PR DESCRIPTION
## Description
Hey this is my first pull request here, hopefully I didn't miss anything. This pull request removes the two lines that were disabling the textLayer and the annotationLayer in the react-pdf document viewer. Our customers have requested the ability to select text and click links in the PDF's they receive to sign. 

## Changes Made

- Enable the textLayer and annotationLayer which were disabled, the default is enabled so removing the two lines enables both features

## Testing Performed

Tested in Chrome and Firefox manually and all related e2e tests passed as well. All of the signing widgets appear on top of the PDF so links do not interfere with signing or any of that functionality.


## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have followed the project's coding style guidelines.

## Additional Notes

These features were disabled without any comments but I understand they may have been disabled for a reason. If the textLayer and annotationLayer being enabled pose security threaths or there is a reason for them being disabled I am fine with that. I would just like a reason to give customers who are asking for this functionality. Thanks!
