### PR TITLE
fix(api): add take parameter to template search query for pagination

### DIFF
--- a/packages/lib/server-only/template/find-templates.ts
+++ b/packages/lib/server-only/template/find-templates.ts
@@ -79,6 +79,7 @@ export const findTemplates = async ({
         },
       },
       skip: Math.max(page - 1, 0) * perPage,
+      take: perPage,
       orderBy: {
         createdAt: 'desc',
       },


### PR DESCRIPTION
## Description

This PR fixes a bug in the `/api/v2/template` endpoint where the pagination parameter `perPage` was being ignored. Previously, the endpoint would return all matching templates regardless of the requested limit, which could lead to performance issues and incorrect API behavior.

## Related Issue

Fixes #2395

## Changes Made

- Updated [packages/lib/server-only/template/find-templates.ts](cci:7://file:///Users/jorge/dev/documenso/packages/lib/server-only/template/find-templates.ts:0:0-0:0) to include `take: perPage` in the `prisma.envelope.findMany` call. This ensures the database query respects the requested page size.

## Testing Performed

I have verified the changes manually using `curl` against a local instance:

- **Before Fix**: Requesting `perPage=1` returned all 2 templates in the database.
- **After Fix**: Requesting `perPage=1` returns exactly 1 template as expected.
- Verified that `page=2` correctly returns the subsequent results.
- Validated that existing pagination for `/api/v2/envelope` and `/api/v2/document` remains unaffected.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

The response metadata (`perPage`, `totalPages`, etc.) was already correct, but the `data` array contained more items than it should have. This change aligns the `data` length with the metadata.