### PR TITLE
feat: allow empty placeholder emails on templates

### DIFF
--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.tsx
@@ -14,6 +14,7 @@ import { useFieldArray, useForm } from 'react-hook-form';
 
 import { useCurrentOrganisation } from '@documenso/lib/client-only/providers/organisation';
 import { useSession } from '@documenso/lib/client-only/providers/session';
+import { TEMPLATE_RECIPIENT_EMAIL_PLACEHOLDER_REGEX } from '@documenso/lib/constants/template';
 import { ZRecipientAuthOptionsSchema } from '@documenso/lib/types/document-auth';
 import { nanoid } from '@documenso/lib/universal/id';
 import { generateRecipientPlaceholder } from '@documenso/lib/utils/templates';
@@ -247,62 +248,6 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
     [form, watchedSigners, toast],
   );
 
-  const triggerDragAndDrop = useCallback(
-    (fromIndex: number, toIndex: number) => {
-      if (!$sensorApi.current) {
-        return;
-      }
-
-      const draggableId = signers[fromIndex].id;
-
-      const preDrag = $sensorApi.current.tryGetLock(draggableId);
-
-      if (!preDrag) {
-        return;
-      }
-
-      const drag = preDrag.snapLift();
-
-      setTimeout(() => {
-        // Move directly to the target index
-        if (fromIndex < toIndex) {
-          for (let i = fromIndex; i < toIndex; i++) {
-            drag.moveDown();
-          }
-        } else {
-          for (let i = fromIndex; i > toIndex; i--) {
-            drag.moveUp();
-          }
-        }
-
-        setTimeout(() => {
-          drag.drop();
-        }, 500);
-      }, 0);
-    },
-    [signers],
-  );
-
-  const updateSigningOrders = useCallback(
-    (newIndex: number, oldIndex: number) => {
-      const updatedSigners = form.getValues('signers').map((signer, index) => {
-        if (index === oldIndex) {
-          return { ...signer, signingOrder: newIndex + 1 };
-        } else if (index >= newIndex && index < oldIndex) {
-          return { ...signer, signingOrder: (signer.signingOrder ?? index + 1) + 1 };
-        } else if (index <= newIndex && index > oldIndex) {
-          return { ...signer, signingOrder: Math.max(1, (signer.signingOrder ?? index + 1) - 1) };
-        }
-        return signer;
-      });
-
-      updatedSigners.forEach((signer, index) => {
-        form.setValue(`signers.${index}.signingOrder`, signer.signingOrder);
-      });
-    },
-    [form],
-  );
-
   const handleSigningOrderChange = useCallback(
     (index: number, newOrderString: string) => {
       const trimmedOrderString = newOrderString.trim();
@@ -393,6 +338,10 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
     form.setValue('signingOrder', DocumentSigningOrder.PARALLEL);
     form.setValue('allowDictateNextSigner', false);
   }, [form]);
+
+  const isSignerEmailPlaceholder = (email: string) => {
+    return TEMPLATE_RECIPIENT_EMAIL_PLACEHOLDER_REGEX.test(email);
+  };
 
   return (
     <>
@@ -602,6 +551,9 @@ export const AddTemplatePlaceholderRecipientsFormPartial = ({
                                         type="email"
                                         placeholder={_(msg`Email`)}
                                         {...field}
+                                        value={
+                                          isSignerEmailPlaceholder(field.value) ? '' : field.value
+                                        }
                                         disabled={
                                           field.disabled ||
                                           isSubmitting ||

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.types.ts
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.types.ts
@@ -1,6 +1,7 @@
 import { DocumentSigningOrder, RecipientRole } from '@prisma/client';
 import { z } from 'zod';
 
+import { TEMPLATE_RECIPIENT_EMAIL_PLACEHOLDER_REGEX } from '@documenso/lib/constants/template';
 import { ZRecipientActionAuthTypesSchema } from '@documenso/lib/types/document-auth';
 
 export const ZAddTemplatePlacholderRecipientsFormSchema = z
@@ -10,7 +11,7 @@ export const ZAddTemplatePlacholderRecipientsFormSchema = z
         formId: z.string().min(1),
         nativeId: z.number().optional(),
         email: z.string().min(1).email(),
-        name: z.string(),
+        name: z.string().min(1, { message: 'Name is required' }),
         role: z.nativeEnum(RecipientRole),
         signingOrder: z.number().optional(),
         actionAuth: z.array(ZRecipientActionAuthTypesSchema).optional().default([]),
@@ -21,12 +22,25 @@ export const ZAddTemplatePlacholderRecipientsFormSchema = z
   })
   .refine(
     (schema) => {
-      const emails = schema.signers.map((signer) => signer.email.toLowerCase());
+      const nonPlaceholderEmails = schema.signers
+        .map((signer) => signer.email.toLowerCase())
+        .filter((email) => !TEMPLATE_RECIPIENT_EMAIL_PLACEHOLDER_REGEX.test(email));
 
-      return new Set(emails).size === emails.length;
+      return new Set(nonPlaceholderEmails).size === nonPlaceholderEmails.length;
     },
     // Dirty hack to handle errors when .root is populated for an array type
     { message: 'Signers must have unique emails', path: ['signers__root'] },
+  )
+  .refine(
+    /*
+      Since placeholder emails are empty, we need to check that the names are unique.
+      If we don't do this, the app will add duplicate signers and merge them in the next step, where you add fields.
+    */
+    (schema) => {
+      const names = schema.signers.map((signer) => signer.name.trim());
+      return new Set(names).size === names.length;
+    },
+    { message: 'Signers must have unique names', path: ['signers__root'] },
   );
 
 export type TAddTemplatePlacholderRecipientsFormSchema = z.infer<


### PR DESCRIPTION
## Description

Allow users to create template placeholders without the placeholder emails.

**How it works currently**:

<img width="526" height="789" alt="Screenshot 2025-07-29 at 10 28 06" src="https://github.com/user-attachments/assets/fcbe18a1-fa9e-467b-aca0-f216b1c55169" />

**After the changes**:

<img width="541" height="795" alt="Screenshot 2025-07-29 at 10 28 25" src="https://github.com/user-attachments/assets/baf53dc1-2fbe-46c2-a354-6ace2c101e27" />

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.