### PR TITLE
fix: strip diacritics from team URL slug generation

### DIFF
--- a/apps/remix/app/components/dialogs/team-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/team-create-dialog.tsx
@@ -127,7 +127,11 @@ export const TeamCreateDialog = ({ trigger, onCreated, ...props }: TeamCreateDia
   };
 
   const mapTextToUrl = (text: string) => {
-    return text.toLowerCase().replace(/\s+/g, '-');
+    return text
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/\s+/g, '-');
   };
 
   const dialogState = useMemo(() => {
@@ -260,7 +264,7 @@ export const TeamCreateDialog = ({ trigger, onCreated, ...props }: TeamCreateDia
                         <Input className="bg-background" {...field} />
                       </FormControl>
                       {!form.formState.errors.teamUrl && (
-                        <span className="text-foreground/50 text-xs font-normal">
+                        <span className="text-xs font-normal text-foreground/50">
                           {field.value ? (
                             `${NEXT_PUBLIC_WEBAPP_URL()}/t/${field.value}`
                           ) : (
@@ -288,7 +292,7 @@ export const TeamCreateDialog = ({ trigger, onCreated, ...props }: TeamCreateDia
                           />
 
                           <label
-                            className="text-muted-foreground ml-2 text-sm"
+                            className="ml-2 text-sm text-muted-foreground"
                             htmlFor="inherit-members"
                           >
                             <Trans>Allow all organisation members to access this team</Trans>


### PR DESCRIPTION
## Description

When creating a team with accented characters in the name (e.g. "Développement", "Ström"), the auto-generated Team URL slug retains diacritical marks. Since the Team URL validator only allows letters, numbers, dashes, and underscores, this causes validation to fail — making it impossible to create teams with accented names.
This PR adds Unicode NFD normalization to the mapTextToUrl function in TeamCreateDialog.tsx to strip diacritical marks before lowercasing and replacing spaces.

## Related Issue

Fixes #[2466](https://github.com/documenso/documenso/issues/2466)

## Changes Made

1. Added .normalize('NFD') to decompose accented characters into their base letter + combining accent mark
2. Added .replace(/[\u0300-\u036f]/g, '') to remove the combining diacritical marks, leaving only ASCII base characters
3. Both steps are applied before the existing .toLowerCase() and .replace(/\s+/g, '-') transformations

## Testing Performed

- Tested team creation with Ström — URL field now correctly generates strom instead of ström
- Tested with Développement — generates developpement
- Tested with Équipe Générale — generates equipe-generale
- Tested with São Paulo — generates sao-paulo
- Tested with naïve — generates naive
- Tested with non-accented names like Engineering — no change in behavior
- Verified that the Team URL validation passes after the fix and teams can be created successfully

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

The fix is a single function change in mapTextToUrl. The approach uses the standard String.normalize('NFD') method which decomposes characters like é into e + a combining acute accent, then strips all combining marks via regex. This covers French, Spanish, German, Portuguese, Nordic, and other Latin-script diacritics.
