### PR TITLE
fix: flatten pdf-lib form fields before sealing document

### DIFF
--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -388,6 +388,10 @@ const decorateAndSignPdf = async ({
       }
     }
 
+    // Should never run into issues with this flatten since all
+    // arcoFields are created by pdf-lib itself.
+    legacy_pdfLibDoc.getForm().flatten();
+
     await pdfDoc.reload(await legacy_pdfLibDoc.save());
   }
 


### PR DESCRIPTION
## Summary

- Fixes checkbox fields not displaying correctly in sealed documents by calling `flatten()` on the pdf-lib form before saving
- This ensures checkbox appearances are correctly generated at flatten time rather than relying on viewer rendering

## Problem

Checkboxes weren't flattening correctly because pdf-lib wasn't generating the correct appearances until flatten time. Without explicitly calling `flatten()`, the checkbox visual state wasn't being baked into the PDF.

## Solution

Added a `flatten()` call on the pdf-lib form after all fields are populated, ensuring appearances are properly generated before the document is saved and sealed.