### PR TITLE
fix(ui): add scroll to date format dropdown

### DIFF
--- a/packages/ui/primitives/select.tsx
+++ b/packages/ui/primitives/select.tsx
@@ -65,7 +65,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={cn(
-          'p-1',
+          'max-h-60 overflow-y-auto p-1',
           position === 'popper' &&
             'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
         )}


### PR DESCRIPTION
## Summary
Adds max-height and scroll overflow to the `SelectContent` viewport, fixing the issue where long select lists (like the date format dropdown in document settings) extend beyond the screen and are not scrollable.

## Issue
Fixes #2625

## Changes
- Added `max-h-60 overflow-y-auto` to the `SelectPrimitive.Viewport` in the shared `SelectContent` component (`packages/ui/primitives/select.tsx`)

## Why at the primitive level?
The date format select has 22 options, which is more than fits on most screens. Rather than adding a one-off fix to the specific dropdown, this applies the constraint at the shared `SelectContent` component level — the standard approach for shadcn/radix select components. This ensures any other long select lists in the app also benefit from scrollability.

## Testing
1. Open a document to send
2. Go to document settings
3. Open the date format dropdown
4. Verify the list is now scrollable with a constrained height
5. Verify other select dropdowns (e.g., timezone, roles) still work correctly