### PR TITLE
fix: use instance-specific emails for service accounts

### DIFF
--- a/apps/remix/server/router.ts
+++ b/apps/remix/server/router.ts
@@ -12,6 +12,8 @@ import { API_V2_BETA_URL, API_V2_URL } from '@documenso/lib/constants/app';
 import { jobsClient } from '@documenso/lib/jobs/client';
 import { LicenseClient } from '@documenso/lib/server-only/license/license-client';
 import { TelemetryClient } from '@documenso/lib/server-only/telemetry/telemetry-client';
+import { migrateDeletedAccountServiceAccount } from '@documenso/lib/server-only/user/service-accounts/deleted-account';
+import { migrateLegacyServiceAccount } from '@documenso/lib/server-only/user/service-accounts/legacy-service-account';
 import { getIpAddress } from '@documenso/lib/universal/get-ip-address';
 import { env } from '@documenso/lib/utils/env';
 import { logger } from '@documenso/lib/utils/logger';
@@ -143,5 +145,8 @@ if (env('NODE_ENV') !== 'development') {
 
 // Start license client to verify license on startup.
 void LicenseClient.start();
+
+void migrateDeletedAccountServiceAccount();
+void migrateLegacyServiceAccount();
 
 export default app;

--- a/packages/auth/server/routes/passkey.ts
+++ b/packages/auth/server/routes/passkey.ts
@@ -5,6 +5,8 @@ import { isoBase64URL } from '@simplewebauthn/server/helpers';
 import { Hono } from 'hono';
 
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { deletedServiceAccountEmail } from '@documenso/lib/server-only/user/service-accounts/deleted-account';
+import { legacyServiceAccountEmail } from '@documenso/lib/server-only/user/service-accounts/legacy-service-account';
 import type { TAuthenticationResponseJSONSchema } from '@documenso/lib/types/webauthn';
 import { ZAuthenticationResponseJSONSchema } from '@documenso/lib/types/webauthn';
 import { getAuthenticatorOptions } from '@documenso/lib/utils/authenticator';
@@ -73,6 +75,13 @@ export const passkeyRoute = new Hono<HonoAuthContext>()
     }
 
     const user = passkey.user;
+
+    if (
+      user.email.toLowerCase() === legacyServiceAccountEmail() ||
+      user.email.toLowerCase() === deletedServiceAccountEmail()
+    ) {
+      return c.text('FORBIDDEN', 403);
+    }
 
     const { rpId, origin } = getAuthenticatorOptions();
 

--- a/packages/lib/constants/email.ts
+++ b/packages/lib/constants/email.ts
@@ -8,8 +8,6 @@ export const DOCUMENSO_INTERNAL_EMAIL = {
   address: FROM_ADDRESS,
 };
 
-export const SERVICE_USER_EMAIL = 'serviceaccount@documenso.com';
-
 export const EMAIL_VERIFICATION_STATE = {
   NOT_FOUND: 'NOT_FOUND',
   VERIFIED: 'VERIFIED',

--- a/packages/lib/server-only/user/get-user-by-reset-token.ts
+++ b/packages/lib/server-only/user/get-user-by-reset-token.ts
@@ -1,0 +1,24 @@
+import { prisma } from '@documenso/prisma';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+
+export interface GetUserByResetTokenOptions {
+  token: string;
+}
+
+export const getUserByResetToken = async ({ token }: GetUserByResetTokenOptions) => {
+  const result = await prisma.passwordResetToken.findFirst({
+    where: {
+      token,
+    },
+    include: {
+      user: true,
+    },
+  });
+
+  if (!result || !result.user) {
+    throw new AppError(AppErrorCode.NOT_FOUND);
+  }
+
+  return result.user;
+};

--- a/packages/lib/server-only/user/service-accounts/legacy-service-account.ts
+++ b/packages/lib/server-only/user/service-accounts/legacy-service-account.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@documenso/prisma';
+
+const LEGACY_SERVICE_ACCOUNT_EMAIL = 'serviceaccount@documenso.com';
+
+export const legacyServiceAccountEmail = () => {
+  try {
+    // eslint-disable-next-line turbo/no-undeclared-env-vars
+    if (process.env.NEXT_PRIVATE_LEGACY_SERVICE_ACCOUNT_EMAIL) {
+      // eslint-disable-next-line turbo/no-undeclared-env-vars
+      return process.env.NEXT_PRIVATE_LEGACY_SERVICE_ACCOUNT_EMAIL;
+    }
+
+    const { hostname } = new URL(process.env.NEXT_PUBLIC_WEBAPP_URL || 'http://localhost:3000');
+
+    return `serviceaccount@${hostname}`;
+  } catch (error) {
+    return LEGACY_SERVICE_ACCOUNT_EMAIL;
+  }
+};
+
+export const migrateLegacyServiceAccount = async () => {
+  if (legacyServiceAccountEmail() !== LEGACY_SERVICE_ACCOUNT_EMAIL) {
+    console.log(`Migrating legacy service account to new email: ${legacyServiceAccountEmail()}`);
+
+    await prisma.user.updateMany({
+      where: {
+        email: LEGACY_SERVICE_ACCOUNT_EMAIL,
+      },
+      data: {
+        email: legacyServiceAccountEmail(),
+      },
+    });
+  }
+};


### PR DESCRIPTION
## Summary

- Service account emails (`deleted-account@...` and `serviceaccount@...`) are now derived from the instance's `NEXT_PUBLIC_WEBAPP_URL` hostname instead of being hardcoded to `@documenso.com`. This ensures each self-hosted deployment uses its own unique service account emails.
- Existing service accounts are automatically migrated to the new email format on startup.
- All auth flows (email/password, passkey, OAuth) now block login attempts against service account emails.

## Details

Previously, service accounts used hardcoded `@documenso.com` email addresses across all deployments. Self-hosted instances rightfully raised concerns about this in #2501 — service accounts should belong to the instance, not to an external domain.

### How it works

1. **Email derivation**: Service account emails are now derived from the app's hostname (e.g., `deleted-account@your-instance.com`, `serviceaccount@your-instance.com`).
2. **Env var overrides**: Can be explicitly set via `NEXT_PRIVATE_DELETED_SERVICE_ACCOUNT_EMAIL` and `NEXT_PRIVATE_LEGACY_SERVICE_ACCOUNT_EMAIL` if needed.
3. **Auto-migration**: On startup, any existing service accounts with the old `@documenso.com` emails are migrated to the new hostname-derived addresses.
4. **Auth hardening**: Service account emails are blocked from all authentication flows (sign-in, sign-up, forgot password, reset password, passkey, OAuth) to prevent misuse.

### Files changed

| File | Change |
|------|--------|
| `packages/lib/server-only/user/service-accounts/deleted-account.ts` | Derive email from hostname, add migration |
| `packages/lib/server-only/user/service-accounts/legacy-service-account.ts` | New — same pattern for the legacy service account |
| `packages/lib/server-only/user/get-user-by-reset-token.ts` | New — helper to look up user by reset token before allowing password reset |
| `packages/lib/constants/email.ts` | Remove old hardcoded `SERVICE_USER_EMAIL` |
| `packages/auth/server/routes/email-password.ts` | Block service account emails in sign-in, forgot-password, reset-password |
| `packages/auth/server/routes/passkey.ts` | Block service account emails in passkey auth |
| `packages/auth/server/lib/utils/handle-oauth-callback-url.ts` | Block service account emails in OAuth |
| `apps/remix/server/router.ts` | Run migrations on startup |

Closes #2501