### PR TITLE
fix: replace hardcoded #7AC455 with text-documenso-700 token

### DIFF
--- a/apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
+++ b/apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@documenso/ui/primitives/skeleton';
 export default function DocumentEditSkeleton() {
   return (
     <div className="mx-auto -mt-4 flex w-full max-w-screen-xl flex-col px-4 md:px-8">
-      <Link to="/" className="flex grow-0 items-center text-[#7AC455] hover:opacity-80">
+      <Link to="/" className="flex grow-0 items-center text-documenso-700 hover:opacity-80">
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
         <Trans>Documents</Trans>
       </Link>

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id._index.tsx
@@ -100,7 +100,7 @@ export default function DocumentPage({ params }: Route.ComponentProps) {
         <DocumentRecipientLinkCopyDialog recipients={envelope.recipients} />
       )}
 
-      <Link to={documentRootPath} className="flex items-center text-[#7AC455] hover:opacity-80">
+      <Link to={documentRootPath} className="flex items-center text-documenso-700 hover:opacity-80">
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
         <Trans>Documents</Trans>
       </Link>

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.legacy_editor.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.legacy_editor.tsx
@@ -84,7 +84,7 @@ export default function DocumentEditPage() {
 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
-      <Link to={documentRootPath} className="flex items-center text-[#7AC455] hover:opacity-80">
+      <Link to={documentRootPath} className="flex items-center text-documenso-700 hover:opacity-80">
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
         <Trans>Documents</Trans>
       </Link>

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -134,7 +134,7 @@ export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) 
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
       <Link
         to={`${documentRootPath}/${document.envelopeId}`}
-        className="flex items-center text-[#7AC455] hover:opacity-80"
+        className="flex items-center text-documenso-700 hover:opacity-80"
       >
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
         <Trans>Document</Trans>

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.$id._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.$id._index.tsx
@@ -117,7 +117,7 @@ export default function TemplatePage({ params }: Route.ComponentProps) {
 
   return (
     <div className="mx-auto -mt-4 w-full max-w-screen-xl px-4 md:px-8">
-      <Link to={templateRootPath} className="flex items-center text-[#7AC455] hover:opacity-80">
+      <Link to={templateRootPath} className="flex items-center text-documenso-700 hover:opacity-80">
         <ChevronLeft className="mr-2 inline-block h-5 w-5" />
         <Trans>Templates</Trans>
       </Link>

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.$id.legacy_editor.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.$id.legacy_editor.tsx
@@ -61,7 +61,7 @@ export default function TemplateEditPage() {
         <div>
           <Link
             to={`${templateRootPath}/${template.envelopeId}`}
-            className="flex items-center text-[#7AC455] hover:opacity-80"
+            className="flex items-center text-documenso-700 hover:opacity-80"
           >
             <ChevronLeft className="mr-2 inline-block h-5 w-5" />
             <Trans>Template</Trans>


### PR DESCRIPTION
## Summary

Standardizes navigation link colors by replacing hardcoded `#7AC455` hex values with the existing `text-documenso-700` design token.

### Changes

Replaced `text-[#7AC455]` with `text-documenso-700` in 6 files:

- `apps/remix/app/components/general/skeletons/document-edit-skeleton.tsx`
- `apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx`
- `apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.$id._index.tsx`
- `apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates.$id.legacy_editor.tsx`
- `apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.legacy_editor.tsx`
- `apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id._index.tsx`

### Why `text-documenso-700`?

After testing in both light and dark mode, `documenso-700` (#66C622) best preserves the intended visual hierarchy for back navigation links while using the design system.

| Color | Hex | Notes |
|-------|-----|-------|
| Original (hardcoded) | #7AC455 | Deliberately darker than brand default |
| **documenso-700** | #66C622 | ✓ Best match after visual testing |
| documenso-600 | #83DF41 | Too bright |
| documenso (default) | #A2E771 | Brand green, too light for nav |

Closes #2357

---

*Found with [Buoy](https://github.com/buoy-design/buoy) — design system drift detection*