### PR TITLE
fix(i18n): add localization context to dialog messages

### DIFF
--- a/apps/remix/app/components/dialogs/organisation-group-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-group-delete-dialog.tsx
@@ -77,7 +77,7 @@ export const OrganisationGroupDeleteDialog = ({
           </DialogTitle>
 
           <DialogDescription className="mt-4">
-            <Trans>
+            <Trans context="Removing group from organisation">
               You are about to remove the following group from{' '}
               <span className="font-semibold">{organisation.name}</span>.
             </Trans>

--- a/apps/remix/app/components/dialogs/team-group-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-group-delete-dialog.tsx
@@ -81,7 +81,7 @@ export const TeamGroupDeleteDialog = ({
           </DialogTitle>
 
           <DialogDescription className="mt-4">
-            <Trans>
+            <Trans context="Removing group from team">
               You are about to remove the following group from{' '}
               <span className="font-semibold">{team.name}</span>.
             </Trans>


### PR DESCRIPTION
## Description
In web.po file you can find:
```
#. placeholder {0}: organisation.name
#. placeholder {0}: team.name
#: apps/remix/app/components/dialogs/organisation-group-delete-dialog.tsx
#: apps/remix/app/components/dialogs/team-group-delete-dialog.tsx
msgid "You are about to remove the following group from <0>{0}</0>."
```
This combined message needs different context for each case. In some languages, translators need to adjust gender form or add `...group from team <0>{0}</0>` or `...group from organisation <0>{0}</0>`to get correct grammatical form. 

After my changes, the final web.po entries are separated:
```
#. placeholder {0}: organisation.name
#: apps/remix/app/components/dialogs/organisation-group-delete-dialog.tsx
msgctxt "Removing group from organisation"
msgid "You are about to remove the following group from <0>{0}</0>."
```

```
#. placeholder {0}: team.name
#: apps/remix/app/components/dialogs/team-group-delete-dialog.tsx
msgctxt "Removing group from team"
msgid "You are about to remove the following group from <0>{0}</0>."
```

Translators have the best opportunity to adapt sentences.

## Changes Made

- Add context to `<Trans>` tags

## Testing Performed

- Run build
- Review web.po file

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.