### PR TITLE
fix: prevent document unsigning on edit

### DIFF
--- a/packages/lib/server-only/recipient/set-document-recipients.ts
+++ b/packages/lib/server-only/recipient/set-document-recipients.ts
@@ -134,6 +134,9 @@ export const setDocumentRecipients = async ({
         existingRecipient.id === recipient.id || existingRecipient.email === recipient.email,
     );
 
+    const canPersistedRecipientBeModified =
+      existing && canRecipientBeModified(existing, document.fields);
+
     if (
       existing &&
       hasRecipientBeenChanged(existing, recipient) &&
@@ -147,6 +150,7 @@ export const setDocumentRecipients = async ({
     return {
       ...recipient,
       _persisted: existing,
+      canPersistedRecipientBeModified,
     };
   });
 
@@ -160,6 +164,13 @@ export const setDocumentRecipients = async ({
             accessAuth: recipient.accessAuth || authOptions.accessAuth,
             actionAuth: recipient.actionAuth || authOptions.actionAuth,
           });
+        }
+
+        if (recipient._persisted && !recipient.canPersistedRecipientBeModified) {
+          return {
+            ...recipient._persisted,
+            clientId: recipient.clientId,
+          };
         }
 
         const upsertedRecipient = await tx.recipient.upsert({

--- a/packages/lib/server-only/recipient/update-document-recipients.ts
+++ b/packages/lib/server-only/recipient/update-document-recipients.ts
@@ -1,7 +1,5 @@
-import type { Recipient } from '@prisma/client';
 import { RecipientRole } from '@prisma/client';
 import { SendStatus, SigningStatus } from '@prisma/client';
-import { isDeepEqual } from 'remeda';
 
 import { DOCUMENT_AUDIT_LOG_TYPE } from '@documenso/lib/types/document-audit-logs';
 import type { TRecipientAccessAuthTypes } from '@documenso/lib/types/document-auth';
@@ -104,10 +102,7 @@ export const updateDocumentRecipients = async ({
       });
     }
 
-    if (
-      hasRecipientBeenChanged(originalRecipient, recipient) &&
-      !canRecipientBeModified(originalRecipient, document.fields)
-    ) {
+    if (!canRecipientBeModified(originalRecipient, document.fields)) {
       throw new AppError(AppErrorCode.INVALID_REQUEST, {
         message: 'Cannot modify a recipient who has already interacted with the document',
       });
@@ -203,9 +198,6 @@ export const updateDocumentRecipients = async ({
   };
 };
 
-/**
- * If you change this you MUST update the `hasRecipientBeenChanged` function.
- */
 type RecipientData = {
   id: number;
   email?: string;
@@ -214,20 +206,4 @@ type RecipientData = {
   signingOrder?: number | null;
   accessAuth?: TRecipientAccessAuthTypes[];
   actionAuth?: TRecipientActionAuthTypes[];
-};
-
-const hasRecipientBeenChanged = (recipient: Recipient, newRecipientData: RecipientData) => {
-  const authOptions = ZRecipientAuthOptionsSchema.parse(recipient.authOptions);
-
-  const newRecipientAccessAuth = newRecipientData.accessAuth || null;
-  const newRecipientActionAuth = newRecipientData.actionAuth || null;
-
-  return (
-    recipient.email !== newRecipientData.email ||
-    recipient.name !== newRecipientData.name ||
-    recipient.role !== newRecipientData.role ||
-    recipient.signingOrder !== newRecipientData.signingOrder ||
-    !isDeepEqual(authOptions.accessAuth, newRecipientAccessAuth) ||
-    !isDeepEqual(authOptions.actionAuth, newRecipientActionAuth)
-  );
 };


### PR DESCRIPTION
## Description

This fixes the issue where if a partially signed document goes through the authoring process, the document becomes "unsigned" even if no recipients/fields were changed.