### PR TITLE
fix: add missing email reply validation

### DIFF
--- a/apps/remix/app/components/general/document/document-edit-form.tsx
+++ b/apps/remix/app/components/general/document/document-edit-form.tsx
@@ -289,7 +289,7 @@ export const DocumentEditForm = ({
           message,
           distributionMethod,
           emailId,
-          emailReplyTo,
+          emailReplyTo: emailReplyTo || null,
           emailSettings: emailSettings,
         },
       });

--- a/apps/remix/app/components/general/template/template-edit-form.tsx
+++ b/apps/remix/app/components/general/template/template-edit-form.tsx
@@ -143,6 +143,7 @@ export const TemplateEditForm = ({
         },
         meta: {
           ...data.meta,
+          emailReplyTo: data.meta.emailReplyTo || null,
           typedSignatureEnabled: signatureTypes.includes(DocumentSignatureType.TYPE),
           uploadSignatureEnabled: signatureTypes.includes(DocumentSignatureType.UPLOAD),
           drawSignatureEnabled: signatureTypes.includes(DocumentSignatureType.DRAW),

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email-domains.$id.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email-domains.$id.tsx
@@ -171,7 +171,7 @@ export default function OrganisationEmailDomainSettingsPage({ params }: Route.Co
         <OrganisationEmailDomainRecordsDialog
           records={records}
           trigger={
-            <Button variant="secondary">
+            <Button variant="outline">
               <Trans>View DNS Records</Trans>
             </Button>
           }

--- a/packages/lib/jobs/definitions/emails/send-document-cancelled-emails.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-cancelled-emails.handler.ts
@@ -48,7 +48,7 @@ export const run = async ({
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const { documentMeta, user: documentOwner } = document;

--- a/packages/lib/jobs/definitions/emails/send-recipient-signed-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-recipient-signed-email.handler.ts
@@ -76,7 +76,7 @@ export const run = async ({
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const assetBaseUrl = NEXT_PUBLIC_WEBAPP_URL() || 'http://localhost:3000';

--- a/packages/lib/jobs/definitions/emails/send-rejection-emails.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-rejection-emails.handler.ts
@@ -68,7 +68,7 @@ export const run = async ({
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const i18n = await getI18nInstance(emailLanguage);

--- a/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
@@ -86,7 +86,7 @@ export const run = async ({
         type: 'team',
         teamId: document.teamId,
       },
-      meta: document.documentMeta || null,
+      meta: document.documentMeta,
     });
 
   const customEmail = document?.documentMeta;

--- a/packages/lib/server-only/document/delete-document.ts
+++ b/packages/lib/server-only/document/delete-document.ts
@@ -156,7 +156,7 @@ const handleDocumentOwnerDelete = async ({
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   // Soft delete completed documents.

--- a/packages/lib/server-only/document/resend-document.ts
+++ b/packages/lib/server-only/document/resend-document.ts
@@ -102,7 +102,7 @@ export const resendDocument = async ({
         type: 'team',
         teamId: document.teamId,
       },
-      meta: document.documentMeta || null,
+      meta: document.documentMeta,
     });
 
   await Promise.all(

--- a/packages/lib/server-only/document/send-completed-email.ts
+++ b/packages/lib/server-only/document/send-completed-email.ts
@@ -59,7 +59,7 @@ export const sendCompletedEmail = async ({ documentId, requestMetadata }: SendDo
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const { user: owner } = document;

--- a/packages/lib/server-only/document/send-delete-email.ts
+++ b/packages/lib/server-only/document/send-delete-email.ts
@@ -49,7 +49,7 @@ export const sendDeleteEmail = async ({ documentId, reason }: SendDeleteEmailOpt
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const { email, name } = document.user;

--- a/packages/lib/server-only/document/send-pending-email.ts
+++ b/packages/lib/server-only/document/send-pending-email.ts
@@ -51,7 +51,7 @@ export const sendPendingEmail = async ({ documentId, recipientId }: SendPendingE
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const isDocumentPendingEmailEnabled = extractDerivedDocumentEmailSettings(

--- a/packages/lib/server-only/document/super-delete-document.ts
+++ b/packages/lib/server-only/document/super-delete-document.ts
@@ -46,7 +46,7 @@ export const superDeleteDocument = async ({ id, requestMetadata }: SuperDeleteDo
       type: 'team',
       teamId: document.teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const { status, user } = document;

--- a/packages/lib/server-only/email/get-email-context.ts
+++ b/packages/lib/server-only/email/get-email-context.ts
@@ -59,7 +59,7 @@ type RecipientGetEmailContextOptions = BaseGetEmailContextOptions & {
    * Force meta options as a typesafe way to ensure developers don't forget to
    * pass it in if it is available.
    */
-  meta: EmailMetaOption | null;
+  meta: EmailMetaOption | null | undefined;
 };
 
 type GetEmailContextOptions = InternalGetEmailContextOptions | RecipientGetEmailContextOptions;
@@ -104,7 +104,7 @@ export const getEmailContext = async (
   }
 
   const replyToEmail = meta?.emailReplyTo || emailContext.settings.emailReplyTo || undefined;
-  const senderEmailId = meta?.emailId || emailContext.settings.emailId;
+  const senderEmailId = meta?.emailId === null ? null : emailContext.settings.emailId;
 
   const foundSenderEmail = emailContext.allowedEmails.find((email) => email.id === senderEmailId);
 

--- a/packages/lib/server-only/recipient/delete-document-recipient.ts
+++ b/packages/lib/server-only/recipient/delete-document-recipient.ts
@@ -130,7 +130,7 @@ export const deleteDocumentRecipient = async ({
         type: 'team',
         teamId: document.teamId,
       },
-      meta: document.documentMeta || null,
+      meta: document.documentMeta,
     });
 
     const [html, text] = await Promise.all([

--- a/packages/lib/server-only/recipient/set-document-recipients.ts
+++ b/packages/lib/server-only/recipient/set-document-recipients.ts
@@ -95,7 +95,7 @@ export const setDocumentRecipients = async ({
       type: 'team',
       teamId,
     },
-    meta: document.documentMeta || null,
+    meta: document.documentMeta,
   });
 
   const recipientsHaveActionAuth = recipients.some(

--- a/packages/trpc/server/document-router/schema.ts
+++ b/packages/trpc/server/document-router/schema.ts
@@ -295,7 +295,7 @@ export const ZDistributeDocumentRequestSchema = z.object({
       redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
       language: ZDocumentMetaLanguageSchema.optional(),
       emailId: z.string().nullish(),
-      emailReplyTo: z.string().nullish(),
+      emailReplyTo: z.string().email().nullish(),
       emailSettings: ZDocumentEmailSettingsSchema.optional(),
     })
     .optional(),

--- a/packages/trpc/server/document-router/update-document.types.ts
+++ b/packages/trpc/server/document-router/update-document.types.ts
@@ -62,7 +62,7 @@ export const ZUpdateDocumentRequestSchema = z.object({
       uploadSignatureEnabled: ZDocumentMetaUploadSignatureEnabledSchema.optional(),
       drawSignatureEnabled: ZDocumentMetaDrawSignatureEnabledSchema.optional(),
       emailId: z.string().nullish(),
-      emailReplyTo: z.string().nullish(),
+      emailReplyTo: z.string().email().nullish(),
       emailSettings: ZDocumentEmailSettingsSchema.optional(),
     })
     .optional(),

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -65,7 +65,7 @@ export const ZTemplateMetaUpsertSchema = z.object({
   dateFormat: ZDocumentMetaDateFormatSchema.optional(),
   distributionMethod: ZDocumentMetaDistributionMethodSchema.optional(),
   emailId: z.string().nullish(),
-  emailReplyTo: z.string().nullish(),
+  emailReplyTo: z.string().email().nullish(),
   emailSettings: ZDocumentEmailSettingsSchema.optional(),
   redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
   language: ZDocumentMetaLanguageSchema.optional(),

--- a/packages/ui/primitives/document-flow/add-subject.types.ts
+++ b/packages/ui/primitives/document-flow/add-subject.types.ts
@@ -6,7 +6,10 @@ import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-emai
 export const ZAddSubjectFormSchema = z.object({
   meta: z.object({
     emailId: z.string().nullable(),
-    emailReplyTo: z.string().email().optional(),
+    emailReplyTo: z.preprocess(
+      (val) => (val === '' ? undefined : val),
+      z.string().email().optional(),
+    ),
     // emailReplyName: z.string().optional(),
     subject: z.string(),
     message: z.string(),

--- a/packages/ui/primitives/template-flow/add-template-settings.types.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.types.tsx
@@ -49,7 +49,10 @@ export const ZAddTemplateSettingsFormSchema = z.object({
       .optional()
       .default('en'),
     emailId: z.string().nullable(),
-    emailReplyTo: z.string().optional(),
+    emailReplyTo: z.preprocess(
+      (val) => (val === '' ? undefined : val),
+      z.string().email().optional(),
+    ),
     emailSettings: ZDocumentEmailSettingsSchema,
     signatureTypes: z.array(z.nativeEnum(DocumentSignatureType)).min(1, {
       message: msg`At least one signature type must be enabled`.id,


### PR DESCRIPTION
## Description

General fixes to the email domain features

Changes made:
- Add "email" validation for "Reply-To email" fields
- Fix issue where you can't remove the "Reply-To" email after it's set
- Fix issue where setting the "Sender email" back to Documenso would still send using the org/team pref