### PR TITLE
fix: add dummy teamid

### DIFF
--- a/packages/lib/server-only/document/get-document-by-id.ts
+++ b/packages/lib/server-only/document/get-document-by-id.ts
@@ -111,7 +111,7 @@ export const getDocumentWhereInput = async ({
       visibility: {
         in: teamVisibilityFilters,
       },
-      teamId,
+      teamId: team.id,
     },
     // Or, if they are a recipient of the document.
     {

--- a/packages/trpc/server/trpc.ts
+++ b/packages/trpc/server/trpc.ts
@@ -141,6 +141,7 @@ export const authenticatedMiddleware = t.middleware(async ({ ctx, next, path }) 
   return await next({
     ctx: {
       ...ctx,
+      teamId: ctx.teamId || -1,
       logger: trpcSessionLogger,
       user: ctx.user,
       session: ctx.session,


### PR DESCRIPTION
## Description

Update the TRPC procedure to correctly output the intended context type for "teamId".

For some reason it currently assumes there is a `teamId` due to returning two different types of data, one for API and one for session