### PR TITLE
fix(i18n): add pluralization to passkey page

### DIFF
--- a/apps/remix/app/components/dialogs/passkey-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/passkey-create-dialog.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { Trans } from '@lingui/react/macro';
+import { Plural, Trans } from '@lingui/react/macro';
 import type * as DialogPrimitive from '@radix-ui/react-dialog';
 import { startRegistration } from '@simplewebauthn/browser';
 import { KeyRoundIcon } from 'lucide-react';
@@ -209,7 +209,11 @@ export const PasskeyCreateDialog = ({ trigger, onSuccess, ...props }: PasskeyCre
                     ))
                     .with('TOO_MANY_PASSKEYS', () => (
                       <AlertDescription>
-                        <Trans>You cannot have more than {MAXIMUM_PASSKEYS} passkeys.</Trans>
+                        <Plural
+                          value={MAXIMUM_PASSKEYS}
+                          one="You cannot have more than # passkey."
+                          other="You cannot have more than # passkeys."
+                        />
                       </AlertDescription>
                     ))
                     .with('InvalidStateError', () => (


### PR DESCRIPTION
## Description

Fixes #2112

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Add pluralization

## Testing Performed

- `npm run translate` with checking web.po file
- `npm run build`

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

In English, there is one singular and one plural form. In many other languages (like Polish) there are more plural forms (few and many). Even when you use only plural case (>1), pluralization is needed.
