### PR TITLE
feat: resend dialog improvements

### DIFF
--- a/apps/remix/app/components/dialogs/document-resend-dialog.tsx
+++ b/apps/remix/app/components/dialogs/document-resend-dialog.tsx
@@ -6,7 +6,7 @@ import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
 import { type Recipient, SigningStatus } from '@prisma/client';
 import { History } from 'lucide-react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import * as z from 'zod';
 
 import { useSession } from '@documenso/lib/client-only/providers/session';
@@ -85,6 +85,11 @@ export const DocumentResendDialog = ({ document, recipients }: DocumentResendDia
     formState: { isSubmitting },
   } = form;
 
+  const selectedRecipients = useWatch({
+    control: form.control,
+    name: 'recipients',
+  });
+
   const onFormSubmit = async ({ recipients }: TResendDocumentFormSchema) => {
     try {
       await resendDocument({ documentId: document.id, recipients });
@@ -151,7 +156,7 @@ export const DocumentResendDialog = ({ document, recipients }: DocumentResendDia
 
                       <FormControl>
                         <Checkbox
-                          className="h-5 w-5 rounded-full"
+                          className="h-5 w-5 rounded-full border border-neutral-400"
                           value={recipient.id}
                           checked={value.includes(recipient.id)}
                           onCheckedChange={(checked: boolean) =>
@@ -182,7 +187,13 @@ export const DocumentResendDialog = ({ document, recipients }: DocumentResendDia
               </Button>
             </DialogClose>
 
-            <Button className="flex-1" loading={isSubmitting} type="submit" form={FORM_ID}>
+            <Button
+              className="flex-1"
+              loading={isSubmitting}
+              type="submit"
+              form={FORM_ID}
+              disabled={isSubmitting || selectedRecipients.length === 0}
+            >
               <Trans>Send reminder</Trans>
             </Button>
           </div>

--- a/packages/ui/primitives/document-flow/add-signers.tsx
+++ b/packages/ui/primitives/document-flow/add-signers.tsx
@@ -714,7 +714,6 @@ export const AddSignersFormPartial = ({
                                           handleRecipientAutoCompleteSelect(index, suggestion)
                                         }
                                         onSearchQueryChange={(query) => {
-                                          console.log('onSearchQueryChange', query);
                                           field.onChange(query);
                                           setRecipientSearchQuery(query);
                                         }}


### PR DESCRIPTION
## Description

The checkboxes were difficult to see and the "Send reminder" button wasn't disabled when no recipients were selected. This PR disables the sending button when there's no selected recipient and improves the checkboxes visibility.

### Before

<img width="395" height="215" alt="Screenshot 2025-09-17 at 10 40 22" src="https://github.com/user-attachments/assets/b8399e41-932e-40cf-8449-4b0588d476c1" />

### After

<img width="392" height="216" alt="Screenshot 2025-09-17 at 10 39 17" src="https://github.com/user-attachments/assets/4b64cc12-fbfb-4fe3-a7c4-b5a25959c750" />

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.