### PR TITLE
fix: ensure cert directory exists before generating PKCS12

### DIFF
--- a/apps/documentation/pages/developers/self-hosting/how-to.mdx
+++ b/apps/documentation/pages/developers/self-hosting/how-to.mdx
@@ -148,6 +148,7 @@ This method avoids file permission issues by creating the certificate directly i
 
    # Generate certificate inside container using environment variable
    docker exec -e CERT_PASS="$CERT_PASS" -it documenso-production-documenso-1 bash -c "
+     mkdir -p /app/certs && \
      openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
        -keyout /tmp/private.key \
        -out /tmp/certificate.crt \


### PR DESCRIPTION
## Description

Ensure the certificate output directory exists before generating the PKCS12 file.
This prevents OpenSSL from failing when `/app/certs` is missing.

## Related Issue

N/A

## Changes Made

- Create `/app/certs` directory before writing `cert.p12`
