### PR TITLE
perf: parallelize async operations in duplicateEnvelope

### DIFF
--- a/packages/lib/server-only/envelope/duplicate-envelope.ts
+++ b/packages/lib/server-only/envelope/duplicate-envelope.ts
@@ -1,4 +1,5 @@
 import { DocumentSource, EnvelopeType, WebhookTriggerEvents } from '@prisma/client';
+import pMap from 'p-map';
 import { omit } from 'remeda';
 
 import { prisma } from '@documenso/prisma';
@@ -136,8 +137,9 @@ export const duplicateEnvelope = async ({ id, userId, teamId }: DuplicateEnvelop
     }),
   );
 
-  await Promise.all(
-    envelope.recipients.map((recipient) =>
+  await pMap(
+    envelope.recipients,
+    (recipient) =>
       prisma.recipient.create({
         data: {
           envelopeId: duplicatedEnvelope.id,
@@ -165,7 +167,7 @@ export const duplicateEnvelope = async ({ id, userId, teamId }: DuplicateEnvelop
           },
         },
       }),
-    ),
+    { concurrency: 5 },
   );
 
   if (duplicatedEnvelope.type === EnvelopeType.DOCUMENT) {


### PR DESCRIPTION
Parallelizes independent async operations in `duplicateEnvelope` using `Promise.all`, eliminating two sequential waterfalls: counter increment with document meta creation, and recipient creation across all recipients.