### PR TITLE
fix(i18n): mark field content for translation

### DIFF
--- a/packages/ui/primitives/document-flow/field-content.tsx
+++ b/packages/ui/primitives/document-flow/field-content.tsx
@@ -1,4 +1,5 @@
 import { useLingui } from '@lingui/react';
+import { Trans } from '@lingui/react/macro';
 import type { DocumentMeta, Signature } from '@prisma/client';
 import { FieldType } from '@prisma/client';
 import { ChevronDown } from 'lucide-react';
@@ -62,7 +63,7 @@ export const FieldContent = ({ field, documentMeta }: FieldIconProps) => {
           <div className="flex items-center">
             <Checkbox className="h-3 w-3" disabled />
             <Label className="text-foreground ml-1.5 text-xs font-normal opacity-50">
-              Checkbox option
+              <Trans>Checkbox option</Trans>
             </Label>
           </div>
         </div>
@@ -140,7 +141,9 @@ export const FieldContent = ({ field, documentMeta }: FieldIconProps) => {
   ) {
     return (
       <div className="text-field-card-foreground flex flex-row items-center py-0.5 text-[clamp(0.07rem,25cqw,0.825rem)] text-sm">
-        <p>Select</p>
+        <p>
+          <Trans>Select</Trans>
+        </p>
         <ChevronDown className="h-4 w-4" />
       </div>
     );


### PR DESCRIPTION
## Description

I mark for translation missing messages in `packages/ui/primitives/document-flow/field-content.tsx` file.

## Changes Made

- Mark missing strings for translation with `<Trans>` tag

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
