### PR TITLE
fix: email attachment names

### DIFF
--- a/packages/lib/server-only/document/send-completed-email.ts
+++ b/packages/lib/server-only/document/send-completed-email.ts
@@ -81,11 +81,15 @@ export const sendCompletedEmail = async ({ id, requestMetadata }: SendDocumentOp
   const { user: owner } = envelope;
 
   const completedDocumentEmailAttachments = await Promise.all(
-    envelope.envelopeItems.map(async (document) => {
-      const file = await getFileServerSide(document.documentData);
+    envelope.envelopeItems.map(async (envelopeItem) => {
+      const file = await getFileServerSide(envelopeItem.documentData);
+
+      // Use the envelope title for version 1, and the envelope item title for version 2.
+      const fileNameToUse =
+        envelope.internalVersion === 1 ? envelope.title : envelopeItem.title + '.pdf';
 
       return {
-        fileName: document.title.endsWith('.pdf') ? document.title : document.title + '.pdf',
+        filename: fileNameToUse.endsWith('.pdf') ? fileNameToUse : fileNameToUse + '.pdf',
         content: Buffer.from(file),
         contentType: 'application/pdf',
       };


### PR DESCRIPTION
## Description

- Fix issue where file attachments show up as "attachment-N".
- Use the envelope title for V1 files
- Use envelope item title for V2 files