### PR TITLE
fix: correct missing French translations for recipient role action verbs

### DIFF
--- a/packages/lib/translations/fr/web.po
+++ b/packages/lib/translations/fr/web.po
@@ -1490,7 +1490,7 @@ msgstr "Version de l'application"
 #: packages/lib/constants/recipient-roles.ts
 msgctxt "Recipient role action verb"
 msgid "Approve"
-msgstr ""
+msgstr "approuver"
 
 #: apps/remix/app/components/tables/inbox-table.tsx
 #: apps/remix/app/components/tables/documents-table-action-dropdown.tsx
@@ -1587,7 +1587,7 @@ msgstr "Équipes assignées"
 #: packages/lib/constants/recipient-roles.ts
 msgctxt "Recipient role action verb"
 msgid "Assist"
-msgstr ""
+msgstr "assister"
 
 #: apps/remix/app/components/general/document-signing/document-signing-page-view.tsx
 #: packages/email/template-components/template-document-invite.tsx
@@ -1923,7 +1923,7 @@ msgstr ""
 #: packages/lib/constants/recipient-roles.ts
 msgctxt "Recipient role action verb"
 msgid "CC"
-msgstr ""
+msgstr "recevoir en copie"
 
 #: packages/lib/constants/recipient-roles.ts
 msgctxt "Recipient role progressive verb"
@@ -2271,7 +2271,7 @@ msgstr "Continuer en approuvant le document."
 
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Continue by assisting with the document."
-msgstr "Continuez en aidant avec le document."
+msgstr "Continuer en aidant avec le document."
 
 #: packages/email/template-components/template-document-completed.tsx
 msgid "Continue by downloading the document."
@@ -6612,7 +6612,7 @@ msgstr "Afficher des modèles dans votre profil public pour que votre audience p
 #: packages/lib/constants/recipient-roles.ts
 msgctxt "Recipient role action verb"
 msgid "Sign"
-msgstr ""
+msgstr "signer"
 
 #: apps/remix/app/routes/_profile+/p.$url.tsx
 #: apps/remix/app/components/tables/inbox-table.tsx
@@ -8620,7 +8620,7 @@ msgstr "Vertical"
 #: packages/lib/constants/recipient-roles.ts
 msgctxt "Recipient role action verb"
 msgid "View"
-msgstr ""
+msgstr "consulter"
 
 #: apps/remix/app/components/tables/organisation-billing-invoices-table.tsx
 #: apps/remix/app/components/tables/inbox-table.tsx


### PR DESCRIPTION
## Description
This PR fixes French translation errors in automated email templates where recipient action verbs were missing, causing broken sentences.

## Problem
When users receive emails in French, they see grammatically incorrect sentences like:
- ❌ "Veuillez **sign** votre document"
- ❌ "Vous avez initié le document qui nécessite que vous **sign** celui-ci"

Instead of the correct:
- ✅ "Veuillez **signer** votre document"
- ✅ "Vous avez initié le document qui nécessite que vous **signiez** celui-ci"

## Root Cause
The recipient role action verbs in `packages/lib/constants/recipient-roles.ts` had empty French translations in `packages/lib/translations/fr/web.po`. These verbs are dynamically inserted into email templates via placeholders like `{recipientActionVerb}`.

## Changes
- ✅ Add French translation for "Sign" → "signer"
- ✅ Add French translation for "Approve" → "approuver"
- ✅ Add French translation for "Assist" → "assister"
- ✅ Add French translation for "View" → "consulter"
- ✅ Add French translation for "CC" → "recevoir en copie"
- ✅ Fix verb form consistency: "Continuez" → "Continuer" to match similar translations

## Testing
These translations affect all automated emails sent to document recipients when the email language is French.

## Files Changed
- `packages/lib/translations/fr/web.po`

## Related
Fixes automated email translations for French-speaking users.