### PR TITLE
fix: prevent long template description from hiding action buttons

### DIFF
--- a/apps/remix/app/components/tables/settings-public-profile-templates-table.tsx
+++ b/apps/remix/app/components/tables/settings-public-profile-templates-table.tsx
@@ -135,15 +135,17 @@ export const SettingsPublicProfileTemplatesTable = () => {
             key={template.id}
             className="bg-background flex items-center justify-between gap-x-6 p-4"
           >
-            <div className="flex gap-x-2">
+            <div className="flex min-w-0 flex-1 gap-x-2">
               <FileIcon
                 className="text-muted-foreground/40 h-8 w-8 flex-shrink-0"
                 strokeWidth={1.5}
               />
 
-              <div>
-                <p className="text-sm">{template.publicTitle}</p>
-                <p className="text-xs text-neutral-400">{template.publicDescription}</p>
+              <div className="min-w-0">
+                <p className="truncate text-sm">{template.publicTitle}</p>
+                <p className="line-clamp-2 text-xs text-neutral-400">
+                  {template.publicDescription}
+                </p>
               </div>
             </div>
 


### PR DESCRIPTION
## Problem

Long descriptions in public profile templates cause the UI layout to break, hiding critical action buttons (Edit, Delete, Copy Shareable Link) in the settings page.

Fixes #2472

## Solution

Added overflow constraints to the template description in the settings public profile templates table:

- **`min-w-0` + `flex-1`** on the text container so it properly shrinks within the flex layout instead of overflowing
- **`truncate`** on the title to handle long titles with ellipsis
- **`line-clamp-2`** on the description to limit it to 2 visible lines
- **`min-w-0`** on the inner text wrapper to enable proper flex shrinking

This ensures the action dropdown menu (⋯) always remains visible and accessible regardless of description length.

## Notes

The public profile page (`p.$url.tsx`) already has `line-clamp-3` on descriptions — this fix brings the same overflow handling to the settings/management view.