### PR TITLE
fix: allow past due subscriptions

### DIFF
--- a/packages/ee/server-only/limits/server.ts
+++ b/packages/ee/server-only/limits/server.ts
@@ -70,7 +70,7 @@ export const getServerLimits = async ({
   }
 
   // Early return for users with an expired subscription.
-  if (subscription && subscription.status !== SubscriptionStatus.ACTIVE) {
+  if (subscription && subscription.status === SubscriptionStatus.INACTIVE) {
     return {
       quota: INACTIVE_PLAN_LIMITS,
       remaining: INACTIVE_PLAN_LIMITS,


### PR DESCRIPTION
## Description

Allow plans with past_due subscriptions to continue to use the platform until the subscription becomes inactive.