### PR TITLE
fix: add page titles for translation

### DIFF
--- a/apps/remix/app/routes/_authenticated+/dashboard.tsx
+++ b/apps/remix/app/routes/_authenticated+/dashboard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { Plural, Trans, useLingui } from '@lingui/react/macro';
 import { Building2Icon, InboxIcon, SettingsIcon, UsersIcon } from 'lucide-react';
 import { DateTime } from 'luxon';
@@ -25,7 +26,7 @@ export function loader() {
 }
 
 export function meta() {
-  return appMetaTags('Dashboard');
+  return appMetaTags(msg`Dashboard`);
 }
 
 export default function DashboardPage() {

--- a/apps/remix/app/routes/_authenticated+/inbox.tsx
+++ b/apps/remix/app/routes/_authenticated+/inbox.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { InboxIcon } from 'lucide-react';
 
@@ -6,7 +7,7 @@ import { InboxTable } from '~/components/tables/inbox-table';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Personal Inbox');
+  return appMetaTags(msg`Personal Inbox`);
 }
 
 export default function InboxPage() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings._layout.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings._layout.tsx
@@ -22,7 +22,7 @@ import { GenericErrorLayout } from '~/components/general/generic-error-layout';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Organisation Settings');
+  return appMetaTags(msg`Organisation Settings`);
 }
 
 export default function SettingsLayout() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.billing.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.billing.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
 import { SubscriptionStatus } from '@prisma/client';
@@ -15,7 +16,7 @@ import { OrganisationBillingInvoicesTable } from '~/components/tables/organisati
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Billing');
+  return appMetaTags(msg`Billing`);
 }
 
 export default function TeamsSettingBillingPage() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.branding.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.branding.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { Loader } from 'lucide-react';
 import { Link } from 'react-router';
@@ -21,7 +22,7 @@ import { useOptionalCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Branding Preferences');
+  return appMetaTags(msg`Branding Preferences`);
 }
 
 export default function OrganisationSettingsBrandingPage() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.document.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.document.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 import { Loader } from 'lucide-react';
 
@@ -16,7 +17,7 @@ import { SettingsHeader } from '~/components/general/settings-header';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Document Preferences');
+  return appMetaTags(msg`Document Preferences`);
 }
 
 export default function OrganisationSettingsDocumentPage() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email-domains._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email-domains._index.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { Link } from 'react-router';
 
@@ -14,7 +15,7 @@ import { OrganisationEmailDomainsDataTable } from '~/components/tables/organisat
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Email Domains');
+  return appMetaTags(msg`Email Domains`);
 }
 
 export default function OrganisationSettingsEmailDomains() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 
 import { useCurrentOrganisation } from '@documenso/lib/client-only/providers/organisation';
@@ -13,7 +14,7 @@ import { SettingsHeader } from '~/components/general/settings-header';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Email Preferences');
+  return appMetaTags(msg`Email Preferences`);
 }
 
 export default function OrganisationSettingsGeneral() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.general.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.general.tsx
@@ -13,7 +13,7 @@ import { SettingsHeader } from '~/components/general/settings-header';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Settings');
+  return appMetaTags(msg`Settings`);
 }
 
 export default function OrganisationSettingsGeneral() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.sso.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.sso.tsx
@@ -69,7 +69,7 @@ const ZProviderFormSchema = ZUpdateOrganisationAuthenticationPortalRequestSchema
 type TProviderFormSchema = z.infer<typeof ZProviderFormSchema>;
 
 export function meta() {
-  return appMetaTags('Organisation SSO Portal');
+  return appMetaTags(msg`Organisation SSO Portal`);
 }
 
 export default function OrganisationSettingSSOLoginPage() {

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.support.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.support.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { BookIcon, HelpCircleIcon, Link2Icon } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router';
@@ -13,7 +14,7 @@ import { SupportTicketForm } from '~/components/forms/support-ticket-form';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Support');
+  return appMetaTags(msg`Support`);
 }
 
 export default function SupportPage() {

--- a/apps/remix/app/routes/_authenticated+/settings+/_layout.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/_layout.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Outlet } from 'react-router';
 
@@ -6,7 +7,7 @@ import { SettingsMobileNav } from '~/components/general/settings-nav-mobile';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Settings');
+  return appMetaTags(msg`Settings`);
 }
 
 export default function SettingsLayout() {

--- a/apps/remix/app/routes/_authenticated+/settings+/profile.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/profile.tsx
@@ -15,7 +15,7 @@ import { TeamEmailUsage } from '~/components/general/teams/team-email-usage';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Profile');
+  return appMetaTags(msg`Profile`);
 }
 
 export default function SettingsProfile() {

--- a/apps/remix/app/routes/_authenticated+/settings+/security._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/security._index.tsx
@@ -19,7 +19,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/security._index';
 
 export function meta() {
-  return appMetaTags('Security');
+  return appMetaTags(msg`Security`);
 }
 
 export async function loader({ request }: Route.LoaderArgs) {

--- a/apps/remix/app/routes/_authenticated+/settings+/security.activity.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/security.activity.tsx
@@ -6,7 +6,7 @@ import { SettingsSecurityActivityTable } from '~/components/tables/settings-secu
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Security activity');
+  return appMetaTags(msg`Security activity`);
 }
 
 export default function SettingsSecurityActivity() {

--- a/apps/remix/app/routes/_authenticated+/settings+/security.linked-accounts.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/security.linked-accounts.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 import { Trans } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
@@ -26,7 +27,7 @@ import { SettingsHeader } from '~/components/general/settings-header';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Linked Accounts');
+  return appMetaTags(msg`Linked Accounts`);
 }
 
 export default function SettingsSecurityLinkedAccounts() {

--- a/apps/remix/app/routes/_authenticated+/settings+/security.passkeys.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/security.passkeys.tsx
@@ -7,7 +7,7 @@ import { SettingsSecurityPasskeyTable } from '~/components/tables/settings-secur
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Manage passkeys');
+  return appMetaTags(msg`Manage passkeys`);
 }
 
 export default function SettingsPasskeys() {

--- a/apps/remix/app/routes/_authenticated+/settings+/security.sessions.tsx
+++ b/apps/remix/app/routes/_authenticated+/settings+/security.sessions.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 import { Trans } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
@@ -21,7 +22,7 @@ import { SettingsHeader } from '~/components/general/settings-header';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Active Sessions');
+  return appMetaTags(msg`Active Sessions`);
 }
 
 const parser = new UAParser();

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents._index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { FolderType, OrganisationType } from '@prisma/client';
 import { useParams, useSearchParams } from 'react-router';
@@ -30,7 +31,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Documents');
+  return appMetaTags(msg`Documents`);
 }
 
 const ZSearchParamsSchema = ZFindDocumentsInternalRequestSchema.pick({

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.folders._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.folders._index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { HomeIcon, Loader2, SearchIcon } from 'lucide-react';
 import { useNavigate } from 'react-router';
@@ -20,7 +21,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Documents');
+  return appMetaTags(msg`Documents`);
 }
 
 export default function DocumentsFoldersPage() {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings._layout.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings._layout.tsx
@@ -24,7 +24,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/settings._layout';
 
 export function meta() {
-  return appMetaTags('Team Settings');
+  return appMetaTags(msg`Team Settings`);
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.branding.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.branding.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 import { Loader } from 'lucide-react';
 
@@ -14,7 +15,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Branding Preferences');
+  return appMetaTags(msg`Branding Preferences`);
 }
 
 export default function TeamsSettingsPage() {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.document.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.document.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 import { Loader } from 'lucide-react';
 
@@ -14,7 +15,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Document Preferences');
+  return appMetaTags(msg`Document Preferences`);
 }
 
 export default function TeamsSettingsPage() {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.email.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.email.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 
 import { trpc } from '@documenso/trpc/react';
@@ -13,7 +14,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Settings');
+  return appMetaTags(msg`Settings`);
 }
 
 export default function TeamEmailSettingsGeneral() {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.public-profile.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.public-profile.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
 import { Trans } from '@lingui/react/macro';
 import { type TemplateDirectLink, TemplateType } from '@prisma/client';
@@ -31,7 +32,7 @@ type DirectTemplate = FindTemplateRow & {
 };
 
 export function meta() {
-  return appMetaTags('Public Profile');
+  return appMetaTags(msg`Public Profile`);
 }
 
 // Todo: This can be optimized.

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.tokens.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.tokens.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
 import { TeamMemberRole } from '@prisma/client';
@@ -15,7 +16,7 @@ import { useOptionalCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('API Tokens');
+  return appMetaTags(msg`API Tokens`);
 }
 
 export default function ApiTokensPage() {
@@ -36,6 +37,7 @@ export default function ApiTokensPage() {
               className="text-primary underline"
               href={'https://docs.documenso.com/developers/public-api'}
               target="_blank"
+              rel="noreferrer"
             >
               Documentation
             </a>{' '}

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks.$id.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks.$id.tsx
@@ -40,7 +40,7 @@ const ZEditWebhookFormSchema = ZEditWebhookRequestSchema.omit({ id: true, teamId
 type TEditWebhookFormSchema = z.infer<typeof ZEditWebhookFormSchema>;
 
 export function meta() {
-  return appMetaTags('Webhooks');
+  return appMetaTags(msg`Webhooks`);
 }
 
 export default function WebhookPage({ params }: Route.ComponentProps) {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks._index.tsx
@@ -18,7 +18,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Webhooks');
+  return appMetaTags(msg`Webhooks`);
 }
 
 export default function WebhookPage() {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates._index.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Bird } from 'lucide-react';
 import { useParams, useSearchParams } from 'react-router';
@@ -15,7 +16,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Templates');
+  return appMetaTags(msg`Templates`);
 }
 
 export default function TemplatesPage() {

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.folders._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.folders._index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { HomeIcon, Loader2, SearchIcon } from 'lucide-react';
 import { useNavigate } from 'react-router';
@@ -20,7 +21,7 @@ import { useCurrentTeam } from '~/providers/team';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Templates');
+  return appMetaTags(msg`Templates`);
 }
 
 export default function TemplatesFoldersPage() {

--- a/apps/remix/app/routes/_profile+/_layout.tsx
+++ b/apps/remix/app/routes/_profile+/_layout.tsx
@@ -19,7 +19,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/_layout';
 
 export function meta() {
-  return appMetaTags('Profile');
+  return appMetaTags(msg`Profile`);
 }
 
 export default function PublicProfileLayout() {

--- a/apps/remix/app/routes/_unauthenticated+/check-email.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/check-email.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Link } from 'react-router';
 
@@ -6,7 +7,7 @@ import { Button } from '@documenso/ui/primitives/button';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Forgot password');
+  return appMetaTags(msg`Forgot password`);
 }
 
 export default function ForgotPasswordPage() {

--- a/apps/remix/app/routes/_unauthenticated+/forgot-password.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/forgot-password.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Link } from 'react-router';
 
@@ -5,7 +6,7 @@ import { ForgotPasswordForm } from '~/components/forms/forgot-password';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Forgot Password');
+  return appMetaTags(msg`Forgot Password`);
 }
 
 export default function ForgotPasswordPage() {

--- a/apps/remix/app/routes/_unauthenticated+/o.$orgUrl.signin.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/o.$orgUrl.signin.tsx
@@ -19,7 +19,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/o.$orgUrl.signin';
 
 export function meta() {
-  return appMetaTags('Sign In');
+  return appMetaTags(msg`Sign In`);
 }
 
 export function ErrorBoundary() {

--- a/apps/remix/app/routes/_unauthenticated+/reset-password.$token.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/reset-password.$token.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Link, redirect } from 'react-router';
 
@@ -9,7 +10,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/reset-password.$token';
 
 export function meta() {
-  return appMetaTags('Reset Password');
+  return appMetaTags(msg`Reset Password`);
 }
 
 export async function loader({ params }: Route.LoaderArgs) {

--- a/apps/remix/app/routes/_unauthenticated+/reset-password._index.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/reset-password._index.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Link } from 'react-router';
 
@@ -6,7 +7,7 @@ import { Button } from '@documenso/ui/primitives/button';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Reset Password');
+  return appMetaTags(msg`Reset Password`);
 }
 
 export default function ResetPasswordPage() {

--- a/apps/remix/app/routes/_unauthenticated+/signin.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/signin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { Link, redirect } from 'react-router';
 
@@ -19,7 +20,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/signin';
 
 export function meta() {
-  return appMetaTags('Sign In');
+  return appMetaTags(msg`Sign In`);
 }
 
 export async function loader({ request }: Route.LoaderArgs) {

--- a/apps/remix/app/routes/_unauthenticated+/signup.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/signup.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { redirect } from 'react-router';
 
 import {
@@ -14,7 +15,7 @@ import { appMetaTags } from '~/utils/meta';
 import type { Route } from './+types/signup';
 
 export function meta() {
-  return appMetaTags('Sign Up');
+  return appMetaTags(msg`Sign Up`);
 }
 
 export function loader({ request }: Route.LoaderArgs) {

--- a/apps/remix/app/routes/_unauthenticated+/verify-email._index.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/verify-email._index.tsx
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { XCircle } from 'lucide-react';
 import { Link } from 'react-router';
@@ -7,7 +8,7 @@ import { Button } from '@documenso/ui/primitives/button';
 import { appMetaTags } from '~/utils/meta';
 
 export function meta() {
-  return appMetaTags('Verify Email');
+  return appMetaTags(msg`Verify Email`);
 }
 
 export default function EmailVerificationWithoutTokenPage() {

--- a/apps/remix/app/utils/meta.ts
+++ b/apps/remix/app/utils/meta.ts
@@ -1,12 +1,15 @@
+import type { MessageDescriptor } from '@lingui/core';
+import { i18n } from '@lingui/core';
+
 import { NEXT_PUBLIC_WEBAPP_URL } from '@documenso/lib/constants/app';
 
-export const appMetaTags = (title?: string) => {
+export const appMetaTags = (title?: MessageDescriptor) => {
   const description =
     'Join Documenso, the open signing infrastructure, and get a 10x better signing experience. Pricing starts at $30/mo. forever! Sign in now and enjoy a faster, smarter, and more beautiful document signing process. Integrates with your favorite tools, customizable, and expandable. Support our mission and become a part of our open-source community.';
 
   return [
     {
-      title: title ? `${title} - Documenso` : 'Documenso',
+      title: title ? `${i18n._(title)} - Documenso` : 'Documenso',
     },
     {
       name: 'description',


### PR DESCRIPTION
## Description
The title of the page being displayed on the tab was not translated previously. Despite changing the language in the settings, the title of the tab would still be displayed in English.

## Related Issue
Closes #2142

## Changes Made
- The `title` parameter passed to `appMetaTags` is now of type `MessageDescriptor` rather than a simple `string`.
- All usages of `appMetaTags` have been modified to use `msg` while passing the title of the page.

## Testing Performed

- I was able to build the project without facing any build issues.
- I verified that the titles were being translated after changing the language. Will be attaching a screenshot of the same.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/6f66602b-29ef-4f84-a943-e68286840ec2" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/9e5961a4-b87e-4d05-acaf-072cfed902d6" />

