### PR TITLE
fix: stale envelope editor query

### DIFF
--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.edit.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.edit.tsx
@@ -33,6 +33,7 @@ export default function EnvelopeEditorPage({ params }: Route.ComponentProps) {
     },
     {
       retry: false,
+      gcTime: 0,
       ...DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
     },
   );

--- a/packages/lib/client-only/providers/envelope-editor-provider.tsx
+++ b/packages/lib/client-only/providers/envelope-editor-provider.tsx
@@ -357,6 +357,7 @@ export const EnvelopeEditorProvider = ({
     },
     {
       enabled: !isEmbedded,
+      gcTime: 0,
       ...DO_NOT_INVALIDATE_QUERY_ON_MUTATION,
     },
   );


### PR DESCRIPTION
## Description

Fix issue where you can see stale data in the envelope editor. This happens because we `useState` to store the data in the editor immediately, and since we do not invalidate the query it will always be the old data.

Resolve this by immediately removing the cache on query via garbage collect (gcTime)

**Steps to replicate**

1. Replace an envelope item
2. Note that the PDF has changed
3. Click the Documenso logo to exit editor
4. Press the back button in browser to return to editor
5. Note that the editor shows the PDF
