### PR TITLE
fix: clean up orphaned DocumentData after envelope item updates

### DIFF
--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -311,6 +311,13 @@ export const run = async ({
       });
     });
 
+    // Delete orphaned DocumentData records that were replaced during sealing.
+    for (const { oldDocumentDataId } of newDocumentData) {
+      await prisma.documentData.delete({
+        where: { id: oldDocumentDataId },
+      });
+    }
+
     return {
       envelopeId: envelope.id,
       envelopeStatus: envelope.status,

--- a/packages/lib/server-only/field/create-envelope-fields.ts
+++ b/packages/lib/server-only/field/create-envelope-fields.ts
@@ -308,6 +308,8 @@ export const createEnvelopeFields = async ({
       continue;
     }
 
+    const oldDocumentDataId = envelopeItem.documentDataId;
+
     const { documentData: newDocumentData } = await putPdfFileServerSide({
       name: 'document.pdf',
       type: 'application/pdf',
@@ -317,6 +319,11 @@ export const createEnvelopeFields = async ({
     await prisma.envelopeItem.update({
       where: { id: envelopeItemId },
       data: { documentDataId: newDocumentData.id },
+    });
+
+    // Delete orphaned DocumentData that was replaced.
+    await prisma.documentData.delete({
+      where: { id: oldDocumentDataId },
     });
   }
 


### PR DESCRIPTION
Fixes #2493

When envelope items are updated (during sealing or field creation with whiteout regions), the code creates a new DocumentData record and updates the EnvelopeItem foreign key to point to it. The old DocumentData record was left orphaned in the database.

This follows the same cleanup pattern already used in replace-envelope-item-pdf.ts, which correctly deletes the old record after replacing. Applied the same approach to:

- seal-document.handler.ts: deletes old DocumentData after sealing completes
- create-envelope-fields.ts: deletes old DocumentData after whiteout region update