### PR TITLE
fix: move window.__ENV__ script before client bundle to prevent stale fallback

### DIFF
--- a/apps/remix/app/root.tsx
+++ b/apps/remix/app/root.tsx
@@ -148,14 +148,14 @@ export function LayoutContent({ children }: { children: React.ReactNode }) {
           </TooltipProvider>
         </SessionProvider>
 
-        <ScrollRestoration />
-        <Scripts />
-
         <script
           dangerouslySetInnerHTML={{
             __html: `window.__ENV__ = ${JSON.stringify(publicEnv)}`,
           }}
         />
+
+        <ScrollRestoration />
+        <Scripts />
       </body>
     </html>
   );


### PR DESCRIPTION
The window.__ENV__ inline script was placed after <Scripts />, so
client-side modules that read NEXT_PUBLIC_WEBAPP_URL at init time
would resolve it before the env was available, falling back to
localhost:3000 regardless of the actual PORT configured.
