### PR TITLE
fix: use select account prompt for sso oidc

### DIFF
--- a/packages/auth/server/lib/utils/handle-oauth-authorize-url.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-authorize-url.ts
@@ -23,12 +23,17 @@ type HandleOAuthAuthorizeUrlOptions = {
    * Optional redirect path to redirect the user somewhere on the app after authorization.
    */
   redirectPath?: string;
+
+  /**
+   * Optional prompt to pass to the authorization endpoint.
+   */
+  prompt?: 'login' | 'consent' | 'select_account';
 };
 
 const oauthCookieMaxAge = 60 * 10; // 10 minutes.
 
 export const handleOAuthAuthorizeUrl = async (options: HandleOAuthAuthorizeUrlOptions) => {
-  const { c, clientOptions, redirectPath } = options;
+  const { c, clientOptions, redirectPath, prompt = 'login' } = options;
 
   if (!clientOptions.clientId || !clientOptions.clientSecret) {
     throw new AppError(AppErrorCode.NOT_SETUP);
@@ -57,8 +62,8 @@ export const handleOAuthAuthorizeUrl = async (options: HandleOAuthAuthorizeUrlOp
     scopes,
   );
 
-  // Allow user to select account during login.
-  url.searchParams.append('prompt', 'login');
+  // Pass the prompt to the authorization endpoint.
+  url.searchParams.append('prompt', prompt);
 
   setCookie(c, `${clientOptions.id}_oauth_state`, state, {
     ...sessionCookieOptions,

--- a/packages/auth/server/routes/oauth.ts
+++ b/packages/auth/server/routes/oauth.ts
@@ -50,5 +50,6 @@ export const oauthRoute = new Hono<HonoAuthContext>()
     return await handleOAuthAuthorizeUrl({
       c,
       clientOptions,
+      prompt: 'select_account',
     });
   });


### PR DESCRIPTION
Use the `select_account` prompt for SSO OIDC to avoid constantly asking for credentials to be entered with a client has an existing session with the SSO provider.