### PR TITLE
fix: add max-height to public profile bio to prevent action button overflow

### DIFF
--- a/apps/remix/app/routes/_profile+/p.$url.tsx
+++ b/apps/remix/app/routes/_profile+/p.$url.tsx
@@ -113,7 +113,7 @@ export default function PublicProfilePage({ loaderData }: Route.ComponentProps) 
           )}
         </div>
 
-        <div className="text-muted-foreground mt-4 space-y-1">
+        <div className="text-muted-foreground mt-4 max-h-32 space-y-1 overflow-y-auto">
           {(profile.bio ?? '').split('\n').map((line, index) => (
             <p
               key={index}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On the public profile page (`/p/:url`), when a user has a very long bio/description, it pushes the template action buttons ("Sign" buttons) far below the viewport, making them hard to find or completely hidden.

## What is the new behavior?

Added `max-h-32` and `overflow-y-auto` to the bio container. Long descriptions now scroll within a fixed-height area, keeping the template list and action buttons always accessible below.

## File changed

- `apps/remix/app/routes/_profile+/p.$url.tsx` — Added height constraint to bio section

## How to test

1. Create a public profile with a very long bio (10+ lines of text)
2. Visit the public profile page
3. **Before**: Action buttons are pushed out of view
4. **After**: Bio scrolls within its container, buttons remain visible

Closes #2472