### PR TITLE
fix: truncate long template description in public profile settings to prevent UI overflow

### DIFF
--- a/apps/remix/app/components/tables/settings-public-profile-templates-table.tsx
+++ b/apps/remix/app/components/tables/settings-public-profile-templates-table.tsx
@@ -135,15 +135,17 @@ export const SettingsPublicProfileTemplatesTable = () => {
             key={template.id}
             className="bg-background flex items-center justify-between gap-x-6 p-4"
           >
-            <div className="flex gap-x-2">
+            <div className="flex min-w-0 flex-1 gap-x-2">
               <FileIcon
                 className="text-muted-foreground/40 h-8 w-8 flex-shrink-0"
                 strokeWidth={1.5}
               />
 
-              <div>
+              <div className="min-w-0">
                 <p className="text-sm">{template.publicTitle}</p>
-                <p className="text-xs text-neutral-400">{template.publicDescription}</p>
+                <p className="line-clamp-2 text-xs text-neutral-400">
+                  {template.publicDescription}
+                </p>
               </div>
             </div>
 


### PR DESCRIPTION
Fixes #2472

## Problem
In the public profile settings page, when a template has an excessively long description, it pushes the action dropdown (Edit, Delete, Copy Link) out of view, making template management impossible.

## Solution
- Added `line-clamp-2` to the template description in the settings table to truncate long text
- Added `min-w-0` and `flex-1` to the text container so it respects flex boundaries instead of overflowing
- The action dropdown menu now always remains visible and accessible

## Changes
- `apps/remix/app/components/tables/settings-public-profile-templates-table.tsx`: Added text truncation and proper flex overflow handling

Note: The public-facing profile page (`p.$url.tsx`) already had `line-clamp-3` on descriptions — this fix addresses the settings/management view which was missing it.