### PR TITLE
fix(i18n): add pluralization to expiration period picker

### DIFF
--- a/packages/ui/components/document/expiration-period-picker.tsx
+++ b/packages/ui/components/document/expiration-period-picker.tsx
@@ -1,7 +1,4 @@
-import type { MessageDescriptor } from '@lingui/core';
-import { msg } from '@lingui/core/macro';
-import { useLingui } from '@lingui/react';
-import { Trans } from '@lingui/react/macro';
+import { Plural, Trans } from '@lingui/react/macro';
 
 import type {
   TEnvelopeExpirationDurationPeriod,
@@ -15,16 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@documenso/ui/primitives/select';
-
-const EXPIRATION_UNITS: Array<{
-  value: TEnvelopeExpirationDurationPeriod['unit'];
-  label: MessageDescriptor;
-}> = [
-  { value: 'day', label: msg`Days` },
-  { value: 'week', label: msg`Weeks` },
-  { value: 'month', label: msg`Months` },
-  { value: 'year', label: msg`Years` },
-];
 
 type ExpirationMode = 'duration' | 'disabled' | 'inherit';
 
@@ -71,8 +58,6 @@ export const ExpirationPeriodPicker = ({
   disabled = false,
   inheritLabel,
 }: ExpirationPeriodPickerProps) => {
-  const { _ } = useLingui();
-
   const mode = getMode(value);
   const amount = getAmount(value);
   const unit = getUnit(value);
@@ -139,11 +124,18 @@ export const ExpirationPeriodPicker = ({
             </SelectTrigger>
 
             <SelectContent>
-              {EXPIRATION_UNITS.map((u) => (
-                <SelectItem key={u.value} value={u.value}>
-                  {_(u.label)}
-                </SelectItem>
-              ))}
+              <SelectItem value="day">
+                <Plural value={amount} one="Day" other="Days" />
+              </SelectItem>
+              <SelectItem value="week">
+                <Plural value={amount} one="Week" other="Weeks" />
+              </SelectItem>
+              <SelectItem value="month">
+                <Plural value={amount} one="Month" other="Months" />
+              </SelectItem>
+              <SelectItem value="year">
+                <Plural value={amount} one="Year" other="Years" />
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Description

I added pluralization to expiration period picker.

Before:
<img width="1125" height="438" alt="image" src="https://github.com/user-attachments/assets/03c7db15-8f73-4e6d-9cb8-8c44d4619b5a" />

After:
<img width="591" height="451" alt="Zrzut ekranu 2026-02-24 173640" src="https://github.com/user-attachments/assets/6b92fb89-b99e-476b-967f-dd73cdca9a96" />
<img width="466" height="443" alt="Zrzut ekranu 2026-02-24 173648" src="https://github.com/user-attachments/assets/964aac1a-b8c0-47a2-bb8b-8e0607199458" />


## Changes Made

- Add pluralization

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.