### PR TITLE
fix: resolve incorrect recipient comparision check

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-auth-provider.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-auth-provider.tsx
@@ -141,7 +141,7 @@ export const DocumentSigningAuthProvider = ({
 
     if (
       derivedRecipientActionAuth.includes(DocumentAuth.ACCOUNT) &&
-      user?.email == recipient.email
+      user?.email === recipient.email
     ) {
       return {
         type: DocumentAuth.ACCOUNT,

--- a/packages/lib/client-only/providers/envelope-editor-provider.tsx
+++ b/packages/lib/client-only/providers/envelope-editor-provider.tsx
@@ -518,7 +518,7 @@ const mapLocalRecipientsToRecipients = ({
   }, -1);
 
   return localRecipients.map((recipient) => {
-    const foundRecipient = envelope.recipients.find((recipient) => recipient.id === recipient.id);
+    const foundRecipient = envelope.recipients.find((r) => r.id === recipient.id);
 
     let recipientId = recipient.id;
 


### PR DESCRIPTION
## Description

Resolve issues with comparison checks.

The `envelope-editor-provider.tsx` should be low impact since it's embed only which will only cause the non relevant attributes (such as sent at) to be incorrectly mapped

The `auth-provider.tsx` one should have no impact