### PR TITLE
fix: correctly set stripe customer names

### DIFF
--- a/packages/trpc/server/enterprise-router/create-subscription.ts
+++ b/packages/trpc/server/enterprise-router/create-subscription.ts
@@ -54,7 +54,7 @@ export const createSubscriptionRoute = authenticatedProcedure
 
     if (!customerId) {
       const customer = await createCustomer({
-        name: organisation.name,
+        name: organisation.owner.name || organisation.owner.email,
         email: organisation.owner.email,
       });
 

--- a/packages/trpc/server/enterprise-router/manage-subscription.ts
+++ b/packages/trpc/server/enterprise-router/manage-subscription.ts
@@ -77,7 +77,7 @@ export const manageSubscriptionRoute = authenticatedProcedure
     // If the customer ID is still missing create a new customer.
     if (!customerId) {
       const customer = await createCustomer({
-        name: organisation.name,
+        name: organisation.owner.name || organisation.owner.email,
         email: organisation.owner.email,
       });
 


### PR DESCRIPTION
## Description

Currently the Stripe customer name is set to the organisation name, which in some cases is just the organisation name.

This update makes it so it uses the owner name instead.