### PR TITLE
fix(web): prevent long public template descriptions from hiding actions

### DIFF
--- a/apps/remix/app/components/tables/settings-public-profile-templates-table.tsx
+++ b/apps/remix/app/components/tables/settings-public-profile-templates-table.tsx
@@ -135,20 +135,22 @@ export const SettingsPublicProfileTemplatesTable = () => {
             key={template.id}
             className="bg-background flex items-center justify-between gap-x-6 p-4"
           >
-            <div className="flex gap-x-2">
+            <div className="flex min-w-0 gap-x-2">
               <FileIcon
                 className="text-muted-foreground/40 h-8 w-8 flex-shrink-0"
                 strokeWidth={1.5}
               />
 
-              <div>
-                <p className="text-sm">{template.publicTitle}</p>
-                <p className="text-xs text-neutral-400">{template.publicDescription}</p>
+              <div className="min-w-0">
+                <p className="truncate text-sm">{template.publicTitle}</p>
+                <p className="line-clamp-3 break-words text-xs text-neutral-400">
+                  {template.publicDescription}
+                </p>
               </div>
             </div>
 
             <DropdownMenu>
-              <DropdownMenuTrigger>
+              <DropdownMenuTrigger className="flex-shrink-0">
                 <MoreHorizontalIcon className="text-muted-foreground h-5 w-5" />
               </DropdownMenuTrigger>
 

--- a/apps/remix/app/routes/_profile+/p.$url.tsx
+++ b/apps/remix/app/routes/_profile+/p.$url.tsx
@@ -174,12 +174,12 @@ export default function PublicProfilePage({ loaderData }: Route.ComponentProps) 
                         strokeWidth={1.5}
                       />
 
-                      <div className="flex flex-1 flex-col gap-4 overflow-hidden md:flex-row md:items-start md:justify-between">
-                        <div>
+                      <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-hidden md:flex-row md:items-start md:justify-between">
+                        <div className="min-w-0">
                           <p className="text-foreground text-sm font-semibold leading-none">
                             {template.publicTitle}
                           </p>
-                          <p className="text-muted-foreground mt-1 line-clamp-3 max-w-[70ch] whitespace-normal text-xs">
+                          <p className="text-muted-foreground mt-1 line-clamp-3 max-w-[70ch] break-words whitespace-normal text-xs">
                             {template.publicDescription}
                           </p>
                         </div>


### PR DESCRIPTION
Fixes #2472.

- Prevent long/unbroken public template titles/descriptions from pushing or clipping the action menu in settings.
- Apply the same overflow-safe styles on the public profile template list so the Sign button stays visible.