### PR TITLE
fix: prevent share dialog from closing when triggered via dropdown

### DIFF
--- a/apps/remix/app/components/general/document/document-page-view-dropdown.tsx
+++ b/apps/remix/app/components/general/document/document-page-view-dropdown.tsx
@@ -51,6 +51,7 @@ export const DocumentPageViewDropdown = ({ envelope }: DocumentPageViewDropdownP
 
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDuplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
 
   const recipient = envelope.recipients.find((recipient) => recipient.email === user.email);
 
@@ -67,9 +68,9 @@ export const DocumentPageViewDropdown = ({ envelope }: DocumentPageViewDropdownP
   const nonSignedRecipients = envelope.recipients.filter((item) => item.signingStatus !== 'SIGNED');
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={isDropdownOpen} onOpenChange={setDropdownOpen}>
       <DropdownMenuTrigger>
-        <MoreHorizontal className="text-muted-foreground h-5 w-5" />
+        <MoreHorizontal className="h-5 w-5 text-muted-foreground" />
       </DropdownMenuTrigger>
 
       <DropdownMenuContent className="w-52" align="end" forceMount>
@@ -148,6 +149,7 @@ export const DocumentPageViewDropdown = ({ envelope }: DocumentPageViewDropdownP
         <DocumentShareButton
           documentId={mapSecondaryIdToDocumentId(envelope.secondaryId)}
           token={isOwner ? undefined : recipient?.token}
+          onDialogClose={() => setDropdownOpen(false)}
           trigger={({ loading, disabled }) => (
             <DropdownMenuItem disabled={disabled || isDraft} onSelect={(e) => e.preventDefault()}>
               <div className="flex items-center">

--- a/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
+++ b/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
@@ -56,6 +56,7 @@ export const DocumentsTableActionDropdown = ({
 
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDuplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
 
   const recipient = row.recipients.find((recipient) => recipient.email === user.email);
 
@@ -74,9 +75,9 @@ export const DocumentsTableActionDropdown = ({
   const nonSignedRecipients = row.recipients.filter((item) => item.signingStatus !== 'SIGNED');
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={isDropdownOpen} onOpenChange={setDropdownOpen}>
       <DropdownMenuTrigger data-testid="document-table-action-btn">
-        <MoreHorizontal className="text-muted-foreground h-5 w-5" />
+        <MoreHorizontal className="h-5 w-5 text-muted-foreground" />
       </DropdownMenuTrigger>
 
       <DropdownMenuContent className="w-52" align="start" forceMount>
@@ -181,6 +182,7 @@ export const DocumentsTableActionDropdown = ({
         <DocumentShareButton
           documentId={row.id}
           token={isOwner ? undefined : recipient?.token}
+          onDialogClose={() => setDropdownOpen(false)}
           trigger={({ loading, disabled }) => (
             <DropdownMenuItem disabled={disabled || isDraft} onSelect={(e) => e.preventDefault()}>
               <div className="flex items-center">

--- a/packages/ui/components/document/document-share-button.tsx
+++ b/packages/ui/components/document/document-share-button.tsx
@@ -133,7 +133,14 @@ export const DocumentShareButton = ({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       {triggerContent ? (
-        <div onClick={() => setIsOpen(true)}>{triggerContent}</div>
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsOpen(true);
+          }}
+        >
+          {triggerContent}
+        </div>
       ) : (
         <DialogTrigger onClick={(e) => e.stopPropagation()} asChild>
           <Button

--- a/packages/ui/components/document/document-share-button.tsx
+++ b/packages/ui/components/document/document-share-button.tsx
@@ -92,6 +92,7 @@ export const DocumentShareButton = ({
     }
 
     setIsOpen(false);
+    onDialogClose?.();
   };
 
   const onTweetClick = async () => {
@@ -121,6 +122,7 @@ export const DocumentShareButton = ({
     );
 
     setIsOpen(false);
+    onDialogClose?.();
   };
 
   const triggerContent = trigger?.({

--- a/packages/ui/components/document/document-share-button.tsx
+++ b/packages/ui/components/document/document-share-button.tsx
@@ -28,6 +28,7 @@ export type DocumentShareButtonProps = HTMLAttributes<HTMLButtonElement> & {
   token?: string;
   documentId: number;
   trigger?: (_props: { loading: boolean; disabled: boolean }) => React.ReactNode;
+  onDialogClose?: () => void;
 };
 
 export const DocumentShareButton = ({
@@ -35,6 +36,7 @@ export const DocumentShareButton = ({
   documentId,
   className,
   trigger,
+  onDialogClose,
 }: DocumentShareButtonProps) => {
   const { _ } = useLingui();
   const { toast } = useToast();
@@ -70,6 +72,10 @@ export const DocumentShareButton = ({
         token,
         documentId,
       });
+    }
+
+    if (!nextOpen) {
+      onDialogClose?.();
     }
 
     setIsOpen(nextOpen);
@@ -117,13 +123,17 @@ export const DocumentShareButton = ({
     setIsOpen(false);
   };
 
+  const triggerContent = trigger?.({
+    disabled: !documentId,
+    loading: isLoading,
+  });
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogTrigger onClick={(e) => e.stopPropagation()} asChild>
-        {trigger?.({
-          disabled: !documentId,
-          loading: isLoading,
-        }) || (
+      {triggerContent ? (
+        <div onClick={() => setIsOpen(true)}>{triggerContent}</div>
+      ) : (
+        <DialogTrigger onClick={(e) => e.stopPropagation()} asChild>
           <Button
             variant="outline"
             disabled={!token || !documentId}
@@ -133,12 +143,12 @@ export const DocumentShareButton = ({
             {!isLoading && <Sparkles className="mr-2 h-5 w-5" />}
             <Trans>Share</Trans>
           </Button>
-        )}
-      </DialogTrigger>
+        </DialogTrigger>
+      )}
 
       <DialogContent position="end">
         <DialogHeader>
-          <DialogTitle>
+          <DialogTitle className="break-words text-lg font-semibold">
             <Trans>Share your signing experience!</Trans>
           </DialogTitle>
 
@@ -166,7 +176,7 @@ export const DocumentShareButton = ({
             </span>
             <div
               className={cn(
-                'bg-muted/40 mt-4 aspect-[1200/630] overflow-hidden rounded-lg border',
+                'mt-4 aspect-[1200/630] overflow-hidden rounded-lg border bg-muted/40',
                 {
                   'animate-pulse': !shareLink?.slug,
                 },


### PR DESCRIPTION
## Description

Fixes an issue where the **“Share Signing Card”** dialog immediately closes when triggered from dropdown menus.  
The dialog now stays open as expected and closes the parent dropdown when the dialog is dismissed.

Additionally, improves the dialog title styling to better handle longer translations.

## Related Issue

- Fixes #2335 

## Changes Made

- Added an optional `onDialogClose` hook in `document-share-button.tsx` and invoked it whenever the dialog closes
- For dropdown-based triggers, kept manual open handling while allowing the dialog to close the parent dropdown via `onDialogClose`
- Preserved existing behavior for the standalone button using `DialogTrigger`
- Wired dropdown parents to close on dialog dismiss in:
  - `documents-table-action-dropdown.tsx`
  - `document-page-view-dropdown.tsx`
- Updated `DialogTitle` styling with `break-words text-lg font-semibold` for improved i18n resilience

## Testing Performed

- Manually opened **“Share Signing Card”** from both dropdown entry points
- Verified the dialog remains open while active and closes the dropdown after dismiss
- Confirmed copy-link and tweet actions close the dialog and then the dropdown
- Ran `npm run build` successfully

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
