### PR TITLE
fix: disable browser autocomplete in typed signature input

### DIFF
--- a/packages/ui/primitives/signature-pad/signature-pad-type.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad-type.tsx
@@ -20,10 +20,14 @@ export const SignaturePadType = ({ className, value, onChange }: SignaturePadTyp
       <input
         data-testid="signature-pad-type-input"
         placeholder={t`Type your signature`}
-        className="font-signature w-full bg-transparent px-4 text-center text-7xl text-black placeholder:text-4xl focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:text-white"
+        className="w-full bg-transparent px-4 text-center font-signature text-7xl text-black placeholder:text-4xl focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:text-white"
         // style={{ color: selectedColor }}
         value={value}
         onChange={(event) => onChange(event.target.value.trimStart())}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
       />
 
       {/* <SignaturePadColorPicker selectedColor={selectedColor} setSelectedColor={setSelectedColor} /> */}


### PR DESCRIPTION
## Description

This PR disables browser autocomplete and automatic text-correction features for the typed signature option.

## Context
The signing flow includes three methods:
- Upload signature
- Draw signature
- Type signature (this is the only one using a text input)

Browsers were autofilling the typed signature input with values like names or emails, which results in accidental or incorrect signatures.
<img width="637" height="503" alt="Screenshot 2025-12-02 215715" src="https://github.com/user-attachments/assets/e7ed5cb8-ac5e-42a9-8341-50f48717debf" />

## Changes Made
Added the following properties to the typed signature <input>:
```
autoComplete="off"
autoCorrect="off"
autoCapitalize="off"
spellCheck={false}
```

## Why
- Prevents unwanted browser autofill
- Ensures typed signatures are always intentional
- Matches UX/security expectations in signature tools
- Does not affect the upload or draw methods

## Testing Performed

- Confirmed that browser autocomplete suggestions no longer appear
- Typed input still works normally
- Other signature types are unaffected

## Checklist

- [x] I have tested these changes locally and they work as expected.
