### PR TITLE
chore(i18n): add message context in EnvelopeDownloadDialog

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
@@ -192,7 +192,7 @@ export const EnvelopeDownloadDialog = ({
                     {!isDownloadingState[generateDownloadKey(item.id, 'original')] && (
                       <DownloadIcon className="mr-2 h-4 w-4" />
                     )}
-                    <Trans>Original</Trans>
+                    <Trans context="Original document (adjective)">Original</Trans>
                   </Button>
 
                   {envelopeStatus === DocumentStatus.COMPLETED && (
@@ -206,7 +206,7 @@ export const EnvelopeDownloadDialog = ({
                       {!isDownloadingState[generateDownloadKey(item.id, 'signed')] && (
                         <DownloadIcon className="mr-2 h-4 w-4" />
                       )}
-                      <Trans>Signed</Trans>
+                      <Trans context="Signed document (adjective)">Signed</Trans>
                     </Button>
                   )}
                 </div>


### PR DESCRIPTION
## Description

Fixes #2100

## Changes Made

Add context to strings

## Testing Performed

- `npm run build`

`web.po` before:
```
#: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
#: apps/remix/app/components/general/document/document-page-view-recipients.tsx
#: apps/remix/app/components/dialogs/envelope-download-dialog.tsx
#: packages/ui/components/document/document-read-only-fields.tsx
msgid "Signed"
msgstr "Signed"
```
`web.po` after:
```
#: apps/remix/app/routes/_internal+/[__htmltopdf]+/certificate.tsx
#: apps/remix/app/components/general/document/document-page-view-recipients.tsx
#: packages/ui/components/document/document-read-only-fields.tsx
msgid "Signed"
msgstr "Signed"

#: apps/remix/app/components/dialogs/envelope-download-dialog.tsx
msgctxt "Signed document (adjective)"
msgid "Signed"
msgstr "Signed"
```

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
