### PR TITLE
fix: preserve prefilled field value on click and prevent unsign on re-edit

### DIFF
--- a/apps/remix/app/components/dialogs/sign-field-number-dialog.tsx
+++ b/apps/remix/app/components/dialogs/sign-field-number-dialog.tsx
@@ -28,10 +28,11 @@ import { Input } from '@documenso/ui/primitives/input';
 
 export type SignFieldNumberDialogProps = {
   fieldMeta: TNumberFieldMeta;
+  initialValue?: string;
 };
 
 export const SignFieldNumberDialog = createCallable<SignFieldNumberDialogProps, string | null>(
-  ({ call, fieldMeta }) => {
+  ({ call, fieldMeta, initialValue }) => {
     const { t } = useLingui();
 
     // Needs to be inside dialog for translation purposes.
@@ -98,7 +99,7 @@ export const SignFieldNumberDialog = createCallable<SignFieldNumberDialogProps, 
     const form = useForm<z.infer<typeof ZSignFieldNumberFormSchema>>({
       resolver: zodResolver(ZSignFieldNumberFormSchema),
       defaultValues: {
-        number: undefined,
+        number: initialValue ?? undefined,
       },
     });
 

--- a/apps/remix/app/components/dialogs/sign-field-text-dialog.tsx
+++ b/apps/remix/app/components/dialogs/sign-field-text-dialog.tsx
@@ -34,16 +34,17 @@ type TSignFieldTextFormSchema = z.infer<typeof ZSignFieldTextFormSchema>;
 
 export type SignFieldTextDialogProps = {
   fieldMeta?: TTextFieldMeta;
+  initialValue?: string;
 };
 
 export const SignFieldTextDialog = createCallable<SignFieldTextDialogProps, string | null>(
-  ({ call, fieldMeta }) => {
+  ({ call, fieldMeta, initialValue }) => {
     const { t } = useLingui();
 
     const form = useForm<TSignFieldTextFormSchema>({
       resolver: zodResolver(ZSignFieldTextFormSchema),
       defaultValues: {
-        text: '',
+        text: initialValue ?? '',
       },
     });
 

--- a/apps/remix/app/components/general/document-signing/document-signing-text-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-text-field.tsx
@@ -230,7 +230,9 @@ export const DocumentSigningTextField = ({
   const labelDisplay = parsedField?.label;
   const textDisplay = parsedField?.text;
 
-  const fieldDisplayName = labelDisplay ? labelDisplay : textDisplay;
+  // Prefer showing the prefilled text value first. Use the label only as a
+  // fallback/placeholder when no text value exists.
+  const fieldDisplayName = textDisplay ? textDisplay : labelDisplay;
   const charactersRemaining = (parsedFieldMeta?.characterLimit ?? 0) - (localText.length ?? 0);
 
   return (
@@ -279,7 +281,7 @@ export const DocumentSigningTextField = ({
           {parsedFieldMeta?.characterLimit !== undefined &&
             parsedFieldMeta?.characterLimit > 0 &&
             !userInputHasErrors && (
-              <div className="text-muted-foreground text-sm">
+              <div className="text-sm text-muted-foreground">
                 <Plural
                   value={charactersRemaining}
                   one="1 character remaining"

--- a/apps/remix/app/utils/field-signing/number-field.ts
+++ b/apps/remix/app/utils/field-signing/number-field.ts
@@ -2,6 +2,7 @@ import { FieldType } from '@prisma/client';
 
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import type { TFieldNumber } from '@documenso/lib/types/field';
+import { ZNumberFieldMeta } from '@documenso/lib/types/field-meta';
 import type { TSignEnvelopeFieldValue } from '@documenso/trpc/server/envelope-router/sign-envelope-field.types';
 
 import { SignFieldNumberDialog } from '~/components/dialogs/sign-field-number-dialog';
@@ -32,8 +33,13 @@ export const handleNumberFieldClick = async (
   let numberToInsert = number;
 
   if (!numberToInsert) {
+    const parsedMeta = ZNumberFieldMeta.safeParse(field.fieldMeta);
+    const initialValue =
+      field.customText ?? (parsedMeta.success ? parsedMeta.data.value : undefined);
+
     numberToInsert = await SignFieldNumberDialog.call({
       fieldMeta: field.fieldMeta,
+      initialValue: initialValue ?? undefined,
     });
   }
 

--- a/apps/remix/app/utils/field-signing/number-field.ts
+++ b/apps/remix/app/utils/field-signing/number-field.ts
@@ -23,13 +23,7 @@ export const handleNumberFieldClick = async (
     });
   }
 
-  if (field.inserted) {
-    return {
-      type: FieldType.NUMBER,
-      value: null,
-    };
-  }
-
+  // When field is already inserted, open dialog to edit (with current value) instead of unsigning.
   let numberToInsert = number;
 
   if (!numberToInsert) {
@@ -45,6 +39,13 @@ export const handleNumberFieldClick = async (
 
   if (!numberToInsert) {
     return null;
+  }
+
+  if (field.inserted && numberToInsert.trim() === '') {
+    return {
+      type: FieldType.NUMBER,
+      value: null,
+    };
   }
 
   return {

--- a/apps/remix/app/utils/field-signing/text-field.ts
+++ b/apps/remix/app/utils/field-signing/text-field.ts
@@ -2,6 +2,7 @@ import { FieldType } from '@prisma/client';
 
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import type { TFieldText } from '@documenso/lib/types/field';
+import { ZTextFieldMeta } from '@documenso/lib/types/field-meta';
 import type { TSignEnvelopeFieldValue } from '@documenso/trpc/server/envelope-router/sign-envelope-field.types';
 
 import { SignFieldTextDialog } from '~/components/dialogs/sign-field-text-dialog';
@@ -32,8 +33,13 @@ export const handleTextFieldClick = async (
   let textToInsert = text;
 
   if (!textToInsert) {
+    const parsedMeta = ZTextFieldMeta.safeParse(field.fieldMeta);
+    const initialValue =
+      field.customText ?? (parsedMeta.success ? parsedMeta.data.text : undefined);
+
     textToInsert = await SignFieldTextDialog.call({
       fieldMeta: field.fieldMeta,
+      initialValue: initialValue ?? undefined,
     });
   }
 

--- a/apps/remix/app/utils/field-signing/text-field.ts
+++ b/apps/remix/app/utils/field-signing/text-field.ts
@@ -23,13 +23,8 @@ export const handleTextFieldClick = async (
     });
   }
 
-  if (field.inserted) {
-    return {
-      type: FieldType.TEXT,
-      value: null,
-    };
-  }
-
+  // When field is already inserted, open dialog to edit (with current value) instead of unsigning.
+  // This preserves the user's entered value when they click the field again.
   let textToInsert = text;
 
   if (!textToInsert) {
@@ -45,6 +40,14 @@ export const handleTextFieldClick = async (
 
   if (!textToInsert) {
     return null;
+  }
+
+  // If user cleared the value and field was inserted, treat as unsign.
+  if (field.inserted && textToInsert.trim() === '') {
+    return {
+      type: FieldType.TEXT,
+      value: null,
+    };
   }
 
   return {

--- a/packages/lib/universal/field-renderer/render-generic-text-field.ts
+++ b/packages/lib/universal/field-renderer/render-generic-text-field.ts
@@ -100,9 +100,10 @@ const upsertFieldText = (field: FieldToRender, options: RenderFieldElementOption
     }
   }
 
-  // Override everything with value if it's inserted.
+  // Override everything with value if it's inserted (signed value always wins over prefill).
   if (field.inserted) {
-    textToRender = field.customText;
+    textToRender =
+      typeof field.customText === 'string' ? field.customText : String(field.customText ?? '');
 
     textAlign = fieldMeta?.textAlign || FIELD_DEFAULT_GENERIC_ALIGN;
 

--- a/packages/lib/universal/field-renderer/render-generic-text-field.ts
+++ b/packages/lib/universal/field-renderer/render-generic-text-field.ts
@@ -82,6 +82,24 @@ const upsertFieldText = (field: FieldToRender, options: RenderFieldElementOption
     }
   }
 
+  // In sign mode, show prefilled value from fieldMeta when field is not yet inserted.
+  if (
+    mode === 'sign' &&
+    !field.inserted &&
+    (fieldMeta?.type === 'text' || fieldMeta?.type === 'number')
+  ) {
+    const value = fieldMeta?.type === 'text' ? fieldMeta.text : fieldMeta.value;
+
+    if (value) {
+      textToRender = value;
+
+      textVerticalAlign = fieldMeta.verticalAlign || FIELD_DEFAULT_GENERIC_VERTICAL_ALIGN;
+      textAlign = fieldMeta.textAlign || FIELD_DEFAULT_GENERIC_ALIGN;
+      textLetterSpacing = fieldMeta.letterSpacing || FIELD_DEFAULT_LETTER_SPACING;
+      textLineHeight = fieldMeta.lineHeight || FIELD_DEFAULT_LINE_HEIGHT;
+    }
+  }
+
   // Override everything with value if it's inserted.
   if (field.inserted) {
     textToRender = field.customText;


### PR DESCRIPTION
## Description

When a document is created from a template via the `/api/v2/envelope/use` endpoint with `prefillFields`, the prefilled value is displayed correctly in the signing view. However, when the recipient clicks on the field to edit it, the prefilled value is erased and replaced with the field's `label` text. This fix ensures the prefilled value is preserved when the field enters edit mode, allowing the recipient to review and modify it as intended.

## Related Issue

Fixes #[2512](https://github.com/documenso/documenso/issues/2512)

## Changes Made

- **`document-signing-text-field.tsx`**: Changed `fieldDisplayName` to prefer `textDisplay` (prefilled value) over `labelDisplay`, so the signing view renders the prefilled value instead of the label.
- **`sign-field-text-dialog.tsx`**: Added `initialValue` prop and used it as the form's default value, so the edit dialog opens with the prefilled text instead of an empty string.
- **`sign-field-number-dialog.tsx`**: Same fix for number fields — added `initialValue` prop and used it as the form's default value.
- **`text-field.ts`**: When opening the text dialog, reads the prefilled value from `field.customText` or `fieldMeta.text` and passes it as `initialValue` to the dialog.
- **`number-field.ts`**: Same fix for number fields — reads from `field.customText` or `fieldMeta.value` and passes it as `initialValue` to the dialog.
- **`render-generic-text-field.ts`**: In sign mode, when a field is not yet inserted, renders the prefilled value from `fieldMeta.text` (text fields) or `fieldMeta.value` (number fields) instead of falling back to the label. When a field is inserted, always renders the signed value (`field.customText`) safely as a string, preventing accidental fallback to the prefill.

Additionally, a follow-up fix was needed to prevent a regression where clicking a field after entering a value would unsign it and revert to the prefilled value:

- **`text-field.ts`**: Removed the early return that unsigned the field on click when already inserted. Clicking a text field now always opens the edit dialog with the current signed value (`field.customText`) or prefilled value (`fieldMeta.text`) as fallback. Submitting updates the value; cancelling leaves it unchanged. Empty submit still unsigns when applicable.
- **`number-field.ts`**: Same change — removed unsign-on-click behavior. The dialog opens with the current value for editing instead of unsigning the field.
- **`render-generic-text-field.ts`**: When `field.inserted` is true, `textToRender` is now always set to a safe string from `field.customText`, so the displayed value is always the signed value and never falls back to the prefill for an inserted field.

## Testing Performed

- Created a template with a text field via the UI.
- Used the `/api/v2/envelope/use` endpoint to create an envelope with a prefilled text field (`label: "Test Label"`, `value: "This should stay"`).
- Opened the signing link as the recipient and confirmed the prefilled value is displayed.
- Clicked on the field and confirmed the prefilled value is preserved and editable in the dialog.
- Entered a new value, submitted, then clicked the field again — confirmed the dialog opens with the new value, not the original prefill.
- Cancelled the dialog after opening — confirmed the existing value is unchanged.
- Cleared the field value and submitted — confirmed the field is properly unsigned.
- Verified that non-prefilled fields still correctly show the label as placeholder text.
- Tested the same flow for number fields.
- Tested on Chrome (latest).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

This bug only affects fields prefilled via the API. Fields created and filled through the UI are unaffected since they don't use the prefill code path. The root cause was the field component unconditionally initializing its editable state from `fieldMeta.label` on click/focus, without checking for an existing value first.