### PR TITLE
fix: Unhide text field scrollbar

### DIFF
--- a/packages/ui/primitives/document-flow/document-flow-root.tsx
+++ b/packages/ui/primitives/document-flow/document-flow-root.tsx
@@ -67,7 +67,7 @@ export const DocumentFlowFormContainerContent = ({
 }: DocumentFlowFormContainerContentProps) => {
   return (
     <div
-      className={cn('custom-scrollbar -mx-2 flex flex-1 flex-col overflow-hidden px-2', className)}
+      className={cn('custom-scrollbar -mx-2 flex flex-1 flex-col px-2', className)}
       {...props}
     >
       <div className="flex flex-1 flex-col">{children}</div>


### PR DESCRIPTION
## Description

The configure text blade when authoring a document is now scrollable

## Related Issue


## Changes Made

- The class causing the configure text blade to not be scrollable is removed

## Testing Performed

- Tested on Chrome

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [X] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [X] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
