### PR TITLE
Log unknown errors in the auth error handler

### DIFF
--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -79,6 +79,7 @@ auth.onError((err, c) => {
   }
 
   // Handle other errors
+  console.error('Unknown Error:', err);
   return c.json(
     {
       code: AppErrorCode.UNKNOWN_ERROR,


### PR DESCRIPTION
## Description

For security reason, the auth API endpoint is not sending unknown exceptions to the client. But the error is not logged either, making it very difficult to understand what happened.

For example, when you try to self host and you forgot the encryption key in the env variable, you will get a `500` on signup, without any other information than "Uknown Error".

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Added a log to show the error in the server standard output

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- The change is straightforward

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- ~[ ] I have added/updated tests that prove the effectiveness of these changes.~ Not applicable
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

I haven't checked for other API endpoint, but if you want I can also do this for other endpoints.
