### PR TITLE
fix: show current month data and add caching

### DIFF
--- a/apps/openpage-api/app/community/total-forks/route.ts
+++ b/apps/openpage-api/app/community/total-forks/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/community/total-issues/route.ts
+++ b/apps/openpage-api/app/community/total-issues/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/community/total-prs/route.ts
+++ b/apps/openpage-api/app/community/total-prs/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/community/total-stars/route.ts
+++ b/apps/openpage-api/app/community/total-stars/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/github/forks/route.ts
+++ b/apps/openpage-api/app/github/forks/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/github/issues/route.ts
+++ b/apps/openpage-api/app/github/issues/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/github/prs/route.ts
+++ b/apps/openpage-api/app/github/prs/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/github/stars/route.ts
+++ b/apps/openpage-api/app/github/stars/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/completed-documents/route.ts
+++ b/apps/openpage-api/app/growth/completed-documents/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/new-users/route.ts
+++ b/apps/openpage-api/app/growth/new-users/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/signer-conversion/route.ts
+++ b/apps/openpage-api/app/growth/signer-conversion/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/total-completed-documents/route.ts
+++ b/apps/openpage-api/app/growth/total-completed-documents/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/total-customers/route.ts
+++ b/apps/openpage-api/app/growth/total-customers/route.ts
@@ -16,6 +16,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/total-signer-conversion/route.ts
+++ b/apps/openpage-api/app/growth/total-signer-conversion/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/app/growth/total-users/route.ts
+++ b/apps/openpage-api/app/growth/total-users/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
       },
     }),
   );

--- a/apps/openpage-api/lib/add-zero-month.ts
+++ b/apps/openpage-api/lib/add-zero-month.ts
@@ -1,15 +1,20 @@
 import { DateTime } from 'luxon';
 
-export interface TransformedData {
+export type TransformedData = {
   labels: string[];
   datasets: Array<{
     label: string;
     data: number[];
   }>;
-}
+};
 
-export function addZeroMonth(transformedData: TransformedData): TransformedData {
-  const result = {
+const FORMAT = 'MMM yyyy';
+
+export const addZeroMonth = (
+  transformedData: TransformedData,
+  isCumulative = false,
+): TransformedData => {
+  const result: TransformedData = {
     labels: [...transformedData.labels],
     datasets: transformedData.datasets.map((dataset) => ({
       label: dataset.label,
@@ -21,34 +26,28 @@ export function addZeroMonth(transformedData: TransformedData): TransformedData 
     return result;
   }
 
-  if (result.datasets.every((dataset) => dataset.data[0] === 0)) {
-    return result;
-  }
-
-  try {
-    let firstMonth = DateTime.fromFormat(result.labels[0], 'MMM yyyy');
+  if (!result.datasets.every((dataset) => dataset.data[0] === 0)) {
+    const firstMonth = DateTime.fromFormat(result.labels[0], FORMAT);
     if (!firstMonth.isValid) {
-      const formats = ['MMM yyyy', 'MMMM yyyy', 'MM/yyyy', 'yyyy-MM'];
-
-      for (const format of formats) {
-        firstMonth = DateTime.fromFormat(result.labels[0], format);
-        if (firstMonth.isValid) break;
-      }
-
-      if (!firstMonth.isValid) {
-        console.warn(`Could not parse date: "${result.labels[0]}"`);
-        return transformedData;
-      }
+      console.warn(`Could not parse date: "${result.labels[0]}"`);
+      return transformedData;
     }
 
-    const zeroMonth = firstMonth.minus({ months: 1 }).toFormat('MMM yyyy');
-    result.labels.unshift(zeroMonth);
+    result.labels.unshift(firstMonth.minus({ months: 1 }).toFormat(FORMAT));
     result.datasets.forEach((dataset) => {
       dataset.data.unshift(0);
     });
-
-    return result;
-  } catch (error) {
-    return transformedData;
   }
-}
+
+  const now = DateTime.now().startOf('month');
+  const lastMonth = DateTime.fromFormat(result.labels[result.labels.length - 1], FORMAT);
+
+  if (lastMonth.isValid && lastMonth.startOf('month') < now) {
+    result.labels.push(now.toFormat(FORMAT));
+    result.datasets.forEach((dataset) => {
+      dataset.data.push(isCumulative ? dataset.data[dataset.data.length - 1] : 0);
+    });
+  }
+
+  return result;
+};

--- a/apps/openpage-api/lib/growth/get-monthly-completed-document.ts
+++ b/apps/openpage-api/lib/growth/get-monthly-completed-document.ts
@@ -21,8 +21,7 @@ export const getCompletedDocumentsMonthly = async (type: 'count' | 'cumulative' 
     .where(() => sql`"Envelope"."status" = ${DocumentStatus.COMPLETED}::"DocumentStatus"`)
     .where(() => sql`"Envelope"."type" = ${EnvelopeType.DOCUMENT}::"EnvelopeType"`)
     .groupBy('month')
-    .orderBy('month', 'desc')
-    .limit(12);
+    .orderBy('month', 'desc');
 
   const result = await qb.execute();
 
@@ -38,7 +37,7 @@ export const getCompletedDocumentsMonthly = async (type: 'count' | 'cumulative' 
     ],
   };
 
-  return addZeroMonth(transformedData);
+  return addZeroMonth(transformedData, type === 'cumulative');
 };
 
 export type GetCompletedDocumentsMonthlyResult = Awaited<

--- a/apps/openpage-api/lib/growth/get-signer-conversion.ts
+++ b/apps/openpage-api/lib/growth/get-signer-conversion.ts
@@ -36,7 +36,7 @@ export const getSignerConversionMonthly = async (type: 'count' | 'cumulative' = 
     ],
   };
 
-  return addZeroMonth(transformedData);
+  return addZeroMonth(transformedData, type === 'cumulative');
 };
 
 export type GetSignerConversionMonthlyResult = Awaited<

--- a/apps/openpage-api/lib/growth/get-user-monthly-growth.ts
+++ b/apps/openpage-api/lib/growth/get-user-monthly-growth.ts
@@ -17,8 +17,7 @@ export const getUserMonthlyGrowth = async (type: 'count' | 'cumulative' = 'count
         .as('cume_count'),
     ])
     .groupBy('month')
-    .orderBy('month', 'desc')
-    .limit(12);
+    .orderBy('month', 'desc');
 
   const result = await qb.execute();
 
@@ -34,7 +33,7 @@ export const getUserMonthlyGrowth = async (type: 'count' | 'cumulative' = 'count
     ],
   };
 
-  return addZeroMonth(transformedData);
+  return addZeroMonth(transformedData, type === 'cumulative');
 };
 
 export type GetUserMonthlyGrowthResult = Awaited<ReturnType<typeof getUserMonthlyGrowth>>;

--- a/apps/openpage-api/lib/transform-data.ts
+++ b/apps/openpage-api/lib/transform-data.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 
-import { addZeroMonth } from './add-zero-month';
+import { type TransformedData, addZeroMonth } from './add-zero-month';
 
 type MetricKeys = {
   stars: number;
@@ -12,14 +12,6 @@ type MetricKeys = {
 
 type DataEntry = {
   [key: string]: MetricKeys;
-};
-
-type TransformData = {
-  labels: string[];
-  datasets: {
-    label: string;
-    data: number[];
-  }[];
 };
 
 type MetricKey = keyof MetricKeys;
@@ -38,7 +30,7 @@ export function transformData({
 }: {
   data: DataEntry;
   metric: MetricKey;
-}): TransformData {
+}): TransformedData {
   try {
     if (!data || Object.keys(data).length === 0) {
       return {
@@ -103,7 +95,7 @@ export function transformData({
       ],
     };
 
-    return addZeroMonth(transformedData);
+    return addZeroMonth(transformedData, true);
   } catch (error) {
     return {
       labels: [],
@@ -111,6 +103,3 @@ export function transformData({
     };
   }
 }
-
-// To be on the safer side
-export const transformRepoStats = transformData;


### PR DESCRIPTION
### Summary

- Add Cache-Control headers to all route responses (1h s-maxage, 2h stale-while-revalidate)
- Append current month to chart data so graphs stay up-to-date (cumulative carries forward, else zero)
- Remove `.limit(12)` from growth queries for full history
- Pass isCumulative flag through addZeroMonth
- Deduplicate TransformedData type, remove transformRepoStats