### PR TITLE
fix(i18n): mark strings inside div for translation

### DIFF
--- a/apps/remix/app/components/general/billing-plans.tsx
+++ b/apps/remix/app/components/general/billing-plans.tsx
@@ -118,7 +118,9 @@ export const BillingPlans = ({ plans }: BillingPlansProps) => {
 
                 {price.product.features && price.product.features.length > 0 && (
                   <div className="mt-4 text-muted-foreground">
-                    <div className="text-sm font-medium">Includes:</div>
+                    <div className="text-sm font-medium">
+                      <Trans>Includes:</Trans>
+                    </div>
 
                     <ul className="mt-1 divide-y text-sm">
                       {price.product.features.map((feature, index) => (

--- a/apps/remix/app/components/general/user-profile-skeleton.tsx
+++ b/apps/remix/app/components/general/user-profile-skeleton.tsx
@@ -51,7 +51,7 @@ export const UserProfileSkeleton = ({ className, user, rows = 2 }: UserProfileSk
       <div className="mt-8 w-full">
         <div className="dark:divide-foreground/30 dark:border-foreground/30 divide-y-2 divide-neutral-200 overflow-hidden rounded-lg border-2 border-neutral-200">
           <div className="text-muted-foreground dark:bg-foreground/20 bg-neutral-50 p-4 font-medium">
-            Documents
+            <Trans>Documents</Trans>
           </div>
 
           {Array(rows)

--- a/apps/remix/app/routes/embed+/_v0+/_layout.tsx
+++ b/apps/remix/app/routes/embed+/_v0+/_layout.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@lingui/react/macro';
 import { Outlet, isRouteErrorResponse, useRouteError } from 'react-router';
 
 import {
@@ -89,5 +90,9 @@ export function ErrorBoundary({ loaderData }: Route.ErrorBoundaryProps) {
     }
   }
 
-  return <div>Not Found</div>;
+  return (
+    <div>
+      <Trans>Not Found</Trans>
+    </div>
+  );
 }

--- a/apps/remix/app/routes/embed+/v1+/authoring+/_layout.tsx
+++ b/apps/remix/app/routes/embed+/v1+/authoring+/_layout.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect } from 'react';
 
+import { Trans } from '@lingui/react/macro';
 import { Outlet, useLoaderData } from 'react-router';
 
 import { verifyEmbeddingPresignToken } from '@documenso/lib/server-only/embedding-presign/verify-embedding-presign-token';
@@ -75,7 +76,11 @@ export default function AuthoringLayout() {
   }, []);
 
   if (!hasValidToken) {
-    return <div>Invalid embedding presign token provided</div>;
+    return (
+      <div>
+        <Trans>Invalid embedding presign token provided</Trans>
+      </div>
+    );
   }
 
   return (

--- a/packages/ui/components/pdf-viewer/pdf-viewer-konva-lazy.tsx
+++ b/packages/ui/components/pdf-viewer/pdf-viewer-konva-lazy.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 
+import { Trans } from '@lingui/react/macro';
 import { type PDFDocumentProxy } from 'pdfjs-dist';
 
 import type { PdfViewerRendererMode } from './pdf-viewer-konva';
@@ -17,7 +18,13 @@ const EnvelopePdfViewer = lazy(async () => import('./pdf-viewer-konva'));
 
 export const PDFViewerKonvaLazy = (props: PDFViewerProps) => {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense
+      fallback={
+        <div>
+          <Trans>Loading...</Trans>
+        </div>
+      }
+    >
       <EnvelopePdfViewer {...props} />
     </Suspense>
   );

--- a/packages/ui/primitives/pdf-viewer/lazy.tsx
+++ b/packages/ui/primitives/pdf-viewer/lazy.tsx
@@ -1,7 +1,19 @@
 import { ClientOnly } from '../../components/client-only';
 
+import { Trans } from '@lingui/react/macro';
+
 import { PDFViewer, type PDFViewerProps } from './base.client';
 
 export const PDFViewerLazy = (props: PDFViewerProps) => {
-  return <ClientOnly fallback={<div>Loading...</div>}>{() => <PDFViewer {...props} />}</ClientOnly>;
+  return (
+    <ClientOnly
+      fallback={
+        <div>
+          <Trans>Loading...</Trans>
+        </div>
+      }
+    >
+      {() => <PDFViewer {...props} />}
+    </ClientOnly>
+  );
 };


### PR DESCRIPTION
## Description

I marked missing strings inside div for translation.

## Changes Made

- Mark strings to translate

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.