### PR TITLE
fix: organisation invite member should be case insensitive

### DIFF
--- a/packages/lib/server-only/organisation/accept-organisation-invitation.ts
+++ b/packages/lib/server-only/organisation/accept-organisation-invitation.ts
@@ -40,7 +40,10 @@ export const acceptOrganisationInvitation = async ({
 
   const user = await prisma.user.findFirst({
     where: {
-      email: organisationMemberInvite.email,
+      email: {
+        equals: organisationMemberInvite.email,
+        mode: 'insensitive',
+      },
     },
     select: {
       id: true,


### PR DESCRIPTION
## Description

The organisation invite member is case sensitive when performing the lookup. Email addresses are not case sensitive so the lookup should not be case sensitive.

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Added the case insensitive mode to the prisma query

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- Verified the organisation invite member is now case insensitive.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [X ] I have tested these changes locally and they work as expected.
- [X ] I have followed the project's coding style guidelines.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
