### PR TITLE
docs: clarify placeholder support is envelope.* only

### DIFF
--- a/apps/docs/content/docs/developers/api/documents.mdx
+++ b/apps/docs/content/docs/developers/api/documents.mdx
@@ -269,6 +269,10 @@ Returns the full document object including recipients, fields, and envelope item
 
 Create a new document with optional recipients and fields in a single request.
 
+<Callout type="info">
+  This endpoint automatically scans uploaded PDFs for [placeholder patterns](/docs/users/documents/advanced/pdf-placeholders) like `{"{{signature, r1}}"}` and creates fields at those locations.
+</Callout>
+
 ```
 POST /envelope/create
 Content-Type: multipart/form-data

--- a/apps/docs/content/docs/developers/api/fields.mdx
+++ b/apps/docs/content/docs/developers/api/fields.mdx
@@ -473,6 +473,10 @@ Instead of specifying exact coordinates, you can position fields using placehold
 
 This approach is useful when generating PDFs programmatically or using templates with consistent layouts.
 
+<Callout type="info">
+  Placeholder support is only available in `envelope.*` endpoints. `POST /template/use` does not support placeholder parsing.
+</Callout>
+
 See the [PDF Placeholders](/docs/users/documents/advanced/pdf-placeholders) guide for the full placeholder format reference, including supported field types, recipient identifiers, and field options.
 
 ---

--- a/apps/docs/content/docs/developers/api/templates.mdx
+++ b/apps/docs/content/docs/developers/api/templates.mdx
@@ -240,6 +240,10 @@ Returns the full template object including recipients, fields, and metadata.
 
 Create a new document using a template. This is the primary way to use templates programmatically.
 
+<Callout type="info">
+  This endpoint does not support [PDF placeholder parsing](/docs/users/documents/advanced/pdf-placeholders). Use `POST /envelope/create` for placeholder-based field positioning.
+</Callout>
+
 ```
 
 POST /template/use


### PR DESCRIPTION
### Description

Added callouts to the Documents, Fields, and Templates API docs clarifying that PDF placeholder parsing is only supported in `envelope.*` endpoints