### PR TITLE
fix(i18n): mark editor field number form placeholder for translation

### DIFF
--- a/apps/remix/app/components/forms/editor/editor-field-number-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-number-form.tsx
@@ -258,7 +258,7 @@ export const EditorFieldNumberForm = ({
                     <FormControl>
                       <Input
                         className="bg-background"
-                        placeholder="E.g. 0"
+                        placeholder={t`E.g. 0`}
                         {...field}
                         value={field.value ?? ''}
                         onChange={(e) =>
@@ -282,7 +282,7 @@ export const EditorFieldNumberForm = ({
                     <FormControl>
                       <Input
                         className="bg-background"
-                        placeholder="E.g. 100"
+                        placeholder={t`E.g. 100`}
                         {...field}
                         value={field.value ?? ''}
                         onChange={(e) =>


### PR DESCRIPTION
## Description

I marked editor field number form placeholder for translation.
<img width="481" height="200" alt="image" src="https://github.com/user-attachments/assets/c2cf6f43-de6c-4729-9cb4-61d22ef55c02" />


## Changes Made

- Mark placeholder for translation

## Testing Performed

- `npm run build`
- Check `web.po` file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.