### PR TITLE
fix(i18n): mark sr-only strings for translation

### DIFF
--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl._index.tsx
@@ -178,7 +178,9 @@ const TeamDropdownMenu = ({ team }: { team: TGetOrganisationSessionResponse[0]['
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
           <MoreVerticalIcon className="h-4 w-4" />
-          <span className="sr-only">Open menu</span>
+          <span className="sr-only">
+            <Trans>Open menu</Trans>
+          </span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>

--- a/packages/ui/primitives/data-table-pagination.tsx
+++ b/packages/ui/primitives/data-table-pagination.tsx
@@ -95,7 +95,9 @@ export function DataTablePagination<TData>({
             onClick={() => table.setPageIndex(0)}
             disabled={!table.getCanPreviousPage()}
           >
-            <span className="sr-only">Go to first page</span>
+            <span className="sr-only">
+              <Trans>Go to first page</Trans>
+            </span>
             <ChevronsLeft className="h-4 w-4" />
           </Button>
           <Button
@@ -104,7 +106,9 @@ export function DataTablePagination<TData>({
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
           >
-            <span className="sr-only">Go to previous page</span>
+            <span className="sr-only">
+              <Trans>Go to previous page</Trans>
+            </span>
             <ChevronLeft className="h-4 w-4" />
           </Button>
           <Button
@@ -113,7 +117,9 @@ export function DataTablePagination<TData>({
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
           >
-            <span className="sr-only">Go to next page</span>
+            <span className="sr-only">
+              <Trans>Go to next page</Trans>
+            </span>
             <ChevronRight className="h-4 w-4" />
           </Button>
           <Button
@@ -122,7 +128,9 @@ export function DataTablePagination<TData>({
             onClick={() => table.setPageIndex(table.getPageCount() - 1)}
             disabled={!table.getCanNextPage()}
           >
-            <span className="sr-only">Go to last page</span>
+            <span className="sr-only">
+              <Trans>Go to last page</Trans>
+            </span>
             <ChevronsRight className="h-4 w-4" />
           </Button>
         </div>

--- a/packages/ui/primitives/dialog.tsx
+++ b/packages/ui/primitives/dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Trans } from '@lingui/react/macro';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 
@@ -81,7 +82,9 @@ const DialogContent = React.forwardRef<
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none"
           >
             <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">
+              <Trans>Close</Trans>
+            </span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>

--- a/packages/ui/primitives/sheet.tsx
+++ b/packages/ui/primitives/sheet.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Trans } from '@lingui/react/macro';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
@@ -160,7 +161,9 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">
+          <Trans>Close</Trans>
+        </span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>

--- a/packages/ui/primitives/signature-pad/signature-pad-draw.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad-draw.tsx
@@ -318,7 +318,9 @@ export const SignaturePadDraw = ({
             onClick={onUndoClick}
           >
             <Undo2 className="h-4 w-4" />
-            <span className="sr-only">Undo</span>
+            <span className="sr-only">
+              <Trans>Undo</Trans>
+            </span>
           </button>
         </div>
       )}


### PR DESCRIPTION
## Description

I marked missing  `sr-only` strings for translation. Previously, only parts of these messages were translatable.

## Changes Made

- Mark strings to translate with `<Trans>` tag

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
