### PR TITLE
chore: remove 'use client' directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The Web UI can be found at http://localhost:9000, while the SMTP port will be on
 
 ### Support IPv6
 
-If you are deploying to a cluster that uses only IPv6, You can use a custom command to pass a parameter to the Next.js start command
+If you are deploying to a cluster that uses only IPv6, You can use a custom command to pass a parameter to the Remix start command
 
 For local docker run
 

--- a/apps/remix/app/components/general/admin-monthly-active-user-charts.tsx
+++ b/apps/remix/app/components/general/admin-monthly-active-user-charts.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { DateTime } from 'luxon';
 import type { TooltipProps } from 'recharts';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';

--- a/packages/ui/primitives/multiselect.tsx
+++ b/packages/ui/primitives/multiselect.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { useEffect } from 'react';
 


### PR DESCRIPTION
  1. Removed `use client` directives from 2 Remix app files:
    - `/packages/ui/primitives/multiselect.tsx`
    - `/apps/remix/app/components/general/admin-monthly-active-user-charts.tsx`
  2. Updated README.md reference from "Next.js start command" to "Remix start command"