### PR TITLE
fix: handle invalid QR token gracefully instead of throwing 500

### DIFF
--- a/packages/lib/server-only/document/get-document-by-access-token.ts
+++ b/packages/lib/server-only/document/get-document-by-access-token.ts
@@ -13,7 +13,7 @@ export const getDocumentByAccessToken = async ({ token }: GetDocumentByAccessTok
     throw new Error('Missing token');
   }
 
-  const result = await prisma.envelope.findFirstOrThrow({
+  const result = await prisma.envelope.findFirst({
     where: {
       type: EnvelopeType.DOCUMENT,
       status: DocumentStatus.COMPLETED,
@@ -56,10 +56,14 @@ export const getDocumentByAccessToken = async ({ token }: GetDocumentByAccessTok
     },
   });
 
-  const firstDocumentData = result.envelopeItems[0].documentData;
+  if (!result) {
+    return null;
+  }
+
+  const firstDocumentData = result.envelopeItems[0]?.documentData;
 
   if (!firstDocumentData) {
-    throw new Error('Missing document data');
+    return null;
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #2484

Requesting `/share/qr_<random>` with a non-existent QR token returns HTTP 500 instead of a graceful redirect. This happens because `getDocumentByAccessToken()` uses Prisma's `findFirstOrThrow()`, which throws an unhandled `PrismaClientKnownRequestError` (P2025) when no matching envelope exists.

### Root Cause

In `packages/lib/server-only/document/get-document-by-access-token.ts`, the function uses `prisma.envelope.findFirstOrThrow()`. When the QR token doesn't match any completed document, Prisma throws instead of returning null.

The calling loader in `apps/remix/app/routes/_share+/share.$slug.tsx` already has a null guard (`if (!document) { throw redirect('/'); }`), but this code path was unreachable because the library function always threw before it could return null.

### Changes

- **`findFirstOrThrow` → `findFirst`**: Returns `null` instead of throwing when no envelope matches the token
- **Added null check**: Early return `null` when the query result is empty
- **Added optional chaining**: `result.envelopeItems[0]?.documentData` to safely handle edge cases where envelope items might be empty
- **Return `null` instead of throwing** for missing document data, keeping error handling consistent

### Behavior After Fix

| Request | Before | After |
|---------|--------|-------|
| `/share/qr_<valid>` | 200 (QR certificate view) | 200 (unchanged) |
| `/share/qr_<invalid>` | 500 Internal Server Error | 302 redirect to `/` |

## Test plan

- [ ] Request `/share/qr_<random_invalid_token>` — should redirect to `/` instead of returning 500
- [ ] Request `/share/qr_<valid_token>` for a completed document — should still show the QR certificate view
- [ ] Verify no regression in the OpenGraph route (`/share/qr_*/opengraph` already returns 404 correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)