### PR TITLE
fix: remove field truncate logic

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-text-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-text-field.tsx
@@ -227,19 +227,8 @@ export const DocumentSigningTextField = ({
 
   const parsedField = field.fieldMeta ? ZTextFieldMeta.parse(field.fieldMeta) : undefined;
 
-  const labelDisplay =
-    parsedField?.label && parsedField.label.length < 20
-      ? parsedField.label
-      : parsedField?.label
-        ? parsedField?.label.substring(0, 20) + '...'
-        : undefined;
-
-  const textDisplay =
-    parsedField?.text && parsedField.text.length < 20
-      ? parsedField.text
-      : parsedField?.text
-        ? parsedField?.text.substring(0, 20) + '...'
-        : undefined;
+  const labelDisplay = parsedField?.label;
+  const textDisplay = parsedField?.text;
 
   const fieldDisplayName = labelDisplay ? labelDisplay : textDisplay;
   const charactersRemaining = (parsedFieldMeta?.characterLimit ?? 0) - (localText.length ?? 0);

--- a/packages/ui/primitives/document-flow/field-content.tsx
+++ b/packages/ui/primitives/document-flow/field-content.tsx
@@ -160,14 +160,14 @@ export const FieldContent = ({ field, documentMeta }: FieldIconProps) => {
     );
   }
 
-  let textToDisplay = fieldMeta?.label || _(FRIENDLY_FIELD_TYPE[type]) || '';
+  const labelToDisplay = fieldMeta?.label || _(FRIENDLY_FIELD_TYPE[type]) || '';
+  let textToDisplay: string | undefined;
 
   const isSignatureField =
     field.type === FieldType.SIGNATURE || field.type === FieldType.FREE_SIGNATURE;
 
-  // Trim default labels.
-  if (textToDisplay.length > 20) {
-    textToDisplay = textToDisplay.substring(0, 20) + '...';
+  if (field.type === FieldType.TEXT && field.fieldMeta?.type === 'text' && field.fieldMeta?.text) {
+    textToDisplay = field.fieldMeta.text;
   }
 
   if (field.inserted) {
@@ -190,18 +190,19 @@ export const FieldContent = ({ field, documentMeta }: FieldIconProps) => {
   const textAlign = fieldMeta && 'textAlign' in fieldMeta ? fieldMeta.textAlign : 'left';
 
   return (
-    <div
-      className={cn(
-        'text-field-card-foreground flex h-full w-full items-center justify-center gap-x-1.5 overflow-clip whitespace-nowrap text-center text-[clamp(0.07rem,25cqw,0.825rem)]',
-        {
-          // Using justify instead of align because we also vertically center the text.
-          'justify-start': field.inserted && !isSignatureField && textAlign === 'left',
-          'justify-end': field.inserted && !isSignatureField && textAlign === 'right',
-          'font-signature text-[clamp(0.07rem,25cqw,1.125rem)]': isSignatureField,
-        },
-      )}
-    >
-      {textToDisplay}
+    <div className="flex h-full w-full items-center overflow-hidden">
+      <p
+        className={cn(
+          'text-foreground w-full whitespace-pre-wrap text-left text-[clamp(0.07rem,25cqw,0.825rem)] duration-200',
+          {
+            '!text-center': textAlign === 'center' || !textToDisplay,
+            '!text-right': textAlign === 'right',
+            'font-signature text-[clamp(0.07rem,25cqw,1.125rem)]': isSignatureField,
+          },
+        )}
+      >
+        {textToDisplay || labelToDisplay}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Remove the truncation logic and render the text for preview/edit mode.

Text will now overflow, but it's up to the user to correct it

Before

<img width="3817" height="1345" alt="Screenshot 2025-08-05 at 2 21 02 pm" src="https://github.com/user-attachments/assets/cca4f969-ef52-4f2a-ae17-e52986781be3" />

After

<img width="3817" height="1345" alt="Screenshot 2025-08-05 at 2 21 27 pm" src="https://github.com/user-attachments/assets/aba32084-38f5-4b46-b7c8-f31f10b640dc" />
