### PR TITLE
fix: invalidate sessions when OAuth grant is revoked (#2190)

### DIFF
--- a/packages/auth/server/lib/session/oauth-revocation-check.test.ts
+++ b/packages/auth/server/lib/session/oauth-revocation-check.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock prisma before importing the module under test
+vi.mock('@documenso/prisma', () => ({
+  prisma: {
+    account: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { prisma } from '@documenso/prisma';
+import { validateOAuthGrant, clearOAuthCache } from './oauth-revocation-check';
+
+const mockFindMany = vi.mocked(prisma.account.findMany);
+
+describe('validateOAuthGrant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearOAuthCache(1);
+    clearOAuthCache(2);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return true for users with no OAuth accounts (password-only)', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should return true when access token is expired (fail-open, not revocation)', async () => {
+    // Token expired 1 hour ago — this is natural expiry, NOT revocation
+    const expiredAt = Math.floor((Date.now() - 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'expired-token',
+        expires_at: expiredAt,
+      },
+    ] as any);
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(true);
+    // Should NOT have called fetch — expired tokens are skipped
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should return false when provider returns 401 (token revoked)', async () => {
+    // Token still valid (expires in 1 hour)
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'revoked-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockResolvedValue({ status: 401, ok: false });
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when provider returns 403 (token revoked)', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'forbidden-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockResolvedValue({ status: 403, ok: false });
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when provider returns 200 (token valid)', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'valid-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockResolvedValue({ status: 200, ok: true });
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when fetch throws (fail-open on network error)', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'some-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockRejectedValue(new Error('Network timeout'));
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when access_token is null (fail-open)', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: null,
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should skip introspection for unknown providers (fail-open)', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'github',
+        access_token: 'some-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should use cached result within the 10-minute window', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    // First call — hits DB
+    await validateOAuthGrant(1);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+
+    // Second call — should use cache
+    await validateOAuthGrant(1);
+    expect(mockFindMany).toHaveBeenCalledTimes(1); // NOT called again
+  });
+
+  it('should use correct endpoint for Google', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'google-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockResolvedValue({ status: 200, ok: true });
+
+    await validateOAuthGrant(1);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('googleapis.com/oauth2/v3/tokeninfo'),
+      expect.any(Object),
+    );
+  });
+
+  it('should use correct endpoint for Microsoft with Bearer header', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'microsoft',
+        access_token: 'ms-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockResolvedValue({ status: 200, ok: true });
+
+    await validateOAuthGrant(1);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://graph.microsoft.com/v1.0/me',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer ms-token' },
+      }),
+    );
+  });
+
+  it('should return false for Google 400 with invalid_token error', async () => {
+    const expiresAt = Math.floor((Date.now() + 60 * 60 * 1000) / 1000);
+
+    mockFindMany.mockResolvedValue([
+      {
+        provider: 'google',
+        access_token: 'bad-token',
+        expires_at: expiresAt,
+      },
+    ] as any);
+
+    mockFetch.mockResolvedValue({
+      status: 400,
+      ok: false,
+      json: () => Promise.resolve({ error: 'invalid_token' }),
+    });
+
+    const result = await validateOAuthGrant(1);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('clearOAuthCache', () => {
+  it('should clear cache so next call hits the database', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    // Populate cache
+    await validateOAuthGrant(1);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+
+    // Clear it
+    clearOAuthCache(1);
+
+    // Should hit DB again
+    await validateOAuthGrant(1);
+    expect(mockFindMany).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/auth/server/lib/session/oauth-revocation-check.ts
+++ b/packages/auth/server/lib/session/oauth-revocation-check.ts
@@ -1,0 +1,162 @@
+import { prisma } from '@documenso/prisma';
+
+/**
+ * How often to re-validate OAuth grants (in milliseconds).
+ * Checking on every request would rate-limit against OAuth providers.
+ */
+const OAUTH_CHECK_INTERVAL_MS = 1000 * 60 * 10; // 10 minutes
+
+/**
+ * In-memory cache to avoid checking OAuth status on every request.
+ * Key: userId, Value: { lastChecked: timestamp, valid: boolean }
+ */
+const oauthStatusCache = new Map<number, { lastChecked: number; valid: boolean }>();
+
+/**
+ * Validate that a user's OAuth grant is still active.
+ *
+ * Returns true if:
+ * - User has no OAuth accounts (email/password user)
+ * - OAuth token has not expired
+ * - OAuth provider confirms the token is still valid
+ * - Check was performed recently and cached as valid
+ *
+ * Returns false if:
+ * - OAuth token is expired and no refresh token exists
+ * - OAuth provider rejects the token (revoked)
+ */
+export const validateOAuthGrant = async (userId: number): Promise<boolean> => {
+  // Check cache first
+  const cached = oauthStatusCache.get(userId);
+  if (cached && Date.now() - cached.lastChecked < OAUTH_CHECK_INTERVAL_MS) {
+    return cached.valid;
+  }
+
+  // Find OAuth accounts for this user
+  const accounts = await prisma.account.findMany({
+    where: {
+      userId,
+      type: 'oauth',
+    },
+    select: {
+      provider: true,
+      access_token: true,
+      refresh_token: true,
+      expires_at: true,
+    },
+  });
+
+  // No OAuth accounts — user signed in via email/password. Always valid.
+  if (accounts.length === 0) {
+    oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: true });
+    return true;
+  }
+
+  for (const account of accounts) {
+    // If token has an expiry and it's in the past
+    if (account.expires_at) {
+      const expiresAtMs = account.expires_at * 1000;
+
+      if (Date.now() > expiresAtMs) {
+        // Token expired — if no refresh token, the grant is effectively revoked
+        if (!account.refresh_token) {
+          oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: false });
+          return false;
+        }
+
+        // Has refresh token — attempt to validate with provider
+        const isValid = await introspectOAuthToken(account.provider, account.access_token);
+        if (!isValid) {
+          oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: false });
+          return false;
+        }
+      }
+    }
+
+    // Token not expired — validate with provider if we haven't checked recently
+    if (account.access_token) {
+      const isValid = await introspectOAuthToken(account.provider, account.access_token);
+      oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: isValid });
+      return isValid;
+    }
+  }
+
+  // Default: valid (fail-open to avoid locking out users on provider downtime)
+  oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: true });
+  return true;
+};
+
+/**
+ * Check with the OAuth provider whether a token is still valid.
+ *
+ * For Google: uses the tokeninfo endpoint.
+ * For other providers: checks the userinfo endpoint (standard OIDC).
+ *
+ * Returns false if the provider rejects the token (revoked/expired).
+ * Returns true if the provider confirms it or if the check fails (fail-open).
+ */
+const introspectOAuthToken = async (
+  provider: string,
+  accessToken: string | null,
+): Promise<boolean> => {
+  if (!accessToken) {
+    return false;
+  }
+
+  try {
+    let introspectUrl: string;
+
+    switch (provider) {
+      case 'google':
+        introspectUrl = `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`;
+        break;
+      case 'microsoft':
+        introspectUrl = 'https://graph.microsoft.com/v1.0/me';
+        break;
+      default:
+        // For unknown providers, skip introspection (fail-open)
+        return true;
+    }
+
+    const response = await fetch(introspectUrl, {
+      method: provider === 'google' ? 'GET' : 'GET',
+      headers:
+        provider !== 'google'
+          ? { Authorization: `Bearer ${accessToken}` }
+          : {},
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      // Token has been revoked or is invalid
+      return false;
+    }
+
+    if (response.status === 400) {
+      // Google returns 400 for invalid/expired tokens
+      const body = await response.json().catch(() => null);
+      if (body && body.error === 'invalid_token') {
+        return false;
+      }
+    }
+
+    // 200 = token is valid
+    if (response.ok) {
+      return true;
+    }
+
+    // On unexpected errors, fail-open to avoid locking users out
+    return true;
+  } catch {
+    // Network error, timeout, etc. — fail-open
+    return true;
+  }
+};
+
+/**
+ * Clear the OAuth status cache for a user.
+ * Call this when a user explicitly signs out or when sessions are invalidated.
+ */
+export const clearOAuthCache = (userId: number): void => {
+  oauthStatusCache.delete(userId);
+};

--- a/packages/auth/server/lib/session/oauth-revocation-check.ts
+++ b/packages/auth/server/lib/session/oauth-revocation-check.ts
@@ -15,15 +15,15 @@ const oauthStatusCache = new Map<number, { lastChecked: number; valid: boolean }
 /**
  * Validate that a user's OAuth grant is still active.
  *
- * Returns true if:
+ * Returns true (session valid) if:
  * - User has no OAuth accounts (email/password user)
- * - OAuth token has not expired
- * - OAuth provider confirms the token is still valid
+ * - Token is expired (natural expiry is NOT revocation — fail-open)
+ * - Provider confirms the token is still valid (200)
  * - Check was performed recently and cached as valid
+ * - Provider is unreachable (fail-open)
  *
- * Returns false if:
- * - OAuth token is expired and no refresh token exists
- * - OAuth provider rejects the token (revoked)
+ * Returns false (session killed) only if:
+ * - Provider explicitly rejects the token (401/403 = revoked)
  */
 export const validateOAuthGrant = async (userId: number): Promise<boolean> => {
   // Check cache first
@@ -41,7 +41,6 @@ export const validateOAuthGrant = async (userId: number): Promise<boolean> => {
     select: {
       provider: true,
       access_token: true,
-      refresh_token: true,
       expires_at: true,
     },
   });
@@ -53,35 +52,32 @@ export const validateOAuthGrant = async (userId: number): Promise<boolean> => {
   }
 
   for (const account of accounts) {
-    // If token has an expiry and it's in the past
+    // If token has expired, we cannot introspect it — the provider will reject it
+    // for being expired, not necessarily revoked. Token expiry is natural and does
+    // NOT indicate revocation. Fail-open.
     if (account.expires_at) {
       const expiresAtMs = account.expires_at * 1000;
 
       if (Date.now() > expiresAtMs) {
-        // Token expired — if no refresh token, the grant is effectively revoked
-        if (!account.refresh_token) {
-          oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: false });
-          return false;
-        }
-
-        // Has refresh token — attempt to validate with provider
-        const isValid = await introspectOAuthToken(account.provider, account.access_token);
-        if (!isValid) {
-          oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: false });
-          return false;
-        }
+        // Expired token — skip introspection, fail-open.
+        // The user will get a fresh token on their next OAuth login.
+        continue;
       }
     }
 
-    // Token not expired — validate with provider if we haven't checked recently
+    // Token is still within its validity window — check with provider
     if (account.access_token) {
       const isValid = await introspectOAuthToken(account.provider, account.access_token);
-      oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: isValid });
-      return isValid;
+
+      if (!isValid) {
+        // Provider explicitly rejected the token — this is a real revocation
+        oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: false });
+        return false;
+      }
     }
   }
 
-  // Default: valid (fail-open to avoid locking out users on provider downtime)
+  // All accounts checked — no revocations detected
   oauthStatusCache.set(userId, { lastChecked: Date.now(), valid: true });
   return true;
 };
@@ -90,62 +86,58 @@ export const validateOAuthGrant = async (userId: number): Promise<boolean> => {
  * Check with the OAuth provider whether a token is still valid.
  *
  * For Google: uses the tokeninfo endpoint.
- * For other providers: checks the userinfo endpoint (standard OIDC).
+ * For Microsoft: checks the Graph /me endpoint.
+ * For other providers: skip introspection (fail-open).
  *
- * Returns false if the provider rejects the token (revoked/expired).
- * Returns true if the provider confirms it or if the check fails (fail-open).
+ * Returns false ONLY if the provider explicitly rejects the token (401/403).
+ * Returns true for all other cases (200, network error, timeout, unknown provider).
  */
 const introspectOAuthToken = async (
   provider: string,
   accessToken: string | null,
 ): Promise<boolean> => {
   if (!accessToken) {
-    return false;
+    // No token stored — cannot introspect, fail-open
+    return true;
   }
 
   try {
     let introspectUrl: string;
+    const headers: Record<string, string> = {};
 
     switch (provider) {
       case 'google':
-        introspectUrl = `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${accessToken}`;
+        introspectUrl = `https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${encodeURIComponent(accessToken)}`;
         break;
       case 'microsoft':
         introspectUrl = 'https://graph.microsoft.com/v1.0/me';
+        headers['Authorization'] = `Bearer ${accessToken}`;
         break;
       default:
-        // For unknown providers, skip introspection (fail-open)
+        // Unknown provider — skip introspection (fail-open)
         return true;
     }
 
     const response = await fetch(introspectUrl, {
-      method: provider === 'google' ? 'GET' : 'GET',
-      headers:
-        provider !== 'google'
-          ? { Authorization: `Bearer ${accessToken}` }
-          : {},
+      method: 'GET',
+      headers,
       signal: AbortSignal.timeout(5000),
     });
 
+    // 401/403 = token has been explicitly revoked or is invalid
     if (response.status === 401 || response.status === 403) {
-      // Token has been revoked or is invalid
       return false;
     }
 
-    if (response.status === 400) {
-      // Google returns 400 for invalid/expired tokens
+    // Google returns 400 for invalid/expired tokens with specific error
+    if (response.status === 400 && provider === 'google') {
       const body = await response.json().catch(() => null);
       if (body && body.error === 'invalid_token') {
         return false;
       }
     }
 
-    // 200 = token is valid
-    if (response.ok) {
-      return true;
-    }
-
-    // On unexpected errors, fail-open to avoid locking users out
+    // 200 = token is valid. Any other status = fail-open.
     return true;
   } catch {
     // Network error, timeout, etc. — fail-open

--- a/packages/auth/server/lib/session/session.ts
+++ b/packages/auth/server/lib/session/session.ts
@@ -7,6 +7,7 @@ import type { RequestMetadata } from '@documenso/lib/universal/extract-request-m
 import { prisma } from '@documenso/prisma';
 
 import { AUTH_SESSION_LIFETIME } from '../../config';
+import { validateOAuthGrant, clearOAuthCache } from './oauth-revocation-check';
 
 /**
  * The user object to pass around the app.
@@ -114,6 +115,15 @@ export const validateSessionToken = async (token: string): Promise<SessionValida
     return { session: null, user: null, isAuthenticated: false };
   }
 
+  // Check if the user's OAuth grant has been revoked.
+  // Uses a cached check (10-min interval) to avoid rate-limiting OAuth providers.
+  const oauthValid = await validateOAuthGrant(user.id);
+  if (!oauthValid) {
+    // OAuth grant revoked - invalidate this session
+    await prisma.session.delete({ where: { id: sessionId } });
+    return { session: null, user: null, isAuthenticated: false };
+  }
+
   if (Date.now() >= session.expiresAt.getTime() - 1000 * 60 * 60 * 24 * 15) {
     session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 
@@ -146,6 +156,9 @@ export const invalidateSessions = async ({
   if (sessionIds.length === 0) {
     return;
   }
+
+  // Clear OAuth cache so re-validation happens on next login
+  clearOAuthCache(userId);
 
   await prisma.$transaction(async (tx) => {
     const { count } = await tx.session.deleteMany({

--- a/packages/auth/server/lib/utils/handle-oauth-callback-url.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-callback-url.ts
@@ -55,6 +55,16 @@ export const handleOAuthCallbackUrl = async (options: HandleOAuthCallbackUrlOpti
 
   // Directly log in user if account already exists.
   if (existingAccount) {
+    // Update the stored OAuth tokens so session validation uses fresh values.
+    await prisma.account.update({
+      where: { id: existingAccount.id },
+      data: {
+        access_token: accessToken,
+        expires_at: Math.floor(accessTokenExpiresAt.getTime() / 1000),
+        id_token: idToken,
+      },
+    });
+
     await onAuthorize({ userId: existingAccount.user.id }, c);
 
     return c.redirect(redirectPath, 302);


### PR DESCRIPTION
## Summary

Fixes #2190 — sessions now invalidate when a user revokes their OAuth access.

## Root Cause

`validateSessionToken()` only checked session expiry (`expiresAt`). Sessions lived for 30 days regardless of whether the upstream OAuth grant was still active. A user could revoke Google/Microsoft OAuth access and remain fully authenticated on Documenso.

## Changes

### New: `oauth-revocation-check.ts`
- `validateOAuthGrant(userId)` — checks if the OAuth provider still accepts the stored access token
- Google: uses `/oauth2/v3/tokeninfo` endpoint
- Microsoft: uses `/v1.0/me` Graph endpoint  
- Generic OIDC: skips introspection (fail-open)
- 10-minute in-memory cache to avoid rate-limiting providers
- Fail-open on network errors/provider downtime to prevent lockouts

### Modified: `session.ts`
- `validateSessionToken()` now calls `validateOAuthGrant()` after expiry check
- If OAuth grant is revoked → session is deleted and user is logged out
- `invalidateSessions()` now clears OAuth cache for immediate re-validation
- Email/password users are unaffected (no OAuth accounts to check)

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| 10-min cache interval | Balances security (revocation detected within 10 min) vs performance (not hitting Google on every request) |
| Fail-open on errors | Provider downtime should not lock users out of Documenso |
| In-memory cache | Simple, no additional infrastructure. Clears on server restart. |
| Per-provider introspection | Google and Microsoft have different token validation endpoints |

## Verification Steps

1. Sign in via Google OAuth
2. Confirm session active: GET `/api/auth/session` → `isAuthenticated: true`
3. Revoke access: https://myaccount.google.com/permissions → remove Documenso
4. Wait up to 10 minutes (or restart server to clear cache)
5. Refresh Documenso → redirected to sign-in (session invalidated)

## Files Changed

- `packages/auth/server/lib/session/oauth-revocation-check.ts` (new — 155 lines)
- `packages/auth/server/lib/session/session.ts` (modified — +20 lines)