### PR TITLE
fix: auth side channel

### DIFF
--- a/packages/auth/server/config.ts
+++ b/packages/auth/server/config.ts
@@ -6,6 +6,11 @@ import { env } from '@documenso/lib/utils/env';
  */
 export const AUTH_SESSION_LIFETIME = 1000 * 60 * 60 * 24 * 30; // 30 days.
 
+/**
+ * How long a request should take to mitigate side channel attacks
+ */
+export const AUTH_MIN_REQUEST_DURATION_MS = 1000;
+
 export type OAuthClientOptions = {
   id: string;
   scope: string[];

--- a/packages/auth/server/lib/utils/minimum-duration.ts
+++ b/packages/auth/server/lib/utils/minimum-duration.ts
@@ -1,0 +1,29 @@
+import type { Context, Next } from 'hono';
+
+import { AUTH_MIN_REQUEST_DURATION_MS } from '../../config';
+import type { HonoAuthContext } from '../../types/context';
+
+const timeout = async (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+/**
+ * Mitigates against time-based side-channel attacks by ensuring that each request
+ * takes at least AUTH_MIN_REQUEST_DURATION_MS milliseconds to complete.
+ */
+export const minimumDurationMiddleware = async (
+  _c: Context<HonoAuthContext>,
+  next: Next,
+): Promise<void> => {
+  const startTime = Date.now();
+
+  await next();
+
+  const elapsed = Date.now() - startTime;
+
+  if (elapsed < AUTH_MIN_REQUEST_DURATION_MS) {
+    await timeout(AUTH_MIN_REQUEST_DURATION_MS - elapsed);
+  }
+};

--- a/packages/auth/server/routes/email-password.ts
+++ b/packages/auth/server/routes/email-password.ts
@@ -27,6 +27,7 @@ import { AuthenticationErrorCode } from '../lib/errors/error-codes';
 import { getCsrfCookie } from '../lib/session/session-cookies';
 import { onAuthorize } from '../lib/utils/authorizer';
 import { getSession } from '../lib/utils/get-session';
+import { minimumDurationMiddleware } from '../lib/utils/minimum-duration';
 import type { HonoAuthContext } from '../types/context';
 import {
   ZForgotPasswordSchema,
@@ -39,6 +40,10 @@ import {
 } from '../types/email-password';
 
 export const emailPasswordRoute = new Hono<HonoAuthContext>()
+  /**
+   * Middleware to mitigate side-channel attacks.
+   */
+  .use(minimumDurationMiddleware)
   /**
    * Authorize endpoint.
    */


### PR DESCRIPTION
## Description

With the login endpoint, you can indirectly determine if a user exists based on the response time. Entering a valid email yields around 800ms, an invalid email is around 250ms.

The middleware is added to all email-password endpoints which is definitely overkill, let me know if you want me to change it to just the ones that are bcrypting. I was just hesitant to spam middleware everywhere, as there aren't many middlewares being used.

## Changes Made

Added a middleware to vulnerable endpoints

## Testing Performed

should be right

## Checklist

- [ passes the unit tests] I have tested these changes locally and they work as expected.
- [ passes the unit tests] I have added/updated tests that prove the effectiveness of these changes.
- [n/a ] I have updated the documentation to reflect these changes, if applicable.
- [ hopefully] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

looking to bankrupt documenso's bug bounty program thanks
