### PR TITLE
feat: upgrade alpine and support chromium path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ###########################
 #     BASE CONTAINER      #
 ###########################
-FROM node:22-alpine3.20 AS base
+FROM node:22-alpine3.22 AS base
 
 RUN apk add --no-cache openssl
 RUN apk add --no-cache font-freefont

--- a/packages/lib/server-only/htmltopdf/get-audit-logs-pdf.ts
+++ b/packages/lib/server-only/htmltopdf/get-audit-logs-pdf.ts
@@ -33,7 +33,9 @@ export const getAuditLogsPdf = async ({ documentId, language }: GetAuditLogsPdfO
     // !: Previously we would have to keep the playwright version in sync with the browserless version to avoid errors.
     browser = await chromium.connectOverCDP(browserlessUrl);
   } else {
-    browser = await chromium.launch();
+    browser = await chromium.launch({
+      executablePath: env('PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH') || undefined,
+    });
   }
 
   if (!browser) {

--- a/packages/lib/server-only/htmltopdf/get-certificate-pdf.ts
+++ b/packages/lib/server-only/htmltopdf/get-certificate-pdf.ts
@@ -33,7 +33,9 @@ export const getCertificatePdf = async ({ documentId, language }: GetCertificate
     // !: Previously we would have to keep the playwright version in sync with the browserless version to avoid errors.
     browser = await chromium.connectOverCDP(browserlessUrl);
   } else {
-    browser = await chromium.launch();
+    browser = await chromium.launch({
+      executablePath: env('PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH') || undefined,
+    });
   }
 
   if (!browser) {


### PR DESCRIPTION
## Description

Upgrade alpine to 3.22
Support chromium executable path

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

## Changes Made



## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- Tested on browsers Chrome.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [X] I have tested these changes locally and they work as expected.
- [X] I have added/updated tests that prove the effectiveness of these changes.
- [X] I have updated the documentation to reflect these changes, if applicable.
- [X] I have followed the project's coding style guidelines.
- [X] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
This will make it possible to use manual-installed chromium to generate signing certificate and auditlog in pdf. 
Sample Dockerfile.chromium:
```
ARG TAG=latest
FROM documenso/documenso:${TAG}

USER root
RUN apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont font-noto-emoji
ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
ENV CHROMIUM_USER_FLAGS='--disable-dev-shm-usage --disable-gpu --no-first-run --mute-audio'
USER nodejs
```



