### PR TITLE
chore: add bundled chromium docker container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,47 @@ jobs:
         env:
           BUILD_PLATFORM: ${{ matrix.os == 'warp-ubuntu-latest-arm64-4x' && 'arm64' || 'amd64' }}
 
+      - name: Build the chromium docker image
+        env:
+          BUILD_PLATFORM: ${{ matrix.os == 'warp-ubuntu-latest-arm64-4x' && 'arm64' || 'amd64' }}
+        run: |
+          APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          GIT_SHA="$(git rev-parse HEAD)"
+
+          docker build \
+            -f ./docker/Dockerfile.chromium \
+            --progress=plain \
+            --build-arg TAG="$GIT_SHA" \
+            -t "documenso/documenso-$BUILD_PLATFORM:latest-chromium" \
+            -t "documenso/documenso-$BUILD_PLATFORM:$GIT_SHA-chromium" \
+            -t "documenso/documenso-$BUILD_PLATFORM:$APP_VERSION-chromium" \
+            -t "ghcr.io/documenso/documenso-$BUILD_PLATFORM:latest-chromium" \
+            -t "ghcr.io/documenso/documenso-$BUILD_PLATFORM:$GIT_SHA-chromium" \
+            -t "ghcr.io/documenso/documenso-$BUILD_PLATFORM:$APP_VERSION-chromium" \
+            .
+
+      - name: Push the chromium docker image to DockerHub
+        env:
+          BUILD_PLATFORM: ${{ matrix.os == 'warp-ubuntu-latest-arm64-4x' && 'arm64' || 'amd64' }}
+        run: |
+          APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          GIT_SHA="$(git rev-parse HEAD)"
+
+          docker push "documenso/documenso-$BUILD_PLATFORM:latest-chromium"
+          docker push "documenso/documenso-$BUILD_PLATFORM:$GIT_SHA-chromium"
+          docker push "documenso/documenso-$BUILD_PLATFORM:$APP_VERSION-chromium" \
+
+      - name: Push the chromium docker image to GitHub Container Registry
+        env:
+          BUILD_PLATFORM: ${{ matrix.os == 'warp-ubuntu-latest-arm64-4x' && 'arm64' || 'amd64' }}
+        run: |
+          APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          GIT_SHA="$(git rev-parse HEAD)"
+
+          docker push "ghcr.io/documenso/documenso-$BUILD_PLATFORM:latest-chromium"
+          docker push "ghcr.io/documenso/documenso-$BUILD_PLATFORM:$GIT_SHA-chromium"
+          docker push "ghcr.io/documenso/documenso-$BUILD_PLATFORM:$APP_VERSION-chromium"
+
   create_and_publish_manifest:
     name: Create and publish manifest
     runs-on: ubuntu-latest
@@ -125,6 +166,43 @@ jobs:
           docker manifest push documenso/documenso:$GIT_SHA
           docker manifest push documenso/documenso:$APP_VERSION
 
+      - name: Create and push DockerHub chromium manifest
+        run: |
+          APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          GIT_SHA="$(git rev-parse HEAD)"
+
+          # Check if the version is stable (no rc or beta in the version)
+          if [[ "$APP_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            docker manifest create \
+              documenso/documenso:latest-chromium \
+              --amend documenso/documenso-amd64:latest-chromium \
+              --amend documenso/documenso-arm64:latest-chromium
+
+            docker manifest push documenso/documenso:latest-chromium
+          fi
+
+          if [[ "$APP_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            docker manifest create \
+              documenso/documenso:rc-chromium \
+              --amend documenso/documenso-amd64:rc-chromium \
+              --amend documenso/documenso-arm64:rc-chromium
+
+            docker manifest push documenso/documenso:rc-chromium
+          fi
+
+          docker manifest create \
+            documenso/documenso:$GIT_SHA-chromium \
+            --amend documenso/documenso-amd64:$GIT_SHA-chromium \
+            --amend documenso/documenso-arm64:$GIT_SHA-chromium
+
+          docker manifest create \
+            documenso/documenso:$APP_VERSION-chromium \
+            --amend documenso/documenso-amd64:$APP_VERSION-chromium \
+            --amend documenso/documenso-arm64:$APP_VERSION-chromium
+
+          docker manifest push documenso/documenso:$GIT_SHA-chromium
+          docker manifest push documenso/documenso:$APP_VERSION-chromium
+
       - name: Create and push Github Container Registry manifest
         run: |
           APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
@@ -161,3 +239,40 @@ jobs:
 
           docker manifest push ghcr.io/documenso/documenso:$GIT_SHA
           docker manifest push ghcr.io/documenso/documenso:$APP_VERSION
+
+      - name: Create and push Github Container Registry chromium manifest
+        run: |
+          APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          GIT_SHA="$(git rev-parse HEAD)"
+
+          # Check if the version is stable (no rc or beta in the version)
+          if [[ "$APP_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            docker manifest create \
+              ghcr.io/documenso/documenso:latest-chromium \
+              --amend ghcr.io/documenso/documenso-amd64:latest-chromium \
+              --amend ghcr.io/documenso/documenso-arm64:latest-chromium
+
+            docker manifest push ghcr.io/documenso/documenso:latest-chromium
+          fi
+
+          if [[ "$APP_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            docker manifest create \
+              ghcr.io/documenso/documenso:rc-chromium \
+              --amend ghcr.io/documenso/documenso-amd64:rc-chromium \
+              --amend ghcr.io/documenso/documenso-arm64:rc-chromium
+
+            docker manifest push ghcr.io/documenso/documenso:rc-chromium
+          fi
+
+          docker manifest create \
+            ghcr.io/documenso/documenso:$GIT_SHA-chromium \
+            --amend ghcr.io/documenso/documenso-amd64:$GIT_SHA-chromium \
+            --amend ghcr.io/documenso/documenso-arm64:$GIT_SHA-chromium
+
+          docker manifest create \
+            ghcr.io/documenso/documenso:$APP_VERSION-chromium \
+            --amend ghcr.io/documenso/documenso-amd64:$APP_VERSION-chromium \
+            --amend ghcr.io/documenso/documenso-arm64:$APP_VERSION-chromium
+
+          docker manifest push ghcr.io/documenso/documenso:$GIT_SHA-chromium
+          docker manifest push ghcr.io/documenso/documenso:$APP_VERSION-chromium

--- a/docker/Dockerfile.chromium
+++ b/docker/Dockerfile.chromium
@@ -1,0 +1,5 @@
+ARG TAG=latest
+FROM documenso/documenso:${TAG}
+
+# Install @playwright/browser-chromium which bundles Playwright + Chromium
+RUN npm install @playwright/browser-chromium


### PR DESCRIPTION
We use playwright + chromium for certificate generation
and other things.

Self-hosters often have an issue with generating certificates
due to the base image not coming with chromium for size purposes.

This adds a new `-chromium` tag to our docker images for downloading
the larger bundled chromium containers.
