### PR TITLE
fix(i18n): mark "(Optional)" strings for translation

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
@@ -353,8 +353,10 @@ export const EnvelopeDistributeDialog = ({
                               render={({ field }) => (
                                 <FormItem>
                                   <FormLabel>
-                                    <Trans>Reply To Email</Trans>{' '}
-                                    <span className="text-muted-foreground">(Optional)</span>
+                                    <Trans>
+                                      Reply To Email{' '}
+                                      <span className="text-muted-foreground">(Optional)</span>
+                                    </Trans>
                                   </FormLabel>
 
                                   <FormControl>
@@ -372,8 +374,10 @@ export const EnvelopeDistributeDialog = ({
                               render={({ field }) => (
                                 <FormItem>
                                   <FormLabel>
-                                    <Trans>Subject</Trans>{' '}
-                                    <span className="text-muted-foreground">(Optional)</span>
+                                    <Trans>
+                                      Subject{' '}
+                                      <span className="text-muted-foreground">(Optional)</span>
+                                    </Trans>
                                   </FormLabel>
 
                                   <FormControl>
@@ -390,8 +394,10 @@ export const EnvelopeDistributeDialog = ({
                               render={({ field }) => (
                                 <FormItem>
                                   <FormLabel className="flex flex-row items-center">
-                                    <Trans>Message</Trans>{' '}
-                                    <span className="text-muted-foreground">(Optional)</span>
+                                    <Trans>
+                                      Message{' '}
+                                      <span className="text-muted-foreground">(Optional)</span>
+                                    </Trans>
                                     <Tooltip>
                                       <TooltipTrigger type="button">
                                         <InfoIcon className="mx-2 h-4 w-4" />

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
@@ -687,8 +687,10 @@ export const EnvelopeEditorSettingsDialog = ({
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel>
-                              <Trans>Reply To Email</Trans>{' '}
-                              <span className="text-muted-foreground">(Optional)</span>
+                              <Trans>
+                                Reply To Email{' '}
+                                <span className="text-muted-foreground">(Optional)</span>
+                              </Trans>
                             </FormLabel>
 
                             <FormControl>
@@ -726,8 +728,9 @@ export const EnvelopeEditorSettingsDialog = ({
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel className="flex flex-row items-center">
-                              <Trans>Message</Trans>{' '}
-                              <span className="text-muted-foreground">(Optional)</span>
+                              <Trans>
+                                Message <span className="text-muted-foreground">(Optional)</span>
+                              </Trans>
                               <Tooltip>
                                 <TooltipTrigger>
                                   <InfoIcon className="mx-2 h-4 w-4" />

--- a/packages/ui/primitives/document-flow/add-subject.tsx
+++ b/packages/ui/primitives/document-flow/add-subject.tsx
@@ -257,8 +257,10 @@ export const AddSubjectFormPartial = ({
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>
-                            <Trans>Reply To Email</Trans>{' '}
-                            <span className="text-muted-foreground">(Optional)</span>
+                            <Trans>
+                              Reply To Email{' '}
+                              <span className="text-muted-foreground">(Optional)</span>
+                            </Trans>
                           </FormLabel>
 
                           <FormControl>
@@ -295,8 +297,9 @@ export const AddSubjectFormPartial = ({
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>
-                            <Trans>Subject</Trans>{' '}
-                            <span className="text-muted-foreground">(Optional)</span>
+                            <Trans>
+                              Subject <span className="text-muted-foreground">(Optional)</span>
+                            </Trans>
                           </FormLabel>
 
                           <FormControl>
@@ -313,8 +316,9 @@ export const AddSubjectFormPartial = ({
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel className="flex flex-row items-center">
-                            <Trans>Message</Trans>{' '}
-                            <span className="text-muted-foreground">(Optional)</span>
+                            <Trans>
+                              Message <span className="text-muted-foreground">(Optional)</span>
+                            </Trans>
                             <Tooltip>
                               <TooltipTrigger>
                                 <InfoIcon className="mx-2 h-4 w-4" />

--- a/packages/ui/primitives/template-flow/add-template-settings.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.tsx
@@ -518,8 +518,10 @@ export const AddTemplateSettingsFormPartial = ({
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel>
-                              <Trans>Reply To Email</Trans>{' '}
-                              <span className="text-muted-foreground">(Optional)</span>
+                              <Trans>
+                                Reply To Email{' '}
+                                <span className="text-muted-foreground">(Optional)</span>
+                              </Trans>
                             </FormLabel>
 
                             <FormControl>
@@ -557,8 +559,9 @@ export const AddTemplateSettingsFormPartial = ({
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel className="flex flex-row items-center">
-                              <Trans>Message</Trans>{' '}
-                              <span className="text-muted-foreground">(Optional)</span>
+                              <Trans>
+                                Message <span className="text-muted-foreground">(Optional)</span>
+                              </Trans>
                               <Tooltip>
                                 <TooltipTrigger>
                                   <InfoIcon className="mx-2 h-4 w-4" />


### PR DESCRIPTION
## Description

I marked missing `(Optional)` strings for translation. These parts of strings were left untranslated.

## Changes Made

- Mark strings to translate with `<Trans>` tag

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
