### PR TITLE
fix: embed authoring permission issue

### DIFF
--- a/packages/lib/utils/envelope-download.ts
+++ b/packages/lib/utils/envelope-download.ts
@@ -32,5 +32,5 @@ export const getEnvelopeItemPdfUrl = (options: EnvelopeItemPdfUrlOptions) => {
 
   return token
     ? `${NEXT_PUBLIC_WEBAPP_URL()}/api/files/token/${token}/envelopeItem/${id}${presignToken ? `?presignToken=${presignToken}` : ''}`
-    : `${NEXT_PUBLIC_WEBAPP_URL()}/api/files/envelope/${envelopeId}/envelopeItem/${id}`;
+    : `${NEXT_PUBLIC_WEBAPP_URL()}/api/files/envelope/${envelopeId}/envelopeItem/${id}${presignToken ? `?token=${presignToken}` : ''}`;
 };


### PR DESCRIPTION
## Description

Permission issue in embed authoring. 
In configure fields step, got the following error: Something went wrong while loading the document.
<img width="524" height="156" alt="image" src="https://github.com/user-attachments/assets/aef438df-67d2-4092-86d0-4000467c46ca" />

Here is the analysis:
In configure-fields-view.tsx line 549,  presignToken is passed to PDFViewer component:
```
<PDFViewerLazy
  presignToken={presignToken}
  overrideData={normalizedDocumentData}
  envelopeItem={normalizedEnvelopeItem}
  token={undefined}
  version="signed"
/>
```
In PDFViewer (packages/ui/primitives/pdf-viewer/base.tsx line 180)
```
const documentUrl = getEnvelopeItemPdfUrl({
  type: 'view',
  envelopeItem: envelopeItem,
  token,
  presignToken,
});
```
In envelope-download.ts line 35, we should pass the presignToke to the backend to load the envelopeItem when the token is undefined:
```
  return token
    ? `${NEXT_PUBLIC_WEBAPP_URL()}/api/files/token/${token}/envelopeItem/${id}${presignToken ? `?presignToken=${presignToken}` : ''}`
    : `${NEXT_PUBLIC_WEBAPP_URL()}/api/files/envelope/${envelopeId}/envelopeItem/${id}`;
```

## Related Issue

N/A

## Changes Made

Pass the missing token to the get envelopeItem endpoint.

## Testing Performed

Tested in Chrome.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [X] I have tested these changes locally and they work as expected.
- [X] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have updated the documentation to reflect these changes, if applicable.
- [X] I have followed the project's coding style guidelines.
- [X] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
N/A

