### PR TITLE
fix: on error job should resubmit with isRetry

### DIFF
--- a/packages/lib/jobs/client/local.ts
+++ b/packages/lib/jobs/client/local.ts
@@ -198,6 +198,7 @@ export class LocalJobProvider extends BaseJobProvider {
           jobId,
           jobDefinitionId: backgroundJob.jobId,
           data: options,
+          isRetry: true,
         });
       }
 


### PR DESCRIPTION
## Description

When a job encounters an error and is submitted to run again the retried counter is not incremented. This causes the job to retry indefinitely for the duration the app runs.

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

## Changes Made

Set the isRetry job when calling submitJobToEndpoint in the try catch.

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

Tested locally and retired is incremented until maxRetries is hit. Then the job is correctly set to FAILED.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [ X] I have tested these changes locally and they work as expected.
- [X ] I have followed the project's coding style guidelines.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
