### PR TITLE
chore(i18n): add message context in user organisation table

### DIFF
--- a/apps/remix/app/components/tables/user-organisations-table.tsx
+++ b/apps/remix/app/components/tables/user-organisations-table.tsx
@@ -60,7 +60,7 @@ export const UserOrganisationsTable = () => {
                     ? _(
                         msg({
                           message: `Personal`,
-                          context: `Personal organization (adjective)`,
+                          context: `Personal organisation (adjective)`,
                         }),
                       )
                     : row.original.name}


### PR DESCRIPTION
## Description

Fixes #2113

## Changes Made

Add context to strings

## Testing Performed

- `npm run build`

`web.po` after:
```
#: apps/remix/app/components/tables/user-organisations-table.tsx
msgctxt "Personal organisation (adjective)"
msgid "Personal"
msgstr ""
```

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
