### PR TITLE
fix: make teamId optional in support form validation

### DIFF
--- a/packages/trpc/server/profile-router/router.ts
+++ b/packages/trpc/server/profile-router/router.ts
@@ -90,10 +90,12 @@ export const profileRouter = router({
 
       const parsedTeamId = teamId ? Number(teamId) : null;
 
-      if (Number.isNaN(parsedTeamId)) {
-        throw new AppError(AppErrorCode.INVALID_BODY, {
-          message: 'Invalid team ID provided',
-        });
+      if (typeof parsedTeamId === 'number') {
+        if (Number.isNaN(parsedTeamId) || parsedTeamId <= 0) {
+          throw new AppError(AppErrorCode.INVALID_BODY, {
+            message: 'Invalid team ID provided',
+          });
+        }
       }
 
       return await submitSupportTicket({


### PR DESCRIPTION
The contact form accepts teamId as an optional param based on
where the user clicks "Support" from. Previously, when opened
from a non-team context, the null teamId would be parsed to NaN
and fail validation, causing the form to error out. Now the
validation only runs when a teamId is actually provided.
