### PR TITLE
fix: envelope editor flush race condition

### DIFF
--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
@@ -458,7 +458,6 @@ export default function EnvelopeEditorFieldsPageRenderer() {
     const fieldGroups = nodes.filter(
       (node) =>
         node.hasName('field-group') && Boolean(node.getStage()) && Boolean(node.getParent()),
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     ) as Konva.Group[];
 
     interactiveTransformer.current?.nodes(fieldGroups);


### PR DESCRIPTION
## Description

Fixes a race condition in the envelope editor when opening "Send Document" immediately after moving/resizing a selected field

Replication
1. Move or resize a field (do not blur the selector/quickbar that appears when a field is selected)
2. Directly click the "Send Document" dialog
3. Error appears

Note: Step 2 needs to happen relatively fast after step 1 since this is a race against the flush debouncer