### PR TITLE
feat: add max file size for uploaded documents

### DIFF
--- a/apps/documentation/pages/users/documents/sending-documents.mdx
+++ b/apps/documentation/pages/users/documents/sending-documents.mdx
@@ -18,6 +18,11 @@ The guide assumes you have a Documenso account. If you don't, you can create a f
 
 Navigate to the [Documenso dashboard](https://app.documenso.com/documents) and click on the "Add a document" button. Select the document you want to upload and wait for the upload to complete.
 
+<Callout type="info">
+  The maximum file size for uploaded documents is 150MB in production. In staging, the limit is
+  50MB.
+</Callout>
+
 ![Documenso dashboard](/document-signing/documenso-documents-dashboard.webp)
 
 After the upload is complete, you will be redirected to the document's page. You can configure the document's settings and add recipients and fields here.


### PR DESCRIPTION
## Description

Add a section on the maximum file size for uploaded documents.

<img width="1495" height="864" alt="Screenshot 2025-09-24 at 09 47 43" src="https://github.com/user-attachments/assets/5ddd98a1-185d-4ce9-af5b-8ed74986f845" />
