### PR TITLE
fix: hide overflow on envelope download dialog

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
@@ -126,7 +126,7 @@ export const EnvelopeDownloadDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex w-full flex-col gap-4 overflow-hidden">
           {isLoadingEnvelopeItems ? (
             <>
               {Array.from({ length: 1 }).map((_, index) => (
@@ -159,7 +159,9 @@ export const EnvelopeDownloadDialog = ({
 
                 <div className="min-w-0 flex-1">
                   {/* Todo: Envelopes - Fix overflow */}
-                  <h4 className="text-foreground truncate text-sm font-medium">{item.title}</h4>
+                  <h4 className="text-foreground truncate text-sm font-medium" title={item.title}>
+                    {item.title}
+                  </h4>
                   <p className="text-muted-foreground mt-0.5 text-xs">
                     <Trans>PDF Document</Trans>
                   </p>


### PR DESCRIPTION
Before:

<img width="2292" height="738" alt="image" src="https://github.com/user-attachments/assets/340a8091-c9f4-43f9-a6bf-a23772e8c2d7" />

After:

<img width="559" height="336" alt="image" src="https://github.com/user-attachments/assets/685173ec-0188-4e56-8505-972e18d6a43f" />
