### PR TITLE
fix: add document page access logging

### DIFF
--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id._index.tsx
@@ -10,6 +10,7 @@ import { useSession } from '@documenso/lib/client-only/providers/session';
 import { getDocumentWithDetailsById } from '@documenso/lib/server-only/document/get-document-with-details-by-id';
 import { getTeamByUrl } from '@documenso/lib/server-only/team/get-team';
 import { DocumentVisibility } from '@documenso/lib/types/document-visibility';
+import { logDocumentAccess } from '@documenso/lib/utils/logger';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { DocumentReadOnlyFields } from '@documenso/ui/components/document/document-read-only-fields';
 import { Badge } from '@documenso/ui/primitives/badge';
@@ -82,6 +83,12 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   if (!document || !document.documentData || !canAccessDocument) {
     throw redirect(documentRootPath);
   }
+
+  logDocumentAccess({
+    request,
+    documentId,
+    userId: user.id,
+  });
 
   return superLoaderJson({
     document,

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.edit.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.edit.tsx
@@ -9,6 +9,7 @@ import { getDocumentWithDetailsById } from '@documenso/lib/server-only/document/
 import { getTeamByUrl } from '@documenso/lib/server-only/team/get-team';
 import { DocumentVisibility } from '@documenso/lib/types/document-visibility';
 import { isDocumentCompleted } from '@documenso/lib/utils/document';
+import { logDocumentAccess } from '@documenso/lib/utils/logger';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 
 import { DocumentEditForm } from '~/components/general/document/document-edit-form';
@@ -77,6 +78,12 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   if (isDocumentCompleted(document.status)) {
     throw redirect(`${documentRootPath}/${documentId}`);
   }
+
+  logDocumentAccess({
+    request,
+    documentId,
+    userId: user.id,
+  });
 
   return superLoaderJson({
     document: {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -11,6 +11,7 @@ import { getSession } from '@documenso/auth/server/lib/utils/get-session';
 import { getDocumentById } from '@documenso/lib/server-only/document/get-document-by-id';
 import { getRecipientsForDocument } from '@documenso/lib/server-only/recipient/get-recipients-for-document';
 import { getTeamByUrl } from '@documenso/lib/server-only/team/get-team';
+import { logDocumentAccess } from '@documenso/lib/utils/logger';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { Card } from '@documenso/ui/primitives/card';
 
@@ -57,6 +58,12 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     documentId,
     userId: user.id,
     teamId: team?.id,
+  });
+
+  logDocumentAccess({
+    request,
+    documentId,
+    userId: user.id,
   });
 
   return {

--- a/packages/lib/utils/logger.ts
+++ b/packages/lib/utils/logger.ts
@@ -1,5 +1,7 @@
 import { type TransportTargetOptions, pino } from 'pino';
 
+import type { BaseApiLog } from '../types/api-logs';
+import { extractRequestMetadata } from '../universal/extract-request-metadata';
 import { env } from './env';
 
 const transports: TransportTargetOptions[] = [];
@@ -33,3 +35,31 @@ export const logger = pino({
         }
       : undefined,
 });
+
+export const logDocumentAccess = ({
+  request,
+  documentId,
+  userId,
+}: {
+  request: Request;
+  documentId: number;
+  userId: number;
+}) => {
+  const metadata = extractRequestMetadata(request);
+
+  const data: BaseApiLog = {
+    ipAddress: metadata.ipAddress,
+    userAgent: metadata.userAgent,
+    path: new URL(request.url).pathname,
+    auth: 'session',
+    source: 'app',
+    userId,
+  };
+
+  logger.info({
+    ...data,
+    input: {
+      documentId,
+    },
+  });
+};


### PR DESCRIPTION
## Description

Add logging when someone accesses a document page:
- /documents/id
- /documents/id/edit
- /documents/id/logs