### PR TITLE
fix: use cpu for skia-canvas rendering

### DIFF
--- a/packages/lib/server-only/ai/pdf-to-images.ts
+++ b/packages/lib/server-only/ai/pdf-to-images.ts
@@ -9,7 +9,10 @@ globalThis.Image = Image;
 
 class SkiaCanvasFactory {
   _createCanvas(width: number, height: number) {
-    return new Canvas(width, height);
+    const canvas = new Canvas(width, height);
+    canvas.gpu = false;
+
+    return canvas;
   }
 
   create(width: number, height: number) {
@@ -60,6 +63,8 @@ export const pdfToImages = async (pdfBytes: Uint8Array, options: PdfToImagesOpti
       const viewport = page.getViewport({ scale });
 
       const canvas = new Canvas(viewport.width, viewport.height);
+      canvas.gpu = false;
+
       const canvasContext = canvas.getContext('2d');
 
       await page.render({


### PR DESCRIPTION
Seems there's a memory leak in gpu rendering with skia canvas
where contexts can live for much longer than expected escaping gc cleanup

CPU rendering seems better albeit a bit slower.

Synthetic tests were ran with `--expose-gc` to simulate load over time.
