### PR TITLE
fix: correctly render new lines in text fields

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-fields.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-fields.tsx
@@ -12,7 +12,7 @@ export const DocumentSigningFieldsLoader = () => {
 
 export const DocumentSigningFieldsUninserted = ({ children }: { children: React.ReactNode }) => {
   return (
-    <p className="group-hover:text-primary text-foreground group-hover:text-recipient-green text-[clamp(0.425rem,25cqw,0.825rem)] duration-200">
+    <p className="text-foreground group-hover:text-recipient-green whitespace-pre-wrap text-[clamp(0.425rem,25cqw,0.825rem)] duration-200">
       {children}
     </p>
   );
@@ -37,7 +37,7 @@ export const DocumentSigningFieldsInserted = ({
     <div className="flex h-full w-full items-center overflow-hidden">
       <p
         className={cn(
-          'text-foreground w-full text-left text-[clamp(0.425rem,25cqw,0.825rem)] duration-200',
+          'text-foreground w-full whitespace-pre-wrap text-left text-[clamp(0.425rem,25cqw,0.825rem)] duration-200',
           {
             '!text-center': textAlign === 'center',
             '!text-right': textAlign === 'right',


### PR DESCRIPTION
## Description

Currently new lines are not rendered in text fields correctly on the `/sign` page. This is an issue because when the field is inserted and sealed we respect new lines.

**Previous**

<img width="617" height="470" alt="Screenshot 2025-07-24 at 11 06 50 am" src="https://github.com/user-attachments/assets/fa78c93b-2126-468b-8dbc-34aa7f08f0c5" />

**New**

<img width="617" height="470" alt="Screenshot 2025-07-24 at 11 07 04 am" src="https://github.com/user-attachments/assets/04a6b421-7616-45d5-8403-3c06826ef304" />
