### PR TITLE
docs(docker): add required compose database env vars

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -31,10 +31,11 @@ POSTGRES_USER="<your-postgres-user>"
 POSTGRES_PASSWORD="<your-postgres-password>"
 POSTGRES_DB="<your-postgres-db-name>"
 
-# Internal database URLs (required by Documenso)
+# Internal database URLs (required by Documenso; direct URL is optional in compose)
 # Use "database" as the host because that is the PostgreSQL service name in compose.yml
 NEXT_PRIVATE_DATABASE_URL="postgres://<your-postgres-user>:<your-postgres-password>@database:5432/<your-postgres-db-name>"
-NEXT_PRIVATE_DIRECT_DATABASE_URL="postgres://<your-postgres-user>:<your-postgres-password>@database:5432/<your-postgres-db-name>"
+# Optional: compose.yml falls back to NEXT_PRIVATE_DATABASE_URL when NEXT_PRIVATE_DIRECT_DATABASE_URL is not set.
+# NEXT_PRIVATE_DIRECT_DATABASE_URL="postgres://<your-postgres-user>:<your-postgres-password>@database:5432/<your-postgres-db-name>"
 
 # SMTP Configuration
 NEXT_PRIVATE_SMTP_TRANSPORT="smtp-auth"

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ This setup includes a PostgreSQL database and the Documenso application. You wil
 
 1. Download the Docker Compose file from the Documenso repository: [compose.yml](https://raw.githubusercontent.com/documenso/documenso/release/docker/production/compose.yml)
 2. Navigate to the directory containing the `compose.yml` file.
-3. Create a `.env` file in the same directory and add your SMTP details as well as a few extra environment variables, following the example below:
+3. Create a `.env` file in the same directory and add the required environment variables (database, app, SMTP, and signing), following the example below:
 
 ```
 # Generate random secrets (you can use: openssl rand -hex 32)
@@ -25,6 +25,16 @@ NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY="<your-secondary-key>"
 
 # Your application URL
 NEXT_PUBLIC_WEBAPP_URL="<your-url>"
+
+# PostgreSQL service configuration (required by compose.yml)
+POSTGRES_USER="<your-postgres-user>"
+POSTGRES_PASSWORD="<your-postgres-password>"
+POSTGRES_DB="<your-postgres-db-name>"
+
+# Internal database URLs (required by Documenso)
+# Use "database" as the host because that is the PostgreSQL service name in compose.yml
+NEXT_PRIVATE_DATABASE_URL="postgres://<your-postgres-user>:<your-postgres-password>@database:5432/<your-postgres-db-name>"
+NEXT_PRIVATE_DIRECT_DATABASE_URL="postgres://<your-postgres-user>:<your-postgres-password>@database:5432/<your-postgres-db-name>"
 
 # SMTP Configuration
 NEXT_PRIVATE_SMTP_TRANSPORT="smtp-auth"


### PR DESCRIPTION
## Description
Adds the missing required database environment variables to the Docker Compose `.env` example in `docker/README.md`.

## Related Issue
Fixes #2527

## Changes Made
- Updated Docker Compose setup step text to clarify required variable categories.
- Added required PostgreSQL service variables: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`.
- Added required Documenso DB URLs: `NEXT_PRIVATE_DATABASE_URL`, `NEXT_PRIVATE_DIRECT_DATABASE_URL`.
- Added a note explaining that `database` is the host because it is the compose service name.

## Testing Performed
- Verified the documented variable names match `docker/production/compose.yml` requirements.
- Checked the updated markdown block for completeness and consistency with existing Docker instructions.

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
This PR is documentation-only and does not change application runtime behavior.