### PR TITLE
feat: add tooltip to team member creation dialog for guidance

### DIFF
--- a/apps/remix/app/components/dialogs/team-member-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-member-create-dialog.tsx
@@ -6,6 +6,7 @@ import { TeamMemberRole } from '@prisma/client';
 import type * as DialogPrimitive from '@radix-ui/react-dialog';
 import { InfoIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
+import { Link } from 'react-router';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
 
@@ -151,7 +152,16 @@ export const TeamMemberCreateDialog = ({ trigger, ...props }: TeamMemberCreateDi
                   <TooltipContent className="text-muted-foreground z-[99999] max-w-xs">
                     <Trans>
                       To be able to add members to a team, you must first add them to the
-                      organisation.
+                      organisation. For more information, please see the{' '}
+                      <Link
+                        to="https://docs.documenso.com/users/organisations/members"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-documenso-700 hover:text-documenso-600 hover:underline"
+                      >
+                        documentation
+                      </Link>
+                      .
                     </Trans>
                   </TooltipContent>
                 </Tooltip>

--- a/apps/remix/app/components/dialogs/team-member-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-member-create-dialog.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { TeamMemberRole } from '@prisma/client';
 import type * as DialogPrimitive from '@radix-ui/react-dialog';
+import { InfoIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
@@ -39,6 +40,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@documenso/ui/primitives/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitives/tooltip';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 import { useCurrentTeam } from '~/providers/team';
@@ -140,8 +142,19 @@ export const TeamMemberCreateDialog = ({ trigger, ...props }: TeamMemberCreateDi
         {match(step)
           .with('SELECT', () => (
             <DialogHeader>
-              <DialogTitle>
+              <DialogTitle className="flex flex-row items-center">
                 <Trans>Add members</Trans>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <InfoIcon className="mx-2 h-4 w-4" />
+                  </TooltipTrigger>
+                  <TooltipContent className="text-muted-foreground z-[99999] max-w-xs">
+                    <Trans>
+                      To be able to add members to a team, you must first add them to the
+                      organisation.
+                    </Trans>
+                  </TooltipContent>
+                </Tooltip>
               </DialogTitle>
 
               <DialogDescription>


### PR DESCRIPTION
## Description

Adding team members can create confusion because you first need to add the member to the organization. We received support queries about this and I also got confused.

<img width="846" height="584" alt="Screenshot 2025-07-31 at 14 20 12" src="https://github.com/user-attachments/assets/5de23cb0-b33d-43b0-9888-dd99d1966f2d" />

If not needed, feel free to close it.