### PR TITLE
fix: exclude native modules from Vite dependency optimization

### DIFF
--- a/apps/remix/vite.config.ts
+++ b/apps/remix/vite.config.ts
@@ -72,6 +72,8 @@ export default defineConfig({
       'playwright',
       'playwright-core',
       '@playwright/browser-chromium',
+      'lightningcss',
+      'fsevents',
     ],
   },
   resolve: {


### PR DESCRIPTION
## Description

Fixes dev server startup errors caused by Vite attempting to optimize native Node.js modules. This issue occurs when using Tailwind CSS v4 with Vite 7, as Tailwind v4 depends on `lightningcss` (a Rust-based native module) and macOS uses `fsevents` for file watching.

The error manifests as:
[ERROR] No loader is configured for ".node" files: ../../node_modules/fsevents/fsevents.node [ERROR] Could not resolve "../pkg"


## Related Issue

Addresses the dev server startup failure when running `npm run dev` on macOS with a fresh `node_modules` installation.

## Changes Made

- Added `lightningcss` to `optimizeDeps.exclude` in `apps/remix/vite.config.ts`
- Added `fsevents` to `optimizeDeps.exclude` in `apps/remix/vite.config.ts`

These native modules are now excluded from Vite's dependency pre-bundling, allowing them to be loaded at runtime as intended.

## Testing Performed

- Tested dev server startup with `npm run dev` - server starts successfully
- Verified the homepage loads without `.node` loader errors
- Tested HMR functionality works as expected
- Confirmed the fix works on macOS ARM64 (darwin-arm64)

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

This issue specifically affects:
- **Tailwind CSS v4** users (which uses `@tailwindcss/postcss` with `lightningcss` dependency)
- **macOS** users (which uses `fsevents` for file watching)
- **Fresh installations** where Vite's dependency cache is invalidated

The fix follows the same pattern already used in the config for other native modules like `@napi-rs/canvas`, `@node-rs/bcrypt`, and `sharp`. Native `.node` modules cannot be bundled by esbuild/Vite and must be excluded from optimization.

This is a proper configuration fix, not a workaround, and should be committed to prevent other developers from encountering this issue.
