### PR TITLE
perf: parallelize independent async operations in createEnvelope

### DIFF
--- a/packages/lib/server-only/envelope/create-envelope.ts
+++ b/packages/lib/server-only/envelope/create-envelope.ts
@@ -265,18 +265,6 @@ export const createEnvelope = async ({
   // for uploads from the frontend
   const timezoneToUse = meta?.timezone || settings.documentTimezone || userTimezone;
 
-  const documentMeta = await prisma.documentMeta.create({
-    data: extractDerivedDocumentMeta(settings, {
-      ...meta,
-      timezone: timezoneToUse,
-    }),
-  });
-
-  const secondaryId =
-    type === EnvelopeType.DOCUMENT
-      ? await incrementDocumentId().then((v) => v.formattedDocumentId)
-      : await incrementTemplateId().then((v) => v.formattedTemplateId);
-
   const getValidatedDelegatedOwner = async () => {
     if (
       !settings.delegateDocumentOwnership ||
@@ -311,7 +299,18 @@ export const createEnvelope = async ({
     return delegatedOwner;
   };
 
-  const delegatedOwner = await getValidatedDelegatedOwner();
+  const [documentMeta, secondaryId, delegatedOwner] = await Promise.all([
+    prisma.documentMeta.create({
+      data: extractDerivedDocumentMeta(settings, {
+        ...meta,
+        timezone: timezoneToUse,
+      }),
+    }),
+    type === EnvelopeType.DOCUMENT
+      ? incrementDocumentId().then((v) => v.formattedDocumentId)
+      : incrementTemplateId().then((v) => v.formattedTemplateId),
+    getValidatedDelegatedOwner(),
+  ]);
   const envelopeOwnerId = delegatedOwner?.id ?? userId;
 
   const createdEnvelope = await prisma.$transaction(async (tx) => {


### PR DESCRIPTION
### Description

Parallelizes three independent async operations (documentMeta create, counter increment, and delegated owner validation) in createEnvelope using Promise.all, eliminating a sequential waterfall.