### PR TITLE
feat: add option to disable document rejection per org/team

### DIFF
--- a/apps/remix/app/components/forms/document-preferences-form.tsx
+++ b/apps/remix/app/components/forms/document-preferences-form.tsx
@@ -76,6 +76,7 @@ export type TDocumentPreferencesFormSchema = {
   includeSenderDetails: boolean | null;
   includeSigningCertificate: boolean | null;
   includeAuditLog: boolean | null;
+  allowDocumentRejection: boolean | null;
   signatureTypes: DocumentSignatureType[];
   defaultRecipients: TDefaultRecipients | null;
   delegateDocumentOwnership: boolean | null;
@@ -93,6 +94,7 @@ type SettingsSubset = Pick<
   | 'includeSenderDetails'
   | 'includeSigningCertificate'
   | 'includeAuditLog'
+  | 'allowDocumentRejection'
   | 'typedSignatureEnabled'
   | 'uploadSignatureEnabled'
   | 'drawSignatureEnabled'
@@ -134,6 +136,7 @@ export const DocumentPreferencesForm = ({
     includeSenderDetails: z.boolean().nullable(),
     includeSigningCertificate: z.boolean().nullable(),
     includeAuditLog: z.boolean().nullable(),
+    allowDocumentRejection: z.boolean().nullable(),
     signatureTypes: z.array(z.nativeEnum(DocumentSignatureType)).min(canInherit ? 0 : 1, {
       message: msg`At least one signature type must be enabled`.id,
     }),
@@ -156,6 +159,7 @@ export const DocumentPreferencesForm = ({
       includeSenderDetails: settings.includeSenderDetails,
       includeSigningCertificate: settings.includeSigningCertificate,
       includeAuditLog: settings.includeAuditLog,
+      allowDocumentRejection: settings.allowDocumentRejection,
       signatureTypes: extractTeamSignatureSettings({ ...settings }),
       defaultRecipients: settings.defaultRecipients
         ? ZDefaultRecipientsSchema.parse(settings.defaultRecipients)
@@ -547,6 +551,55 @@ export const DocumentPreferencesForm = ({
                     Controls whether the audit logs will be included in the document when it is
                     downloaded. The audit logs can still be downloaded from the logs page
                     separately.
+                  </Trans>
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="allowDocumentRejection"
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormLabel>
+                  <Trans>Allow Document Rejection</Trans>
+                </FormLabel>
+
+                <FormControl>
+                  <Select
+                    {...field}
+                    value={field.value === null ? '-1' : field.value.toString()}
+                    onValueChange={(value) =>
+                      field.onChange(value === 'true' ? true : value === 'false' ? false : null)
+                    }
+                  >
+                    <SelectTrigger className="bg-background text-muted-foreground">
+                      <SelectValue />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectItem value="true">
+                        <Trans>Yes</Trans>
+                      </SelectItem>
+
+                      <SelectItem value="false">
+                        <Trans>No</Trans>
+                      </SelectItem>
+
+                      {canInherit && (
+                        <SelectItem value={'-1'}>
+                          <Trans>Inherit from organisation</Trans>
+                        </SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+
+                <FormDescription>
+                  <Trans>
+                    Controls whether recipients can reject a document. When disabled, the reject
+                    option will not be shown on the signing page.
                   </Trans>
                 </FormDescription>
               </FormItem>

--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
@@ -60,6 +60,7 @@ export type DocumentSigningPageViewV1Props = {
   isRecipientsTurn: boolean;
   allRecipients?: RecipientWithFields[];
   includeSenderDetails: boolean;
+  allowDocumentRejection?: boolean;
 };
 
 export const DocumentSigningPageViewV1 = ({
@@ -70,6 +71,7 @@ export const DocumentSigningPageViewV1 = ({
   isRecipientsTurn,
   allRecipients = [],
   includeSenderDetails,
+  allowDocumentRejection = true,
 }: DocumentSigningPageViewV1Props) => {
   const { documentData, documentMeta } = document;
 
@@ -265,7 +267,9 @@ export const DocumentSigningPageViewV1 = ({
               envelopeId={document.envelopeId}
               token={recipient.token}
             />
-            <DocumentSigningRejectDialog documentId={document.id} token={recipient.token} />
+            {allowDocumentRejection && (
+              <DocumentSigningRejectDialog documentId={document.id} token={recipient.token} />
+            )}
           </div>
         </div>
 

--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v2.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v2.tsx
@@ -200,7 +200,9 @@ export const DocumentSigningPageViewV2 = () => {
                   }
                 />
 
-                {envelope.type === EnvelopeType.DOCUMENT && allowDocumentRejection && (
+                {envelope.type === EnvelopeType.DOCUMENT &&
+                  allowDocumentRejection &&
+                  (envelope.documentMeta.allowDocumentRejection ?? true) && (
                   <DocumentSigningRejectDialog
                     documentId={mapSecondaryIdToDocumentId(envelope.secondaryId)}
                     token={recipient.token}

--- a/packages/lib/server-only/envelope/get-envelope-for-recipient-signing.ts
+++ b/packages/lib/server-only/envelope/get-envelope-for-recipient-signing.ts
@@ -48,6 +48,7 @@ export const ZEnvelopeForSigningResponse = z.object({
       uploadSignatureEnabled: true,
       drawSignatureEnabled: true,
       allowDictateNextSigner: true,
+      allowDocumentRejection: true,
       language: true,
     }),
     recipients: ZRecipientLiteSchema.pick({

--- a/packages/lib/server-only/template/create-document-from-template.ts
+++ b/packages/lib/server-only/template/create-document-from-template.ts
@@ -540,6 +540,8 @@ export const createDocumentFromTemplate = async ({
         override?.allowDictateNextSigner ?? template.documentMeta?.allowDictateNextSigner,
       envelopeExpirationPeriod:
         override?.envelopeExpirationPeriod ?? template.documentMeta?.envelopeExpirationPeriod,
+      allowDocumentRejection:
+        template.documentMeta?.allowDocumentRejection,
     }),
   });
 

--- a/packages/lib/utils/document.ts
+++ b/packages/lib/utils/document.ts
@@ -69,6 +69,10 @@ export const extractDerivedDocumentMeta = (
 
     // Reminder settings.
     reminderSettings: meta.reminderSettings ?? settings.reminderSettings ?? null,
+
+    // Rejection settings.
+    allowDocumentRejection:
+      meta.allowDocumentRejection ?? settings.allowDocumentRejection ?? null,
   } satisfies Omit<DocumentMeta, 'id'>;
 };
 

--- a/packages/lib/utils/organisations.ts
+++ b/packages/lib/utils/organisations.ts
@@ -146,5 +146,7 @@ export const generateDefaultOrganisationSettings = (): Omit<
     reminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
 
     aiFeaturesEnabled: false,
+
+    allowDocumentRejection: true,
   };
 };

--- a/packages/lib/utils/teams.ts
+++ b/packages/lib/utils/teams.ts
@@ -211,6 +211,8 @@ export const generateDefaultTeamSettings = (): Omit<TeamGlobalSettings, 'id' | '
     reminderSettings: null,
 
     aiFeaturesEnabled: null,
+
+    allowDocumentRejection: null,
   };
 };
 

--- a/packages/prisma/migrations/20260321100000_add_allow_document_rejection_setting/migration.sql
+++ b/packages/prisma/migrations/20260321100000_add_allow_document_rejection_setting/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "OrganisationGlobalSettings" ADD COLUMN "allowDocumentRejection" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "TeamGlobalSettings" ADD COLUMN "allowDocumentRejection" BOOLEAN;
+ALTER TABLE "DocumentMeta" ADD COLUMN "allowDocumentRejection" BOOLEAN;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -533,6 +533,8 @@ model DocumentMeta {
 
   reminderSettings Json? /// [EnvelopeReminderSettings] @zod.custom.use(ZEnvelopeReminderSettingsSchema)
 
+  allowDocumentRejection Boolean?
+
   envelope Envelope?
 }
 
@@ -867,6 +869,8 @@ model OrganisationGlobalSettings {
 
   reminderSettings Json? /// [EnvelopeReminderSettings] @zod.custom.use(ZEnvelopeReminderSettingsSchema)
 
+  allowDocumentRejection Boolean @default(true)
+
   // AI features settings.
   aiFeaturesEnabled Boolean @default(false)
 }
@@ -907,6 +911,8 @@ model TeamGlobalSettings {
   envelopeExpirationPeriod Json? /// [EnvelopeExpirationPeriod] @zod.custom.use(ZEnvelopeExpirationPeriodSchema)
 
   reminderSettings Json? /// [EnvelopeReminderSettings] @zod.custom.use(ZEnvelopeReminderSettingsSchema)
+
+  allowDocumentRejection Boolean?
 
   // AI features settings.
   aiFeaturesEnabled Boolean?


### PR DESCRIPTION
Fixes #2561

Adds an "Allow Document Rejection" toggle to org and team document preferences. When disabled, the reject button is hidden on the signing page.

The setting follows the existing inheritance pattern: org sets the default, teams can override, and it can also be set per-document via DocumentMeta for more granular control.

Changes:
- Added `allowDocumentRejection` to OrganisationGlobalSettings (default true), TeamGlobalSettings (nullable), and DocumentMeta (nullable)
- Added the toggle to the document preferences form
- V2 signing page now checks both the embed context and documentMeta setting
- V1 signing page now accepts and respects the prop
- Template-created documents inherit the setting from the template