### PR TITLE
fix(recipient): relax search output validation to prevent 500 crash

### DIFF
--- a/packages/trpc/server/recipient-router/find-recipient-suggestions.types.ts
+++ b/packages/trpc/server/recipient-router/find-recipient-suggestions.types.ts
@@ -8,7 +8,7 @@ export const ZGetRecipientSuggestionsResponseSchema = z.object({
   results: z.array(
     z.object({
       name: z.string().nullable(),
-      email: z.string().email(),
+      email: z.string(),
     }),
   ),
 });


### PR DESCRIPTION
## Description

This PR fixes a critical **500 Internal Server Error** that occurs when searching for recipients with draft or non-standard email formats. It ensures that the autocomplete functionality remains stable even when encountering placeholder data in the database.

## Related Issue

Fixes #2486

## Changes Made

* **Relaxed Output Validation**: Updated the `ZGetRecipientSuggestionsResponseSchema` in `find-recipient-suggestions.types.ts` by changing the `email` field validation from `z.string().email()` to `z.string()`.
* **Reasoning**: Since the application allows creating recipients with draft/placeholder emails (by design), enforcing strict email validation on the search output causes a crash when those records are retrieved.

## Testing Performed

* **Production Reproduction**: Verified the 500 error on `app.documenso.com` using the search query "new" and "test".
* **Local Validation**: Confirmed that after relaxing the Zod schema, the search returns results correctly (200 OK) even for recipients with placeholder emails.
* **Regression**: Ensured other recipient fields (name, id) are still mapped correctly.

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

The crash was a direct result of an inconsistency between the liberal input validation (allowing draft emails) and the strict output validation in the search router. This fix aligns the search API with the existing product behavior.
