### PR TITLE
chore(i18n): improve punctuation

### DIFF
--- a/apps/remix/app/components/dialogs/admin-organisation-member-update-dialog.tsx
+++ b/apps/remix/app/components/dialogs/admin-organisation-member-update-dialog.tsx
@@ -156,8 +156,8 @@ export const AdminOrganisationMemberUpdateDialog = ({
 
           <DialogDescription className="mt-4">
             <Trans>
-              You are currently updating{' '}
-              <span className="font-bold">{organisationMemberName}.</span>
+              You are currently updating <span className="font-bold">{organisationMemberName}</span>
+              .
             </Trans>
           </DialogDescription>
         </DialogHeader>

--- a/apps/remix/app/components/dialogs/envelope-item-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-item-delete-dialog.tsx
@@ -117,7 +117,7 @@ export const EnvelopeItemDeleteDialog = ({
 
             <DialogDescription className="mt-4">
               <Trans>
-                You cannot delete this item because the document has been sent to recipients
+                You cannot delete this item because the document has been sent to recipients.
               </Trans>
             </DialogDescription>
           </DialogHeader>

--- a/apps/remix/app/components/dialogs/organisation-email-domain-records-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-email-domain-records-dialog.tsx
@@ -121,7 +121,7 @@ export const OrganisationEmailDomainRecordContent = ({ records }: { records: Dom
             <Trans>
               Once you update your DNS records, it may take up to 48 hours for it to be propogated.
               Once the DNS propagation is complete you will need to come back and press the "Sync"
-              domains button
+              domains button.
             </Trans>
           </AlertDescription>
         </Alert>

--- a/apps/remix/app/components/dialogs/organisation-member-update-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-member-update-dialog.tsx
@@ -148,8 +148,8 @@ export const OrganisationMemberUpdateDialog = ({
 
           <DialogDescription className="mt-4">
             <Trans>
-              You are currently updating{' '}
-              <span className="font-bold">{organisationMemberName}.</span>
+              You are currently updating <span className="font-bold">{organisationMemberName}</span>
+              .
             </Trans>
           </DialogDescription>
         </DialogHeader>

--- a/apps/remix/app/components/dialogs/team-member-update-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-member-update-dialog.tsx
@@ -146,7 +146,7 @@ export const TeamMemberUpdateDialog = ({
 
           <DialogDescription>
             <Trans>
-              You are currently updating <span className="font-bold">{memberName}.</span>
+              You are currently updating <span className="font-bold">{memberName}</span>.
             </Trans>
           </DialogDescription>
         </DialogHeader>

--- a/apps/remix/app/components/dialogs/webhook-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/webhook-create-dialog.tsx
@@ -219,9 +219,8 @@ export const WebhookCreateDialog = ({ trigger, ...props }: WebhookCreateDialogPr
                     <FormDescription>
                       <Trans>
                         A secret that will be sent to your URL so you can verify that the request
-                        has been sent by Documenso
+                        has been sent by Documenso.
                       </Trans>
-                      .
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/apps/remix/app/components/forms/signin.tsx
+++ b/apps/remix/app/components/forms/signin.tsx
@@ -244,11 +244,11 @@ export const SignInForm = ({
       const errorMessage = match(error.code)
         .with(
           AuthenticationErrorCode.InvalidCredentials,
-          () => msg`The email or password provided is incorrect`,
+          () => msg`The email or password provided is incorrect.`,
         )
         .with(
           AuthenticationErrorCode.InvalidTwoFactorCode,
-          () => msg`The two-factor authentication code provided is incorrect`,
+          () => msg`The two-factor authentication code provided is incorrect.`,
         )
         .otherwise(() => handleFallbackErrorMessages(error.code));
 

--- a/apps/remix/app/components/forms/token.tsx
+++ b/apps/remix/app/components/forms/token.tsx
@@ -131,7 +131,7 @@ export const ApiTokenForm = ({ className, tokens }: ApiTokenFormProps) => {
       const errorMessage = match(error.code)
         .with(
           AppErrorCode.UNAUTHORIZED,
-          () => msg`You do not have permission to create a token for this team`,
+          () => msg`You do not have permission to create a token for this team.`,
         )
         .otherwise(() => msg`Something went wrong. Please try again later.`);
 

--- a/apps/remix/app/components/general/document/document-upload-button-legacy.tsx
+++ b/apps/remix/app/components/general/document/document-upload-button-legacy.tsx
@@ -110,14 +110,14 @@ export const DocumentUploadButtonLegacy = ({ className }: DocumentUploadButtonLe
       console.error(err);
 
       const errorMessage = match(error.code)
-        .with('INVALID_DOCUMENT_FILE', () => msg`You cannot upload encrypted PDFs`)
+        .with('INVALID_DOCUMENT_FILE', () => msg`You cannot upload encrypted PDFs.`)
         .with(
           AppErrorCode.LIMIT_EXCEEDED,
           () => msg`You have reached your document limit for this month. Please upgrade your plan.`,
         )
         .with(
           'ENVELOPE_ITEM_LIMIT_EXCEEDED',
-          () => msg`You have reached the limit of the number of files per envelope`,
+          () => msg`You have reached the limit of the number of files per envelope.`,
         )
         .otherwise(() => msg`An error occurred while uploading your document.`);
 

--- a/apps/remix/app/components/general/envelope/envelope-drop-zone-wrapper.tsx
+++ b/apps/remix/app/components/general/envelope/envelope-drop-zone-wrapper.tsx
@@ -123,14 +123,14 @@ export const EnvelopeDropZoneWrapper = ({
       const error = AppError.parseError(err);
 
       const errorMessage = match(error.code)
-        .with('INVALID_DOCUMENT_FILE', () => t`You cannot upload encrypted PDFs`)
+        .with('INVALID_DOCUMENT_FILE', () => t`You cannot upload encrypted PDFs.`)
         .with(
           AppErrorCode.LIMIT_EXCEEDED,
           () => t`You have reached your document limit for this month. Please upgrade your plan.`,
         )
         .with(
           'ENVELOPE_ITEM_LIMIT_EXCEEDED',
-          () => t`You have reached the limit of the number of files per envelope`,
+          () => t`You have reached the limit of the number of files per envelope.`,
         )
         .otherwise(() => t`An error occurred during upload.`);
 

--- a/apps/remix/app/components/general/envelope/envelope-upload-button.tsx
+++ b/apps/remix/app/components/general/envelope/envelope-upload-button.tsx
@@ -126,14 +126,14 @@ export const EnvelopeUploadButton = ({ className, type, folderId }: EnvelopeUplo
       console.error(err);
 
       const errorMessage = match(error.code)
-        .with('INVALID_DOCUMENT_FILE', () => t`You cannot upload encrypted PDFs`)
+        .with('INVALID_DOCUMENT_FILE', () => t`You cannot upload encrypted PDFs.`)
         .with(
           AppErrorCode.LIMIT_EXCEEDED,
           () => t`You have reached your document limit for this month. Please upgrade your plan.`,
         )
         .with(
           'ENVELOPE_ITEM_LIMIT_EXCEEDED',
-          () => t`You have reached the limit of the number of files per envelope`,
+          () => t`You have reached the limit of the number of files per envelope.`,
         )
         .otherwise(() => t`An error occurred while uploading your document.`);
 

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.branding.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.branding.tsx
@@ -87,9 +87,9 @@ export default function OrganisationSettingsBrandingPage() {
   const settingsHeaderText = t`Branding Preferences`;
 
   const settingsHeaderSubtitle = isPersonalLayoutMode
-    ? t`Here you can set your general branding preferences`
+    ? t`Here you can set your general branding preferences.`
     : team
-      ? t`Here you can set branding preferences for your team`
+      ? t`Here you can set branding preferences for your team.`
       : t`Here you can set branding preferences for your organisation. Teams will inherit these settings by default.`;
 
   return (

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.document.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.document.tsx
@@ -112,7 +112,7 @@ export default function OrganisationSettingsDocumentPage() {
 
   const settingsHeaderText = t`Document Preferences`;
   const settingsHeaderSubtitle = isPersonalLayoutMode
-    ? t`Here you can set your general document preferences`
+    ? t`Here you can set your general document preferences.`
     : t`Here you can set document preferences for your organisation. Teams will inherit these settings by default.`;
 
   return (

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.email.tsx
@@ -65,7 +65,7 @@ export default function OrganisationSettingsGeneral() {
     <div className="max-w-2xl">
       <SettingsHeader
         title={t`Email Preferences`}
-        subtitle={t`You can manage your email preferences here`}
+        subtitle={t`You can manage your email preferences here.`}
       />
 
       <section>

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.email.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.email.tsx
@@ -63,7 +63,7 @@ export default function TeamEmailSettingsGeneral() {
     <div className="max-w-2xl">
       <SettingsHeader
         title={t`Email Preferences`}
-        subtitle={t`You can manage your email preferences here`}
+        subtitle={t`You can manage your email preferences here.`}
       />
 
       <section>

--- a/apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
+++ b/apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
@@ -371,8 +371,9 @@ const SigningPageV1 = ({ data }: { data: Awaited<ReturnType<typeof handleV1Loade
                   to="https://documenso.com"
                   className="text-documenso-700 hover:text-documenso-600"
                 >
-                  Check out Documenso.
+                  Check out Documenso
                 </Link>
+                .
               </Trans>
             </p>
           )}
@@ -470,8 +471,9 @@ const SigningPageV2 = ({ data }: { data: Awaited<ReturnType<typeof handleV2Loade
                   to="https://documenso.com"
                   className="text-documenso-700 hover:text-documenso-600"
                 >
-                  Check out Documenso.
+                  Check out Documenso
                 </Link>
+                .
               </Trans>
             </p>
           )}

--- a/packages/email/template-components/template-footer.tsx
+++ b/packages/email/template-components/template-footer.tsx
@@ -17,8 +17,9 @@ export const TemplateFooter = ({ isDocument = true }: TemplateFooterProps) => {
           <Trans>
             This document was sent using{' '}
             <Link className="text-[#7AC455]" href="https://documen.so/mail-footer">
-              Documenso.
+              Documenso
             </Link>
+            .
           </Trans>
         </Text>
       )}

--- a/packages/email/templates/confirm-team-email.tsx
+++ b/packages/email/templates/confirm-team-email.tsx
@@ -106,7 +106,7 @@ export const ConfirmTeamEmailTemplate = ({
                 <Text className="mt-2 text-sm">
                   <Trans>
                     You can revoke access at any time in your team settings on Documenso{' '}
-                    <Link href={`${baseUrl}/settings/teams`}>here.</Link>
+                    <Link href={`${baseUrl}/settings/teams`}>here</Link>.
                   </Trans>
                 </Text>
               </Section>

--- a/packages/email/templates/reset-password.tsx
+++ b/packages/email/templates/reset-password.tsx
@@ -73,8 +73,9 @@ export const ResetPasswordTemplate = ({
                   Didn't request a password change? We are here to help you secure your account,
                   just{' '}
                   <Link className="text-documenso-700 font-normal" href="mailto:hi@documenso.com">
-                    contact us.
+                    contact us
                   </Link>
+                  .
                 </Trans>
               </Text>
             </Section>


### PR DESCRIPTION
## Description

I fixed inconsistent punctuation (periods) in translation strings.

## Changes Made

- Added missing periods to setting descriptions so all end consistently.
- Moved periods outside of formatting tags (bold or link tags) where they were incorrectly placed inside.
- Added missing periods to longer sentences.

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
