### PR TITLE
fix(i18n): mark SUBSCRIPTION_STATUS_MAP for translation

### DIFF
--- a/apps/remix/app/components/tables/admin-organisations-table.tsx
+++ b/apps/remix/app/components/tables/admin-organisations-table.tsx
@@ -131,7 +131,7 @@ export const AdminOrganisationsTable = ({
               target="_blank"
               className="flex flex-row items-center gap-2"
             >
-              {SUBSCRIPTION_STATUS_MAP[row.original.subscription.status]}
+              {i18n._(SUBSCRIPTION_STATUS_MAP[row.original.subscription.status])}
               <ExternalLinkIcon className="h-4 w-4" />
             </Link>
           ) : (
@@ -177,7 +177,7 @@ export const AdminOrganisationsTable = ({
         ),
       },
     ] satisfies DataTableColumnDef<(typeof results)['data'][number]>[];
-  }, []);
+  }, [i18n, t, memberUserId, showOwnerColumn]);
 
   return (
     <div>

--- a/apps/remix/app/routes/_authenticated+/admin+/organisations.$id.tsx
+++ b/apps/remix/app/routes/_authenticated+/admin+/organisations.$id.tsx
@@ -56,7 +56,7 @@ export default function OrganisationGroupSettingsPage({
 }: Route.ComponentProps) {
   const { licenseFlags } = loaderData;
 
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   const { toast } = useToast();
 
   const navigate = useNavigate();
@@ -98,7 +98,7 @@ export default function OrganisationGroupSettingsPage({
         accessorKey: 'url',
       },
     ] satisfies DataTableColumnDef<TGetAdminOrganisationResponse['teams'][number]>[];
-  }, []);
+  }, [t]);
 
   const organisationMembersColumns = useMemo(() => {
     return [
@@ -143,7 +143,7 @@ export default function OrganisationGroupSettingsPage({
         },
       },
     ] satisfies DataTableColumnDef<TGetAdminOrganisationResponse['members'][number]>[];
-  }, [organisation]);
+  }, [organisation, t]);
 
   if (isLoadingOrganisation) {
     return (
@@ -209,7 +209,8 @@ export default function OrganisationGroupSettingsPage({
           <AlertDescription className="mr-2">
             {organisation.subscription ? (
               <span>
-                {SUBSCRIPTION_STATUS_MAP[organisation.subscription.status]} subscription found
+                {i18n._(SUBSCRIPTION_STATUS_MAP[organisation.subscription.status])} subscription
+                found
               </span>
             ) : (
               <span>

--- a/packages/lib/constants/billing.ts
+++ b/packages/lib/constants/billing.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { SubscriptionStatus } from '@prisma/client';
 
 export enum STRIPE_PLAN_TYPE {
@@ -12,7 +13,16 @@ export enum STRIPE_PLAN_TYPE {
 export const FREE_TIER_DOCUMENT_QUOTA = 5;
 
 export const SUBSCRIPTION_STATUS_MAP = {
-  [SubscriptionStatus.ACTIVE]: 'Active',
-  [SubscriptionStatus.INACTIVE]: 'Inactive',
-  [SubscriptionStatus.PAST_DUE]: 'Past Due',
+  [SubscriptionStatus.ACTIVE]: msg({
+    message: 'Active',
+    context: 'Subscription status',
+  }),
+  [SubscriptionStatus.INACTIVE]: msg({
+    message: 'Inactive',
+    context: 'Subscription status',
+  }),
+  [SubscriptionStatus.PAST_DUE]: msg({
+    message: 'Past Due',
+    context: 'Subscription status',
+  }),
 };


### PR DESCRIPTION
## Description

I marked missing `SUBSCRIPTION_STATUS_MAP` for translation.

## Changes Made

- Mark strings to translate

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.