### PR TITLE
fix: show legacy ids on template and document view page

### DIFF
--- a/apps/remix/app/components/general/document/document-page-view-information.tsx
+++ b/apps/remix/app/components/general/document/document-page-view-information.tsx
@@ -7,6 +7,7 @@ import { DateTime } from 'luxon';
 
 import { useIsMounted } from '@documenso/lib/client-only/hooks/use-is-mounted';
 import type { TEnvelope } from '@documenso/lib/types/envelope';
+import { mapSecondaryIdToDocumentId } from '@documenso/lib/utils/envelope';
 
 export type DocumentPageViewInformationProps = {
   userId: number;
@@ -39,6 +40,10 @@ export const DocumentPageViewInformation = ({
         value: DateTime.fromJSDate(envelope.updatedAt)
           .setLocale(i18n.locales?.[0] || i18n.locale)
           .toRelative(),
+      },
+      {
+        description: msg`Document ID (Legacy)`,
+        value: mapSecondaryIdToDocumentId(envelope.secondaryId),
       },
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/remix/app/components/general/template/template-page-view-information.tsx
+++ b/apps/remix/app/components/general/template/template-page-view-information.tsx
@@ -7,11 +7,13 @@ import type { User } from '@prisma/client';
 import { DateTime } from 'luxon';
 
 import { useIsMounted } from '@documenso/lib/client-only/hooks/use-is-mounted';
+import { mapSecondaryIdToTemplateId } from '@documenso/lib/utils/envelope';
 
 export type TemplatePageViewInformationProps = {
   userId: number;
   template: {
     userId: number;
+    secondaryId: string;
     createdAt: Date;
     updatedAt: Date;
     user: Pick<User, 'id' | 'name' | 'email'>;
@@ -42,6 +44,10 @@ export const TemplatePageViewInformation = ({
         value: DateTime.fromJSDate(template.updatedAt)
           .setLocale(i18n.locales?.[0] || i18n.locale)
           .toRelative(),
+      },
+      {
+        description: msg`Template ID (Legacy)`,
+        value: mapSecondaryIdToTemplateId(template.secondaryId),
       },
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<img width="557" height="455" alt="image" src="https://github.com/user-attachments/assets/7b669f4a-c6c5-4fdc-bf10-da0def7b0b3f" />
