### PR TITLE
fix: persist formValues in document creation endpoints

### DIFF
--- a/packages/api/v1/implementation.ts
+++ b/packages/api/v1/implementation.ts
@@ -796,6 +796,7 @@ export const ApiContractV1Implementation = tsr.router(ApiContractV1, {
           title: body.title,
         },
         attachments: body.attachments,
+        formValues: body.formValues,
         requestMetadata: metadata,
       });
 

--- a/packages/trpc/server/document-router/create-document-temporary.ts
+++ b/packages/trpc/server/document-router/create-document-temporary.ts
@@ -38,6 +38,7 @@ export const createDocumentTemporaryRoute = authenticatedProcedure
       meta,
       folderId,
       attachments,
+      formValues,
     } = input;
 
     const { remaining } = await getServerLimits({ userId: user.id, teamId });
@@ -68,6 +69,7 @@ export const createDocumentTemporaryRoute = authenticatedProcedure
         title,
         externalId,
         visibility,
+        formValues,
         globalAccessAuth,
         globalActionAuth,
         recipients: (recipients || []).map((recipient) => ({

--- a/packages/trpc/server/document-router/create-document-temporary.types.ts
+++ b/packages/trpc/server/document-router/create-document-temporary.types.ts
@@ -27,6 +27,7 @@ import {
 
 /**
  * Temporariy endpoint for V2 Beta until we allow passthrough documents on create.
+ * @deprecated
  */
 export const createDocumentTemporaryMeta: TrpcRouteMeta = {
   openapi: {
@@ -36,6 +37,7 @@ export const createDocumentTemporaryMeta: TrpcRouteMeta = {
     description:
       'You will need to upload the PDF to the provided URL returned. Note: Once V2 API is released, this will be removed since we will allow direct uploads, instead of using an upload URL.',
     tags: ['Document'],
+    deprecated: true,
   },
 };
 

--- a/packages/trpc/server/document-router/create-document.ts
+++ b/packages/trpc/server/document-router/create-document.ts
@@ -78,6 +78,7 @@ export const createDocumentRoute = authenticatedProcedure
         visibility,
         globalAccessAuth,
         globalActionAuth,
+        formValues,
         recipients: (recipients || []).map((recipient) => ({
           ...recipient,
           fields: (recipient.fields || []).map((field) => ({


### PR DESCRIPTION
formValues were not being passed through in the API v1 implementation,
create-document, and create-document-temporary routes, causing the
document completed webhook to return empty formValues.
