### PR TITLE
fix: include extra recipient info in missing fields error msg

### DIFF
--- a/packages/lib/server-only/document/send-document.ts
+++ b/packages/lib/server-only/document/send-document.ts
@@ -159,10 +159,12 @@ export const sendDocument = async ({
   );
 
   if (recipientsWithMissingFields.length > 0) {
-    const missingRecipientIds = recipientsWithMissingFields.map((r) => r.id).join(', ');
+    const missingRecipientDescriptions = recipientsWithMissingFields
+      .map((r) => (r.name ? `${r.name} (${r.email}, id: ${r.id})` : `${r.email} (id: ${r.id})`))
+      .join(', ');
 
     throw new AppError(AppErrorCode.INVALID_REQUEST, {
-      message: `The following recipients are missing required fields: ${missingRecipientIds}. Signers must have at least one signature field.`,
+      message: `The following recipients are missing required fields: ${missingRecipientDescriptions}. Signers must have at least one signature field.`,
     });
   }
 


### PR DESCRIPTION
## Description

#### Error message before

```
The following recipients are missing required fields: 11927. Signers must have at least one signature field.
```

#### Error message now

```
The following recipients are missing required fields: John Doe (john@example.com, id: 42), jane@example.com (id: 57). Signers must have at least one signature field.
```

## Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
