### PR TITLE
feat: add validation for API token expiration date

### DIFF
--- a/packages/trpc/server/api-token-router/create-api-token.types.ts
+++ b/packages/trpc/server/api-token-router/create-api-token.types.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 export const ZCreateApiTokenRequestSchema = z.object({
   teamId: z.number(),
   tokenName: z.string().min(3, { message: 'The token name should be 3 characters or longer' }),
-  expirationDate: z.string().nullable(),
+  expirationDate: z
+    .string()
+    .nullable()
+    .refine((val) => val === null || val.length > 0, {
+      message: 'Expiration date must be selected or set to never expire',
+    }),
 });
 
 export const ZCreateApiTokenResponseSchema = z.object({


### PR DESCRIPTION
## Description 
### Context:- "Create API Token" component in the "/settings/tokens" route.
 

Tasks performed:-
- Add frontend validation with form refinement
- Add backend API validation with Zod schema
- Show error message when neither expiration date nor 'never expire' is selected

#### In the "/settings/tokens" route, the create token form's behavior:-
There are some edge cases present in the currrent app:-
1) The token name is validated but the token expiry date is not.
2) when we create a token without selecting token expiry date or without enabling "never expire" toggle, it creates a new token with no expiry.
3) When we create a token, the entire form state is not nulled, rather only the  name is nulled.


#### Now the UX has been improved
New Behaviour:-
1) Both, token name and the expiration date are validated.
2) User sees an error below the field if token expiry date is not selected or the "never expire" switch is not enabled
3) The entire form state  is nulled (reset) after successfully creating a token.
4) The API endpoint is also secured by zod validation.

Attaching a video with explanation:-
[Loom Link](https://www.loom.com/share/29c2c092f22a4eab9bb87bf114ac12b5)



## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have been successful in building the project locally 'npm run build'
- [x] I have followed the project's coding style guidelines.
