### PR TITLE
fix: templates inherit org/team signing certificate and audit log settings

### DIFF
--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -198,8 +198,10 @@ export const run = async ({
 
     const usePlaywrightPdf = NEXT_PRIVATE_USE_PLAYWRIGHT_PDF();
 
-    const needsCertificate = settings.includeSigningCertificate;
-    const needsAuditLog = settings.includeAuditLog;
+    const needsCertificate =
+      envelope.documentMeta?.includeSigningCertificate ?? settings.includeSigningCertificate;
+    const needsAuditLog =
+      envelope.documentMeta?.includeAuditLog ?? settings.includeAuditLog;
 
     const newDocumentData: Array<{ oldDocumentDataId: string; newDocumentDataId: string }> = [];
 

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -540,6 +540,10 @@ export const createDocumentFromTemplate = async ({
         override?.allowDictateNextSigner ?? template.documentMeta?.allowDictateNextSigner,
       envelopeExpirationPeriod:
         override?.envelopeExpirationPeriod ?? template.documentMeta?.envelopeExpirationPeriod,
+      includeSigningCertificate:
+        template.documentMeta?.includeSigningCertificate,
+      includeAuditLog:
+        template.documentMeta?.includeAuditLog,
     }),
   });
 

--- a/packages/lib/utils/document.ts
+++ b/packages/lib/utils/document.ts
@@ -66,6 +66,11 @@ export const extractDerivedDocumentMeta = (
     // Envelope expiration.
     envelopeExpirationPeriod:
       meta.envelopeExpirationPeriod ?? settings.envelopeExpirationPeriod ?? null,
+
+    // Certificate and audit log settings.
+    includeSigningCertificate:
+      meta.includeSigningCertificate ?? settings.includeSigningCertificate ?? null,
+    includeAuditLog: meta.includeAuditLog ?? settings.includeAuditLog ?? null,
   } satisfies Omit<DocumentMeta, 'id'>;
 };
 

--- a/packages/prisma/migrations/20260321000000_add_document_meta_certificate_audit_settings/migration.sql
+++ b/packages/prisma/migrations/20260321000000_add_document_meta_certificate_audit_settings/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "DocumentMeta" ADD COLUMN "includeSigningCertificate" BOOLEAN;
+ALTER TABLE "DocumentMeta" ADD COLUMN "includeAuditLog" BOOLEAN;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -531,6 +531,9 @@ model DocumentMeta {
 
   envelopeExpirationPeriod Json? /// [EnvelopeExpirationPeriod] @zod.custom.use(ZEnvelopeExpirationPeriodSchema)
 
+  includeSigningCertificate Boolean?
+  includeAuditLog           Boolean?
+
   envelope Envelope?
 }
 


### PR DESCRIPTION
Fixes #2311

Documents created from templates were missing signing certificates and audit logs even when these were enabled in org/team settings. The issue was that `DocumentMeta` didn't store these settings, so when a document was sealed, it read the current team settings instead of what was configured when the template was created.

Added `includeSigningCertificate` and `includeAuditLog` as nullable fields to `DocumentMeta`. When a document is created (from a template or otherwise), these get captured from the org/team settings via `extractDerivedDocumentMeta()`. At seal time, the handler now reads from `documentMeta` first and falls back to team settings if not set.

Nullable so existing documents keep the current behavior (fall through to team settings).