### PR TITLE
fix: v2 embed direct templates not reading email/lockEmail from hash params

### DIFF
--- a/apps/remix/app/components/embed/embed-document-signing-page-v2.tsx
+++ b/apps/remix/app/components/embed/embed-document-signing-page-v2.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useState } from 'react';
 
 import { useLingui } from '@lingui/react';
+import { EnvelopeType } from '@prisma/client';
 
 import { mapSecondaryIdToDocumentId } from '@documenso/lib/utils/envelope';
 
@@ -25,7 +26,7 @@ export const EmbedSignDocumentV2ClientPage = ({
 }: EmbedSignDocumentV2ClientPageProps) => {
   const { _ } = useLingui();
 
-  const { envelope, recipient, envelopeData, setFullName, fullName } =
+  const { envelope, recipient, envelopeData, setFullName, setEmail, fullName } =
     useRequiredEnvelopeSigningContext();
 
   const { isCompleted, isRejected, recipientSignature } = envelopeData;
@@ -35,6 +36,7 @@ export const EmbedSignDocumentV2ClientPage = ({
   const [hasFinishedInit, setHasFinishedInit] = useState(false);
   const [allowDocumentRejection, setAllowDocumentRejection] = useState(false);
   const [isNameLocked, setIsNameLocked] = useState(false);
+  const [isEmailLocked, setIsEmailLocked] = useState(envelope.type === EnvelopeType.DOCUMENT);
 
   const onDocumentCompleted = (data: {
     token: string;
@@ -132,6 +134,17 @@ export const EmbedSignDocumentV2ClientPage = ({
       // Since a recipient can be provided a name we can lock it without requiring
       // a to be provided by the parent application, unlike direct templates.
       setIsNameLocked(!!data.lockName);
+
+      if (envelope.type === EnvelopeType.TEMPLATE) {
+        if (!isCompleted && data.email) {
+          setEmail(data.email);
+        }
+
+        if (data.email) {
+          setIsEmailLocked(!!data.lockEmail);
+        }
+      }
+
       setAllowDocumentRejection(!!data.allowDocumentRejection);
 
       if (data.darkModeDisabled) {
@@ -213,6 +226,7 @@ export const EmbedSignDocumentV2ClientPage = ({
   return (
     <EmbedSigningProvider
       isNameLocked={isNameLocked}
+      isEmailLocked={isEmailLocked}
       hidePoweredBy={hidePoweredBy}
       allowDocumentRejection={allowDocumentRejection}
       onDocumentCompleted={onDocumentCompleted}


### PR DESCRIPTION
## Summary

The v2 signing page (`EmbedSignDocumentV2ClientPage`) wasn't reading `email` or `lockEmail` from the embed hash params for direct template flows. This meant:

- The email passed by the embed SDK was silently ignored, so the completion dialog always showed an empty email field
- Since `isEmailLocked` was never explicitly passed to the `EmbedSigningProvider`, it defaulted to `true` — so as soon as a user typed a single character the field locked, leaving them stuck with an invalid email and no way to complete signing

Reported externally and tracked in #2258.

## Changes

- Read `email` and `lockEmail` from hash params for `TEMPLATE` type envelopes and apply them to state
- Pass `isEmailLocked` through to `EmbedSigningProvider`
- Default `isEmailLocked` to `true` for `DOCUMENT` types (email is server-provided) and `false` for `TEMPLATE` types (email comes from the embed hash)