### PR TITLE
fix: checkbox states not showing in signed PDF for legacy uploads

### DIFF
--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -388,6 +388,11 @@ const decorateAndSignPdf = async ({
       }
     }
 
+    // Flatten the form to bake checkbox/radio appearances into the PDF content
+    // This ensures proper rendering when the PDF is processed by libpdf
+    const form = legacy_pdfLibDoc.getForm();
+    form.flatten();
+
     await pdfDoc.reload(await legacy_pdfLibDoc.save());
   }
 


### PR DESCRIPTION
Flatten the pdf-lib form before saving to bake checkbox/radio appearances into the PDF content. This ensures checked states are preserved when the PDF is subsequently processed by libpdf for final signing.

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
