### PR TITLE
chore(i18n): add context to ambiguous message

### DIFF
--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.public-profile.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.public-profile.tsx
@@ -207,7 +207,9 @@ export default function PublicProfilePage({ loaderData }: Route.ComponentProps) 
             directTemplates={enabledPrivateDirectTemplates}
             trigger={
               <Button variant="outline">
-                <Trans>Link template</Trans>
+                <Trans context="Action button to link template to public profile">
+                  Link template
+                </Trans>
               </Button>
             }
           />


### PR DESCRIPTION
## Description

`<Trans>Link template</Trans>`

This message is ambiguous. Translator could read it as:

1. Link (noun) of template
2. Action to link (verb) template

Even Crowdin AI translator translated it in the wrong way. I added context to solve it.

## Changes Made

- Added context to message

## Testing Performed

- Run build
- Check web.po file

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.