### PR TITLE
fix: access audit logs for documents in folder

### DIFF
--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -34,7 +34,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   const documentId = Number(id);
 
-  const documentRootPath = formatDocumentsPath(team.url);
+  let documentRootPath = formatDocumentsPath(team.url);
 
   if (!documentId || Number.isNaN(documentId)) {
     throw redirect(documentRootPath);
@@ -51,7 +51,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   }
 
   if (document.folderId) {
-    throw redirect(documentRootPath);
+    documentRootPath = `${formatDocumentsPath(team.url)}/f/${document.folderId}`;
   }
 
   const recipients = await getRecipientsForDocument({
@@ -68,13 +68,13 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   return {
     document,
-    documentRootPath,
     recipients,
+    team,
   };
 }
 
 export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) {
-  const { document, documentRootPath, recipients } = loaderData;
+  const { document, recipients, team } = loaderData;
 
   const { _, i18n } = useLingui();
 
@@ -127,7 +127,7 @@ export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
       <Link
-        to={`${documentRootPath}/${document.id}`}
+        to={`/t/${team.url}/documents/${document.id}`}
         className="flex items-center text-[#7AC455] hover:opacity-80"
       >
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -34,7 +34,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   const documentId = Number(id);
 
-  let documentRootPath = formatDocumentsPath(team.url);
+  const documentRootPath = formatDocumentsPath(team.url);
 
   if (!documentId || Number.isNaN(documentId)) {
     throw redirect(documentRootPath);
@@ -48,10 +48,6 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   if (!document || !document.documentData) {
     throw redirect(documentRootPath);
-  }
-
-  if (document.folderId) {
-    documentRootPath = `${formatDocumentsPath(team.url)}/f/${document.folderId}`;
   }
 
   const recipients = await getRecipientsForDocument({
@@ -68,13 +64,13 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   return {
     document,
-    documentRootPath,
     recipients,
+    team,
   };
 }
 
 export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) {
-  const { document, documentRootPath, recipients } = loaderData;
+  const { document, recipients, team } = loaderData;
 
   const { _, i18n } = useLingui();
 
@@ -127,7 +123,7 @@ export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
       <Link
-        to={`${documentRootPath}/${document.id}`}
+        to={`${formatDocumentsPath(team.url)}/${document.id}`}
         className="flex items-center text-[#7AC455] hover:opacity-80"
       >
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -65,12 +65,12 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   return {
     document,
     recipients,
-    team,
+    documentRootPath,
   };
 }
 
 export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) {
-  const { document, recipients, team } = loaderData;
+  const { document, recipients, documentRootPath } = loaderData;
 
   const { _, i18n } = useLingui();
 
@@ -123,7 +123,7 @@ export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
       <Link
-        to={`${formatDocumentsPath(team.url)}/${document.id}`}
+        to={`${documentRootPath}/${document.id}`}
         className="flex items-center text-[#7AC455] hover:opacity-80"
       >
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -68,13 +68,13 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   return {
     document,
+    documentRootPath,
     recipients,
-    team,
   };
 }
 
 export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) {
-  const { document, recipients, team } = loaderData;
+  const { document, documentRootPath, recipients } = loaderData;
 
   const { _, i18n } = useLingui();
 
@@ -127,7 +127,7 @@ export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
       <Link
-        to={`/t/${team.url}/documents/${document.id}`}
+        to={`${documentRootPath}/${document.id}`}
         className="flex items-center text-[#7AC455] hover:opacity-80"
       >
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />


### PR DESCRIPTION
For Documents stored in team subfolders, clicking "Audit Log" would redirect users back to the team's root documents folder instead.