### PR TITLE
fix: exclude soft-deleted documents from folder count

### DIFF
--- a/packages/lib/server-only/folder/find-folders-internal.ts
+++ b/packages/lib/server-only/folder/find-folders-internal.ts
@@ -66,12 +66,14 @@ export const findFoldersInternal = async ({
               where: {
                 type: EnvelopeType.DOCUMENT,
                 folderId: folder.id,
+                deletedAt: null,
               },
             }),
             prisma.envelope.count({
               where: {
                 type: EnvelopeType.TEMPLATE,
                 folderId: folder.id,
+                deletedAt: null,
               },
             }),
             prisma.folder.count({


### PR DESCRIPTION
## Description

Fixed folder document count incorrectly including soft-deleted documents. When a completed document was deleted (soft-delete), it remained in the folder count because the query didn't filter by `deletedAt`.

## Related Issue

Fixes #2398 

## Changes Made

- Added `deletedAt: null` filter to the document count query in `find-folders-internal.ts`
- Added `deletedAt: null` filter to the template count query in `find-folders-internal.ts`

## Testing Performed

- Reproduced the bug locally:
  1. Created a folder
  2. Added a completed document to the folder
  3. Deleted the document (soft-delete)
  4. Observed folder showing incorrect count (1 document instead of 0)
- Verified the fix works - folder now shows 0 documents after deletion

## Checklist

- [+] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [+] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

The same pattern (`deletedAt: null`) is already used in other query functions like `find-documents.ts` and `search-documents-with-keyword.ts`
