### PR TITLE
fix: guard send dialogs against org claim races

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
@@ -82,6 +82,7 @@ export const EnvelopeDistributeDialog = ({
   onDistribute,
 }: EnvelopeDistributeDialogProps) => {
   const organisation = useCurrentOrganisation();
+  const hasOrganisationEmailDomains = Boolean(organisation.organisationClaim?.flags.emailDomains);
 
   const { envelope, syncEnvelope, isAutosaving, autosaveError } = useCurrentEnvelopeEditor();
 
@@ -116,10 +117,15 @@ export const EnvelopeDistributeDialog = ({
   } = form;
 
   const { data: emailData, isLoading: isLoadingEmails } =
-    trpc.enterprise.organisation.email.find.useQuery({
-      organisationId: organisation.id,
-      perPage: 100,
-    });
+    trpc.enterprise.organisation.email.find.useQuery(
+      {
+        organisationId: organisation.id,
+        perPage: 100,
+      },
+      {
+        enabled: isOpen && hasOrganisationEmailDomains,
+      },
+    );
 
   const emails = emailData?.data || [];
 
@@ -268,7 +274,7 @@ export const EnvelopeDistributeDialog = ({
 
                 <div
                   className={cn('min-h-72', {
-                    'min-h-[23rem]': organisation.organisationClaim.flags.emailDomains,
+                    'min-h-[23rem]': hasOrganisationEmailDomains,
                   })}
                 >
                   <AnimatePresence initial={false} mode="wait">
@@ -293,7 +299,7 @@ export const EnvelopeDistributeDialog = ({
                             className="mt-2 flex flex-col gap-y-4 rounded-lg"
                             disabled={form.formState.isSubmitting}
                           >
-                            {organisation.organisationClaim.flags.emailDomains && (
+                            {hasOrganisationEmailDomains && (
                               <FormField
                                 control={form.control}
                                 name="meta.emailId"

--- a/packages/ui/primitives/document-flow/add-subject.tsx
+++ b/packages/ui/primitives/document-flow/add-subject.tsx
@@ -79,6 +79,7 @@ export const AddSubjectFormPartial = ({
   const { _ } = useLingui();
 
   const organisation = useCurrentOrganisation();
+  const hasOrganisationEmailDomains = Boolean(organisation.organisationClaim?.flags.emailDomains);
 
   const form = useForm<TAddSubjectFormSchema>({
     defaultValues: {
@@ -106,10 +107,15 @@ export const AddSubjectFormPartial = ({
   } = form;
 
   const { data: emailData, isLoading: isLoadingEmails } =
-    trpc.enterprise.organisation.email.find.useQuery({
-      organisationId: organisation.id,
-      perPage: 100,
-    });
+    trpc.enterprise.organisation.email.find.useQuery(
+      {
+        organisationId: organisation.id,
+        perPage: 100,
+      },
+      {
+        enabled: hasOrganisationEmailDomains,
+      },
+    );
 
   const emails = emailData?.data || [];
 
@@ -212,7 +218,7 @@ export const AddSubjectFormPartial = ({
                     className="flex flex-col gap-y-4 rounded-lg border p-4"
                     disabled={form.formState.isSubmitting}
                   >
-                    {organisation.organisationClaim.flags.emailDomains && (
+                    {hasOrganisationEmailDomains && (
                       <FormField
                         control={form.control}
                         name="meta.emailId"


### PR DESCRIPTION
## Description
Fix intermittent 500 errors when opening send flows before organisation claim data is fully available.

## Changes Made
- Guard org email-domain checks in the modern send dialog to avoid null-access during first render.
- Apply the same guard and conditional sender-email lookup in the legacy editor

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.