### PR TITLE
fix: certificate pdfs are blank when using browserless

### DIFF
--- a/packages/lib/server-only/htmltopdf/get-certificate-pdf.ts
+++ b/packages/lib/server-only/htmltopdf/get-certificate-pdf.ts
@@ -46,7 +46,7 @@ export const getCertificatePdf = async ({ documentId, language }: GetCertificate
 
   await page.context().addCookies([
     {
-      name: 'language',
+      name: 'lang',
       value: lang,
       url: NEXT_PUBLIC_WEBAPP_URL(),
     },
@@ -54,6 +54,19 @@ export const getCertificatePdf = async ({ documentId, language }: GetCertificate
 
   await page.goto(`${NEXT_PUBLIC_WEBAPP_URL()}/__htmltopdf/certificate?d=${encryptedId}`, {
     waitUntil: 'networkidle',
+    timeout: 10_000,
+  });
+
+  // !: This is a workaround to ensure the page is loaded correctly.
+  // !: It's not clear why but suddenly browserless cdp connections would
+  // !: cause the page to render blank until a reload is performed.
+  await page.reload({
+    waitUntil: 'networkidle',
+    timeout: 10_000,
+  });
+
+  await page.waitForSelector('h1', {
+    state: 'visible',
     timeout: 10_000,
   });
 


### PR DESCRIPTION
Certificates have suddenly become blank when using browserless and Chrome CDP.

This change introduces a workaround that involves reloading the certificate pdf. Which is hacky but seems to work for now, a better solution should be found in the future.