### PR TITLE
fix: clicking on tooltip icon submit parent form

### DIFF
--- a/packages/ui/components/document/document-signature-settings-tooltip.tsx
+++ b/packages/ui/components/document/document-signature-settings-tooltip.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitive
 export const DocumentSignatureSettingsTooltip = () => {
   return (
     <Tooltip>
-      <TooltipTrigger>
+      <TooltipTrigger type="button">
         <InfoIcon className="mx-2 h-4 w-4" />
       </TooltipTrigger>
 


### PR DESCRIPTION
## Description

In "Organization Settings" and "Team Settings" preferences pages, a click on the tooltip information icon submit the page form, which is unexpected.

<img width="1005" height="787" alt="Screenshot 2025-07-21 à 11 48 49" src="https://github.com/user-attachments/assets/1604e501-5d6d-4743-9085-adaa015d1b0f" />



To reproduce this issue:
- navigate to organization settings preferences page
- next to the form input label "Default Signature Settings", click on the information icon (circled "i")
- the page form is submitted (you get the popup "Document preferences updated")

## Related Issue


## Changes Made

Changed the tooltip icon button type to "button", as it is done in some other places in the project.

## Testing Performed

Tested on Safari and Firefox (macOS).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
