### PR TITLE
fix: replace z.string().email() with RFC 5322 compliant ZEmail/zEmail

### DIFF
--- a/apps/remix/app/components/dialogs/assistant-confirmation-dialog.tsx
+++ b/apps/remix/app/components/dialogs/assistant-confirmation-dialog.tsx
@@ -5,6 +5,7 @@ import { Trans, useLingui } from '@lingui/react/macro';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+import { zEmail } from '@documenso/lib/utils/zod';
 import { Button } from '@documenso/ui/primitives/button';
 import {
   Dialog,
@@ -43,7 +44,7 @@ type ConfirmationDialogProps = {
 
 const ZNextSignerFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
-  email: z.string().email('Invalid email address'),
+  email: zEmail('Invalid email address'),
 });
 
 type TNextSignerFormSchema = z.infer<typeof ZNextSignerFormSchema>;

--- a/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
@@ -16,6 +16,7 @@ import { useCurrentOrganisation } from '@documenso/lib/client-only/providers/org
 import { DO_NOT_INVALIDATE_QUERY_ON_MUTATION } from '@documenso/lib/constants/trpc';
 import { extractDocumentAuthMethods } from '@documenso/lib/utils/document-auth';
 import { getRecipientsWithMissingFields } from '@documenso/lib/utils/recipients';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { trpc, trpc as trpcReact } from '@documenso/trpc/react';
 import { DocumentSendEmailMessageHelper } from '@documenso/ui/components/document/document-send-email-message-helper';
 import { cn } from '@documenso/ui/lib/utils';
@@ -62,10 +63,7 @@ export type EnvelopeDistributeDialogProps = {
 export const ZEnvelopeDistributeFormSchema = z.object({
   meta: z.object({
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess(
-      (val) => (val === '' ? undefined : val),
-      z.string().email().optional(),
-    ),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
     subject: z.string(),
     message: z.string(),
     distributionMethod: z

--- a/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
@@ -17,6 +17,7 @@ import { IS_BILLING_ENABLED, SUPPORT_EMAIL } from '@documenso/lib/constants/app'
 import { ORGANISATION_MEMBER_ROLE_HIERARCHY } from '@documenso/lib/constants/organisations';
 import { ORGANISATION_MEMBER_ROLE_MAP } from '@documenso/lib/constants/organisations-translations';
 import { INTERNAL_CLAIM_ID } from '@documenso/lib/types/subscription';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { ZCreateOrganisationMemberInvitesRequestSchema } from '@documenso/trpc/server/organisation-router/create-organisation-member-invites.types';
 import { cn } from '@documenso/ui/lib/utils';
@@ -94,7 +95,7 @@ type TabTypes = 'INDIVIDUAL' | 'BULK';
 
 const ZImportOrganisationMemberSchema = z.array(
   z.object({
-    email: z.string().email(),
+    email: ZEmail,
     organisationRole: z.nativeEnum(OrganisationMemberRole),
   }),
 );
@@ -329,12 +330,12 @@ export const OrganisationMemberInviteDialog = ({
             onValueChange={(value) => setInvitationType(value as TabTypes)}
           >
             <TabsList className="w-full">
-              <TabsTrigger value="INDIVIDUAL" className="hover:text-foreground w-full">
+              <TabsTrigger value="INDIVIDUAL" className="w-full hover:text-foreground">
                 <MailIcon size={20} className="mr-2" />
                 <Trans>Invite Members</Trans>
               </TabsTrigger>
 
-              <TabsTrigger value="BULK" className="hover:text-foreground w-full">
+              <TabsTrigger value="BULK" className="w-full hover:text-foreground">
                 <UsersIcon size={20} className="mr-2" /> <Trans>Bulk Import</Trans>
               </TabsTrigger>
             </TabsList>
@@ -382,7 +383,7 @@ export const OrganisationMemberInviteDialog = ({
                                 )}
                                 <FormControl>
                                   <Select {...field} onValueChange={field.onChange}>
-                                    <SelectTrigger className="text-muted-foreground max-w-[200px]">
+                                    <SelectTrigger className="max-w-[200px] text-muted-foreground">
                                       <SelectValue />
                                     </SelectTrigger>
 
@@ -447,7 +448,7 @@ export const OrganisationMemberInviteDialog = ({
               <div className="mt-4 space-y-4">
                 <Card gradient className="h-32">
                   <CardContent
-                    className="text-muted-foreground/80 hover:text-muted-foreground/90 flex h-full cursor-pointer flex-col items-center justify-center rounded-lg p-0 transition-colors"
+                    className="flex h-full cursor-pointer flex-col items-center justify-center rounded-lg p-0 text-muted-foreground/80 transition-colors hover:text-muted-foreground/90"
                     onClick={() => fileInputRef.current?.click()}
                   >
                     <Upload className="h-5 w-5" />

--- a/apps/remix/app/components/dialogs/sign-field-email-dialog.tsx
+++ b/apps/remix/app/components/dialogs/sign-field-email-dialog.tsx
@@ -5,6 +5,7 @@ import { createCallable } from 'react-call';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { Button } from '@documenso/ui/primitives/button';
 import {
   Dialog,
@@ -24,10 +25,7 @@ import {
 import { Input } from '@documenso/ui/primitives/input';
 
 const ZSignFieldEmailFormSchema = z.object({
-  email: z
-    .string()
-    .email()
-    .min(1, { message: msg`Email is required`.id }),
+  email: ZEmail.min(1, { message: msg`Email is required`.id }),
 });
 
 type TSignFieldEmailFormSchema = z.infer<typeof ZSignFieldEmailFormSchema>;

--- a/apps/remix/app/components/embed/authoring/configure-document-view.types.ts
+++ b/apps/remix/app/components/embed/authoring/configure-document-view.types.ts
@@ -6,6 +6,7 @@ import {
   ZDocumentMetaLanguageSchema,
 } from '@documenso/lib/types/document-meta';
 import { ZRecipientEmailSchema } from '@documenso/lib/types/recipient';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { DocumentDistributionMethod } from '@documenso/prisma/generated/types';
 
 // Define the schema for configuration
@@ -19,7 +20,7 @@ export const ZConfigureEmbedFormSchema = z.object({
         nativeId: z.number().optional(),
         formId: z.string(),
         name: z.string(),
-        email: z.string().email('Invalid email address'),
+        email: zEmail('Invalid email address'),
         role: z.enum(['SIGNER', 'CC', 'APPROVER', 'VIEWER', 'ASSISTANT']),
         signingOrder: z.number().optional(),
         disabled: z.boolean().optional(),

--- a/apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+++ b/apps/remix/app/components/embed/embed-direct-template-client-page.tsx
@@ -29,6 +29,7 @@ import {
 import { getDocumentDataUrlForPdfViewer } from '@documenso/lib/utils/envelope-download';
 import { sortFieldsByPosition, validateFieldsInserted } from '@documenso/lib/utils/fields';
 import { dynamicActivate } from '@documenso/lib/utils/i18n';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { isSignatureFieldType } from '@documenso/prisma/guards/is-signature-field';
 import { trpc } from '@documenso/trpc/react';
 import type {
@@ -210,7 +211,7 @@ export const EmbedDirectTemplateClientPage = ({
         return;
       }
 
-      const { success: isEmailValid } = z.string().email().safeParse(email);
+      const { success: isEmailValid } = ZEmail.safeParse(email);
 
       if (!isEmailValid) {
         setEmailError(_(msg`A valid email is required`));

--- a/apps/remix/app/components/forms/email-preferences-form.tsx
+++ b/apps/remix/app/components/forms/email-preferences-form.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_DOCUMENT_EMAIL_SETTINGS,
   ZDocumentEmailSettingsSchema,
 } from '@documenso/lib/types/document-email';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { DocumentEmailCheckboxes } from '@documenso/ui/components/document/document-email-checkboxes';
 import { Button } from '@documenso/ui/primitives/button';
@@ -33,7 +34,7 @@ import {
 
 const ZEmailPreferencesFormSchema = z.object({
   emailId: z.string().nullable(),
-  emailReplyTo: z.string().email().nullable(),
+  emailReplyTo: ZEmail.nullable(),
   // emailReplyToName: z.string(),
   emailDocumentSettings: ZDocumentEmailSettingsSchema.nullable(),
 });

--- a/apps/remix/app/components/forms/forgot-password.tsx
+++ b/apps/remix/app/components/forms/forgot-password.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router';
 import { z } from 'zod';
 
 import { authClient } from '@documenso/auth/client';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -21,7 +22,7 @@ import { Input } from '@documenso/ui/primitives/input';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export const ZForgotPasswordFormSchema = z.object({
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
 });
 
 export type TForgotPasswordFormSchema = z.infer<typeof ZForgotPasswordFormSchema>;

--- a/apps/remix/app/components/forms/send-confirmation-email.tsx
+++ b/apps/remix/app/components/forms/send-confirmation-email.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { authClient } from '@documenso/auth/client';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -20,7 +21,7 @@ import { Input } from '@documenso/ui/primitives/input';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export const ZSendConfirmationEmailFormSchema = z.object({
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
 });
 
 export type TSendConfirmationEmailFormSchema = z.infer<typeof ZSendConfirmationEmailFormSchema>;

--- a/apps/remix/app/components/forms/signin.tsx
+++ b/apps/remix/app/components/forms/signin.tsx
@@ -17,6 +17,7 @@ import { z } from 'zod';
 import { authClient } from '@documenso/auth/client';
 import { AuthenticationErrorCode } from '@documenso/auth/server/lib/errors/error-codes';
 import { AppError } from '@documenso/lib/errors/app-error';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { ZCurrentPasswordSchema } from '@documenso/trpc/server/auth-router/schema';
 import { cn } from '@documenso/ui/lib/utils';
@@ -58,7 +59,7 @@ const handleFallbackErrorMessages = (code: string) => {
 const LOGIN_REDIRECT_PATH = '/';
 
 export const ZSignInFormSchema = z.object({
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
   password: ZCurrentPasswordSchema,
   totpCode: z.string().trim().optional(),
   backupCode: z.string().trim().optional(),

--- a/apps/remix/app/components/forms/signup.tsx
+++ b/apps/remix/app/components/forms/signup.tsx
@@ -15,6 +15,7 @@ import communityCardsImage from '@documenso/assets/images/community-cards.png';
 import { authClient } from '@documenso/auth/client';
 import { useAnalytics } from '@documenso/lib/client-only/hooks/use-analytics';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { ZPasswordSchema } from '@documenso/trpc/server/auth-router/schema';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
@@ -39,7 +40,7 @@ export const ZSignUpFormSchema = z
       .string()
       .trim()
       .min(1, { message: msg`Please enter a valid name.`.id }),
-    email: z.string().email().min(1),
+    email: ZEmail.min(1),
     password: ZPasswordSchema,
     signature: z.string().min(1, { message: msg`We need your signature to sign documents`.id }),
   })

--- a/apps/remix/app/components/general/claim-account.tsx
+++ b/apps/remix/app/components/general/claim-account.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { authClient } from '@documenso/auth/client';
 import { useAnalytics } from '@documenso/lib/client-only/hooks/use-analytics';
 import { AppError } from '@documenso/lib/errors/app-error';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { ZPasswordSchema } from '@documenso/trpc/server/auth-router/schema';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -37,7 +38,7 @@ export const ZClaimAccountFormSchema = z
       .string()
       .trim()
       .min(1, { message: msg`Please enter a valid name.`.id }),
-    email: z.string().email().min(1),
+    email: ZEmail.min(1),
     password: ZPasswordSchema,
   })
   .refine(

--- a/apps/remix/app/components/general/direct-template/direct-template-configure-form.tsx
+++ b/apps/remix/app/components/general/direct-template/direct-template-configure-form.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import { useOptionalSession } from '@documenso/lib/client-only/providers/session';
 import type { TTemplate } from '@documenso/lib/types/template';
+import { zEmail } from '@documenso/lib/utils/zod';
 import {
   DocumentReadOnlyFields,
   mapFieldsWithRecipients,
@@ -33,7 +34,7 @@ import { useStep } from '@documenso/ui/primitives/stepper';
 import { useRequiredDocumentSigningAuthContext } from '~/components/general/document-signing/document-signing-auth-provider';
 
 const ZDirectTemplateConfigureFormSchema = z.object({
-  email: z.string().email('Email is invalid'),
+  email: zEmail('Email is invalid'),
 });
 
 export type TDirectTemplateConfigureFormSchema = z.infer<typeof ZDirectTemplateConfigureFormSchema>;

--- a/apps/remix/app/components/general/document-signing/document-signing-complete-dialog.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-complete-dialog.tsx
@@ -14,6 +14,7 @@ import {
   ZDocumentAccessAuthSchema,
 } from '@documenso/lib/types/document-auth';
 import { fieldsContainUnsignedRequiredField } from '@documenso/lib/utils/advanced-fields-helpers';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { Button } from '@documenso/ui/primitives/button';
 import {
   Dialog,
@@ -68,7 +69,7 @@ export type DocumentSigningCompleteDialogProps = {
 
 const ZNextSignerFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
-  email: z.string().email('Invalid email address'),
+  email: zEmail('Invalid email address'),
   accessAuthOptions: ZDocumentAccessAuthSchema.optional(),
 });
 
@@ -76,7 +77,7 @@ type TNextSignerFormSchema = z.infer<typeof ZNextSignerFormSchema>;
 
 const ZDirectRecipientFormSchema = z.object({
   name: z.string(),
-  email: z.string().email('Invalid email address'),
+  email: zEmail('Invalid email address'),
 });
 
 type TDirectRecipientFormSchema = z.infer<typeof ZDirectRecipientFormSchema>;

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
@@ -51,6 +51,7 @@ import {
   canAccessTeamDocument,
   extractTeamSignatureSettings,
 } from '@documenso/lib/utils/teams';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { DocumentEmailCheckboxes } from '@documenso/ui/components/document/document-email-checkboxes';
 import {
@@ -138,10 +139,7 @@ export const ZAddSettingsFormSchema = z.object({
       .optional()
       .default('en'),
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess(
-      (val) => (val === '' ? undefined : val),
-      z.string().email().optional(),
-    ),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
     emailSettings: ZDocumentEmailSettingsSchema,
     signatureTypes: z.array(z.nativeEnum(DocumentSignatureType)).min(1, {
       message: msg`At least one signature type must be enabled`.id,

--- a/apps/remix/app/components/tables/admin-document-recipient-item-table.tsx
+++ b/apps/remix/app/components/tables/admin-document-recipient-item-table.tsx
@@ -14,6 +14,7 @@ import { useForm } from 'react-hook-form';
 import { useRevalidator } from 'react-router';
 import { z } from 'zod';
 
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
 import type { DataTableColumnDef } from '@documenso/ui/primitives/data-table';
@@ -46,7 +47,7 @@ const RECIPIENT_ROLE_LABELS: Record<RecipientRole, string> = {
 
 const ZAdminUpdateRecipientFormSchema = z.object({
   name: z.string().min(1),
-  email: z.string().email(),
+  email: ZEmail,
   role: z.nativeEnum(RecipientRole),
 });
 

--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -24,6 +24,7 @@ import {
 import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
 import { ZEnvelopeAttachmentTypeSchema } from '@documenso/lib/types/envelope-attachment';
 import { ZFieldMetaPrefillFieldsSchema, ZFieldMetaSchema } from '@documenso/lib/types/field-meta';
+import { ZEmail } from '@documenso/lib/utils/zod';
 
 extendZodWithOpenApi(z);
 
@@ -150,7 +151,7 @@ export const ZCreateDocumentMutationSchema = z.object({
   recipients: z.array(
     z.object({
       name: z.string().min(1),
-      email: z.string().email().min(1),
+      email: ZEmail.min(1),
       role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
       signingOrder: z.number().nullish(),
     }),
@@ -224,7 +225,7 @@ export const ZCreateDocumentMutationResponseSchema = z.object({
     z.object({
       recipientId: z.number(),
       name: z.string(),
-      email: z.string().email().min(1),
+      email: ZEmail.min(1),
       token: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().nullish(),
@@ -244,7 +245,7 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
   recipients: z.array(
     z.object({
       name: z.string().min(1),
-      email: z.string().email().min(1),
+      email: ZEmail.min(1),
       role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
       signingOrder: z.number().nullish(),
     }),
@@ -299,7 +300,7 @@ export const ZCreateDocumentFromTemplateMutationResponseSchema = z.object({
     z.object({
       recipientId: z.number(),
       name: z.string(),
-      email: z.string().email().min(1),
+      email: ZEmail.min(1),
       token: z.string(),
       role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
       signingOrder: z.number().nullish(),
@@ -326,7 +327,7 @@ export const ZGenerateDocumentFromTemplateMutationSchema = z.object({
     .array(
       z.object({
         id: z.number(),
-        email: z.string().email(),
+        email: ZEmail,
         name: z.string().optional(),
         signingOrder: z.number().optional(),
       }),
@@ -386,7 +387,7 @@ export const ZGenerateDocumentFromTemplateMutationResponseSchema = z.object({
     z.object({
       recipientId: z.number(),
       name: z.string(),
-      email: z.string().email().min(1),
+      email: ZEmail.min(1),
       token: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().nullish(),
@@ -402,7 +403,7 @@ export type TGenerateDocumentFromTemplateMutationResponseSchema = z.infer<
 
 export const ZCreateRecipientMutationSchema = z.object({
   name: z.string().min(1),
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
   role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
   signingOrder: z.number().nullish(),
   authOptions: z
@@ -437,7 +438,7 @@ export const ZSuccessfulRecipientResponseSchema = z.object({
   // !: This handles the fact that we have null documentId's for templates
   // !: while we won't need the default we must add it to satisfy typescript
   documentId: z.number().nullish().default(-1),
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
   name: z.string(),
   role: z.nativeEnum(RecipientRole),
   signingOrder: z.number().nullish(),
@@ -576,7 +577,7 @@ export const ZRecipientSchema = z.object({
   id: z.number(),
   documentId: z.number().nullish(),
   templateId: z.number().nullish(),
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
   name: z.string(),
   token: z.string(),
   signingOrder: z.number().nullish(),

--- a/packages/auth/server/types/email-password.ts
+++ b/packages/auth/server/types/email-password.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
+import { ZEmail } from '@documenso/lib/utils/zod';
+
 export const ZCurrentPasswordSchema = z
   .string()
   .min(6, { message: 'Must be at least 6 characters in length' })
   .max(72);
 
 export const ZSignInSchema = z.object({
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
   password: ZCurrentPasswordSchema,
   totpCode: z.string().trim().optional(),
   backupCode: z.string().trim().optional(),
@@ -34,7 +36,7 @@ export const ZPasswordSchema = z
 
 export const ZSignUpSchema = z.object({
   name: z.string().min(1),
-  email: z.string().email(),
+  email: ZEmail,
   password: ZPasswordSchema,
   signature: z.string().nullish(),
 });
@@ -42,7 +44,7 @@ export const ZSignUpSchema = z.object({
 export type TSignUpSchema = z.infer<typeof ZSignUpSchema>;
 
 export const ZForgotPasswordSchema = z.object({
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
 });
 
 export type TForgotPasswordSchema = z.infer<typeof ZForgotPasswordSchema>;
@@ -61,7 +63,7 @@ export const ZVerifyEmailSchema = z.object({
 export type TVerifyEmailSchema = z.infer<typeof ZVerifyEmailSchema>;
 
 export const ZResendVerifyEmailSchema = z.object({
-  email: z.string().email().min(1),
+  email: ZEmail.min(1),
 });
 
 export type TResendVerifyEmailSchema = z.infer<typeof ZResendVerifyEmailSchema>;

--- a/packages/lib/jobs/definitions/emails/send-confirmation-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-confirmation-email.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
 
+import { ZEmail } from '../../../utils/zod';
 import type { JobDefinition } from '../../client/_internal/job';
 
 const SEND_CONFIRMATION_EMAIL_JOB_DEFINITION_ID = 'send.signup.confirmation.email';
 
 const SEND_CONFIRMATION_EMAIL_JOB_DEFINITION_SCHEMA = z.object({
-  email: z.string().email(),
+  email: ZEmail,
   force: z.boolean().optional(),
 });
 

--- a/packages/lib/jobs/definitions/internal/bulk-send-template.handler.ts
+++ b/packages/lib/jobs/definitions/internal/bulk-send-template.handler.ts
@@ -9,6 +9,7 @@ import { BulkSendCompleteEmail } from '@documenso/email/templates/bulk-send-comp
 import { sendDocument } from '@documenso/lib/server-only/document/send-document';
 import { createDocumentFromTemplate } from '@documenso/lib/server-only/template/create-document-from-template';
 import { getTemplateById } from '@documenso/lib/server-only/template/get-template-by-id';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { prisma } from '@documenso/prisma';
 
 import { getI18nInstance } from '../../../client-only/providers/i18n-server';
@@ -22,7 +23,7 @@ import type { TBulkSendTemplateJobDefinition } from './bulk-send-template';
 const ZRecipientRowSchema = z.object({
   name: z.string().optional(),
   email: z.union([
-    z.string().email({ message: 'Value must be a valid email or empty string' }),
+    zEmail('Value must be a valid email or empty string'),
     z.string().max(0, { message: 'Value must be a valid email or empty string' }),
   ]),
 });

--- a/packages/lib/types/default-recipients.ts
+++ b/packages/lib/types/default-recipients.ts
@@ -1,8 +1,10 @@
 import { RecipientRole } from '@prisma/client';
 import { z } from 'zod';
 
+import { ZEmail } from '../utils/zod';
+
 export const ZDefaultRecipientSchema = z.object({
-  email: z.string().email(),
+  email: ZEmail,
   name: z.string(),
   role: z.nativeEnum(RecipientRole),
 });

--- a/packages/lib/types/document-audit-logs.ts
+++ b/packages/lib/types/document-audit-logs.ts
@@ -7,6 +7,7 @@
 import { DocumentSource, FieldType } from '@prisma/client';
 import { z } from 'zod';
 
+import { ZEmail } from '../utils/zod';
 import { ZRecipientAccessAuthTypesSchema, ZRecipientActionAuthTypesSchema } from './document-auth';
 
 export const ZDocumentAuditLogTypeSchema = z.enum([
@@ -279,7 +280,7 @@ export const ZDocumentAuditLogEventDocumentCreatedSchema = z.object({
         z.object({
           type: z.literal(DocumentSource.TEMPLATE_DIRECT_LINK),
           templateId: z.number(),
-          directRecipientEmail: z.string().email(),
+          directRecipientEmail: ZEmail,
         }),
       ])
       .optional(),

--- a/packages/lib/types/document-meta.ts
+++ b/packages/lib/types/document-meta.ts
@@ -6,6 +6,7 @@ import { VALID_DATE_FORMAT_VALUES } from '@documenso/lib/constants/date-formats'
 import { ZEnvelopeExpirationPeriod } from '@documenso/lib/constants/envelope-expiration';
 import { SUPPORTED_LANGUAGE_CODES } from '@documenso/lib/constants/i18n';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { DocumentMetaSchema } from '@documenso/prisma/generated/zod/modelSchema/DocumentMetaSchema';
 
 import { ZDocumentEmailSettingsSchema } from './document-email';
@@ -127,7 +128,7 @@ export const ZDocumentMetaCreateSchema = z.object({
   uploadSignatureEnabled: ZDocumentMetaUploadSignatureEnabledSchema.optional(),
   drawSignatureEnabled: ZDocumentMetaDrawSignatureEnabledSchema.optional(),
   emailId: z.string().nullish(),
-  emailReplyTo: z.string().email().nullish(),
+  emailReplyTo: ZEmail.nullish(),
   emailSettings: ZDocumentEmailSettingsSchema.nullish(),
   envelopeExpirationPeriod: ZEnvelopeExpirationPeriod.nullish(),
 });

--- a/packages/lib/types/embed-direct-template-schema.ts
+++ b/packages/lib/types/embed-direct-template-schema.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
+import { ZEmail } from '../utils/zod';
 import { ZBaseEmbedDataSchema } from './embed-base-schemas';
 
 export const ZDirectTemplateEmbedDataSchema = ZBaseEmbedDataSchema.extend({
   email: z
-    .union([z.literal(''), z.string().email()])
+    .union([z.literal(''), ZEmail])
     .optional()
     .transform((value) => value || undefined),
   lockEmail: z.boolean().optional().default(false),

--- a/packages/lib/types/embed-document-sign-schema.ts
+++ b/packages/lib/types/embed-document-sign-schema.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
+import { ZEmail } from '../utils/zod';
 import { ZBaseEmbedDataSchema } from './embed-base-schemas';
 
 export const ZSignDocumentEmbedDataSchema = ZBaseEmbedDataSchema.extend({
   email: z
-    .union([z.literal(''), z.string().email()])
+    .union([z.literal(''), ZEmail])
     .optional()
     .transform((value) => value || undefined),
   lockEmail: z.boolean().optional().default(false),

--- a/packages/lib/types/embed-multisign-document-schema.ts
+++ b/packages/lib/types/embed-multisign-document-schema.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
+import { ZEmail } from '../utils/zod';
 import { ZBaseEmbedDataSchema } from './embed-base-schemas';
 
 export const ZEmbedMultiSignDocumentSchema = ZBaseEmbedDataSchema.extend({
   email: z
-    .union([z.literal(''), z.string().email()])
+    .union([z.literal(''), ZEmail])
     .optional()
     .transform((value) => value || undefined),
   lockEmail: z.boolean().optional().default(false),

--- a/packages/lib/types/recipient.ts
+++ b/packages/lib/types/recipient.ts
@@ -4,6 +4,7 @@ import { RecipientSchema } from '@documenso/prisma/generated/zod/modelSchema/Rec
 import { TeamSchema } from '@documenso/prisma/generated/zod/modelSchema/TeamSchema';
 import { UserSchema } from '@documenso/prisma/generated/zod/modelSchema/UserSchema';
 
+import { zEmail } from '../utils/zod';
 import { ZFieldSchema } from './field';
 
 /**
@@ -119,5 +120,5 @@ export const ZEnvelopeRecipientManySchema = ZRecipientManySchema.omit({
 
 export const ZRecipientEmailSchema = z.union([
   z.literal(''),
-  z.string().trim().toLowerCase().email({ message: 'Invalid email' }).max(254),
+  zEmail('Invalid email').trim().toLowerCase().max(254),
 ]);

--- a/packages/lib/utils/envelope-signing.ts
+++ b/packages/lib/utils/envelope-signing.ts
@@ -21,6 +21,7 @@ import {
   ZTextFieldMeta,
 } from '@documenso/lib/types/field-meta';
 import { toCheckboxCustomText, toRadioCustomText } from '@documenso/lib/utils/fields';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import type { TSignEnvelopeFieldValue } from '@documenso/trpc/server/envelope-router/sign-envelope-field.types';
 import { checkboxValidationSigns } from '@documenso/ui/primitives/document-flow/field-items-advanced-settings/constants';
 
@@ -37,7 +38,7 @@ export const extractFieldInsertionValues = ({
 }: ExtractFieldInsertionValuesOptions): { customText: string; inserted: boolean } => {
   return match(fieldValue)
     .with({ type: FieldType.EMAIL }, (fieldValue) => {
-      const parsedEmailValue = z.string().email().nullable().safeParse(fieldValue.value);
+      const parsedEmailValue = ZEmail.nullable().safeParse(fieldValue.value);
 
       if (!parsedEmailValue.success) {
         throw new AppError(AppErrorCode.INVALID_BODY, {

--- a/packages/lib/utils/recipients.ts
+++ b/packages/lib/utils/recipients.ts
@@ -1,12 +1,12 @@
 import type { Envelope } from '@prisma/client';
 import { type Field, type Recipient, RecipientRole, SigningStatus } from '@prisma/client';
-import { z } from 'zod';
 
 import { isSignatureFieldType } from '@documenso/prisma/guards/is-signature-field';
 
 import { NEXT_PUBLIC_WEBAPP_URL } from '../constants/app';
 import { AppError, AppErrorCode } from '../errors/app-error';
 import { extractLegacyIds } from '../universal/id';
+import { ZEmail } from './zod';
 
 /**
  * Roles that require fields to be assigned before a document can be distributed.
@@ -93,7 +93,7 @@ export const mapRecipientToLegacyRecipient = (
 };
 
 export const isRecipientEmailValidForSending = (recipient: Pick<Recipient, 'email'>) => {
-  return z.string().email().safeParse(recipient.email).success;
+  return ZEmail.safeParse(recipient.email).success;
 };
 
 /**

--- a/packages/lib/utils/zod.ts
+++ b/packages/lib/utils/zod.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+/**
+ * RFC 5322 compliant email regex.
+ *
+ * This is more permissive than Zod's built-in `.email()` validator which rejects
+ * valid international characters (e.g. "Søren@gmail.com").
+ *
+ * Compiled once at module level to avoid re-compilation on every validation call.
+ */
+const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\u{0080}-\u{FFFF}-]+@[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?(?:\.[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?)*$/u;
+
+const DEFAULT_EMAIL_MESSAGE = 'Invalid email address';
+
+/**
+ * A Zod schema for validating email addresses using an RFC 5322 compliant regex.
+ *
+ * This supports international characters in the local part and domain
+ * (e.g. "Søren@gmail.com", "user@dömain.com").
+ *
+ * Use `zEmail()` if you need to pass a custom error message.
+ */
+export const ZEmail = z.string().regex(EMAIL_REGEX, { message: DEFAULT_EMAIL_MESSAGE });
+
+/**
+ * Creates a Zod email schema with an optional custom error message.
+ *
+ * @example
+ * ```ts
+ * // With default message
+ * zEmail()
+ *
+ * // With custom message string
+ * zEmail('Email is invalid')
+ *
+ * // With message object
+ * zEmail({ message: 'Email is invalid' })
+ * ```
+ */
+export const zEmail = (options?: string | { message?: string }) => {
+  const message =
+    typeof options === 'string' ? options : (options?.message ?? DEFAULT_EMAIL_MESSAGE);
+
+  return z.string().regex(EMAIL_REGEX, { message });
+};

--- a/packages/trpc/server/admin-router/update-recipient.types.ts
+++ b/packages/trpc/server/admin-router/update-recipient.types.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
+import { ZEmail } from '@documenso/lib/utils/zod';
+
 export const ZUpdateRecipientRequestSchema = z.object({
   id: z.number().min(1),
   name: z.string().optional(),
-  email: z.string().email().optional(),
+  email: ZEmail.optional(),
   role: z.enum(['CC', 'SIGNER', 'VIEWER', 'APPROVER', 'ASSISTANT']).optional(),
 });
 

--- a/packages/trpc/server/admin-router/update-user.types.ts
+++ b/packages/trpc/server/admin-router/update-user.types.ts
@@ -1,10 +1,12 @@
 import { Role } from '@prisma/client';
 import { z } from 'zod';
 
+import { ZEmail } from '@documenso/lib/utils/zod';
+
 export const ZUpdateUserRequestSchema = z.object({
   id: z.number().min(1),
   name: z.string().nullish(),
-  email: z.string().email().optional(),
+  email: ZEmail.optional(),
   roles: z.array(z.nativeEnum(Role)).optional(),
 });
 

--- a/packages/trpc/server/document-router/distribute-document.types.ts
+++ b/packages/trpc/server/document-router/distribute-document.types.ts
@@ -11,6 +11,7 @@ import {
   ZDocumentMetaSubjectSchema,
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
+import { ZEmail } from '@documenso/lib/utils/zod';
 
 import type { TrpcRouteMeta } from '../trpc';
 
@@ -36,7 +37,7 @@ export const ZDistributeDocumentRequestSchema = z.object({
       redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
       language: ZDocumentMetaLanguageSchema.optional(),
       emailId: z.string().nullish(),
-      emailReplyTo: z.string().email().nullish(),
+      emailReplyTo: ZEmail.nullish(),
       emailSettings: ZDocumentEmailSettingsSchema.optional(),
     })
     .optional(),

--- a/packages/trpc/server/embedding-router/create-embedding-document.types.ts
+++ b/packages/trpc/server/embedding-router/create-embedding-document.types.ts
@@ -21,6 +21,7 @@ import {
   ZFieldWidthSchema,
 } from '@documenso/lib/types/field';
 import { ZFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { RecipientRole } from '@documenso/prisma/client';
 import { DocumentSigningOrder } from '@documenso/prisma/generated/types';
 
@@ -33,7 +34,7 @@ export const ZCreateEmbeddingDocumentRequestSchema = z.object({
   recipients: z.array(
     z.object({
       id: z.number().optional(),
-      email: z.string().email(),
+      email: ZEmail,
       name: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().optional(),

--- a/packages/trpc/server/embedding-router/update-embedding-document.types.ts
+++ b/packages/trpc/server/embedding-router/update-embedding-document.types.ts
@@ -21,6 +21,7 @@ import {
   ZFieldWidthSchema,
 } from '@documenso/lib/types/field';
 import { ZFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { DocumentSigningOrder, RecipientRole } from '@documenso/prisma/generated/types';
 
 import { ZDocumentExternalIdSchema, ZDocumentTitleSchema } from '../document-router/schema';
@@ -32,7 +33,7 @@ export const ZUpdateEmbeddingDocumentRequestSchema = z.object({
   recipients: z.array(
     z.object({
       id: z.number().optional(),
-      email: z.string().email(),
+      email: ZEmail,
       name: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().optional(),

--- a/packages/trpc/server/enterprise-router/create-organisation-email.types.ts
+++ b/packages/trpc/server/enterprise-router/create-organisation-email.types.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
+import { zEmail } from '@documenso/lib/utils/zod';
+
 export const ZCreateOrganisationEmailRequestSchema = z.object({
   emailDomainId: z.string(),
   emailName: z.string().min(1).max(100),
-  email: z.string().email().toLowerCase(),
+  email: zEmail().toLowerCase(),
 
   // This does not need to be validated to be part of the domain.
   // replyTo: z.string().email().optional(),

--- a/packages/trpc/server/envelope-router/create-envelope.types.ts
+++ b/packages/trpc/server/envelope-router/create-envelope.types.ts
@@ -17,6 +17,7 @@ import {
   ZFieldPageNumberSchema,
 } from '@documenso/lib/types/field';
 import { ZEnvelopeFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 import { zfdFile, zodFormData } from '../../utils/zod-form-data';
 import {
@@ -41,9 +42,7 @@ export const createEnvelopeMeta: TrpcRouteMeta = {
 export const ZCreateEnvelopePayloadSchema = z.object({
   title: ZDocumentTitleSchema,
   type: z.nativeEnum(EnvelopeType),
-  delegatedDocumentOwner: z
-    .string()
-    .email()
+  delegatedDocumentOwner: zEmail()
     .describe('The email of the user who will own the document.')
     .optional(),
   externalId: ZDocumentExternalIdSchema.optional(),

--- a/packages/trpc/server/organisation-router/create-organisation-member-invites.types.ts
+++ b/packages/trpc/server/organisation-router/create-organisation-member-invites.types.ts
@@ -1,6 +1,8 @@
 import { OrganisationMemberRole } from '@prisma/client';
 import { z } from 'zod';
 
+import { zEmail } from '@documenso/lib/utils/zod';
+
 // export const createOrganisationMemberInvitesMeta: TrpcOpenApiMeta = {
 //   openapi: {
 //     method: 'POST',
@@ -16,7 +18,7 @@ export const ZCreateOrganisationMemberInvitesRequestSchema = z.object({
   invitations: z
     .array(
       z.object({
-        email: z.string().trim().email().toLowerCase(),
+        email: zEmail().trim().toLowerCase(),
         organisationRole: z.nativeEnum(OrganisationMemberRole),
       }),
     )

--- a/packages/trpc/server/organisation-router/update-organisation-settings.types.ts
+++ b/packages/trpc/server/organisation-router/update-organisation-settings.types.ts
@@ -9,6 +9,7 @@ import {
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
 import { DocumentVisibility } from '@documenso/lib/types/document-visibility';
+import { ZEmail } from '@documenso/lib/utils/zod';
 
 export const ZUpdateOrganisationSettingsRequestSchema = z.object({
   organisationId: z.string(),
@@ -36,7 +37,7 @@ export const ZUpdateOrganisationSettingsRequestSchema = z.object({
 
     // Email related settings.
     emailId: z.string().nullish(),
-    emailReplyTo: z.string().email().nullish(),
+    emailReplyTo: ZEmail.nullish(),
     // emailReplyToName: z.string().optional(),
     emailDocumentSettings: ZDocumentEmailSettingsSchema.optional(),
 

--- a/packages/trpc/server/recipient-router/find-recipient-suggestions.types.ts
+++ b/packages/trpc/server/recipient-router/find-recipient-suggestions.types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ZEmail } from '@documenso/lib/utils/zod';
+
 export const ZGetRecipientSuggestionsRequestSchema = z.object({
   query: z.string().default(''),
 });
@@ -8,7 +10,7 @@ export const ZGetRecipientSuggestionsResponseSchema = z.object({
   results: z.array(
     z.object({
       name: z.string().nullable(),
-      email: z.union([z.string().email(), z.literal('')]),
+      email: z.union([ZEmail, z.literal('')]),
     }),
   ),
 });

--- a/packages/trpc/server/recipient-router/schema.ts
+++ b/packages/trpc/server/recipient-router/schema.ts
@@ -9,6 +9,7 @@ import {
   ZRecipientActionAuthTypesSchema,
 } from '@documenso/lib/types/document-auth';
 import { ZRecipientLiteSchema, ZRecipientSchema } from '@documenso/lib/types/recipient';
+import { ZEmail, zEmail } from '@documenso/lib/utils/zod';
 
 export const ZGetRecipientRequestSchema = z.object({
   recipientId: z.number(),
@@ -24,7 +25,7 @@ export const ZGetRecipientResponseSchema = ZRecipientSchema;
  * pass along required details.
  */
 export const ZCreateRecipientSchema = z.object({
-  email: z.string().toLowerCase().email().min(1).max(254),
+  email: zEmail().toLowerCase().min(1).max(254),
   name: z.string().max(255),
   role: z.nativeEnum(RecipientRole),
   signingOrder: z.number().optional(),
@@ -34,7 +35,7 @@ export const ZCreateRecipientSchema = z.object({
 
 export const ZUpdateRecipientSchema = z.object({
   id: z.number().describe('The ID of the recipient to update.'),
-  email: z.string().toLowerCase().email().min(1).max(254).optional(),
+  email: zEmail().toLowerCase().min(1).max(254).optional(),
   name: z.string().max(255).optional(),
   role: z.nativeEnum(RecipientRole).optional(),
   signingOrder: z.number().optional(),
@@ -83,7 +84,7 @@ export const ZSetDocumentRecipientsRequestSchema = z.object({
   recipients: z.array(
     z.object({
       id: z.number().optional(),
-      email: z.string().toLowerCase().email().min(1).max(254),
+      email: zEmail().toLowerCase().min(1).max(254),
       name: z.string().max(255),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().optional(),
@@ -142,10 +143,7 @@ export const ZSetTemplateRecipientsRequestSchema = z.object({
         .toLowerCase()
         .refine(
           (email) => {
-            return (
-              isTemplateRecipientEmailPlaceholder(email) ||
-              z.string().email().safeParse(email).success
-            );
+            return isTemplateRecipientEmailPlaceholder(email) || ZEmail.safeParse(email).success;
           },
           { message: 'Please enter a valid email address' },
         ),
@@ -167,13 +165,13 @@ export const ZCompleteDocumentWithTokenMutationSchema = z.object({
   accessAuthOptions: ZRecipientAccessAuthSchema.optional(),
   nextSigner: z
     .object({
-      email: z.string().email().max(254),
+      email: ZEmail.max(254),
       name: z.string().min(1).max(255),
     })
     .optional(),
   recipientOverride: z
     .object({
-      email: z.string().trim().toLowerCase().email().max(254).optional(),
+      email: zEmail().trim().toLowerCase().max(254).optional(),
       name: z.string().max(255).optional(),
     })
     .optional(),

--- a/packages/trpc/server/team-router/schema.ts
+++ b/packages/trpc/server/team-router/schema.ts
@@ -2,6 +2,7 @@ import { TeamMemberRole } from '@prisma/client';
 import { z } from 'zod';
 
 import { PROTECTED_TEAM_URLS } from '@documenso/lib/constants/teams';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 /**
  * Restrict team URLs schema.
@@ -43,7 +44,7 @@ export const ZTeamNameSchema = z
 export const ZCreateTeamEmailVerificationMutationSchema = z.object({
   teamId: z.number(),
   name: z.string().trim().min(1, { message: 'Please enter a valid name.' }),
-  email: z.string().trim().email().toLowerCase().min(1, 'Please enter a valid email.'),
+  email: zEmail().trim().toLowerCase().min(1, 'Please enter a valid email.'),
 });
 
 export const ZDeleteTeamEmailMutationSchema = z.object({

--- a/packages/trpc/server/team-router/update-team-settings.types.ts
+++ b/packages/trpc/server/team-router/update-team-settings.types.ts
@@ -9,6 +9,7 @@ import {
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
 import { DocumentVisibility } from '@documenso/lib/types/document-visibility';
+import { ZEmail } from '@documenso/lib/utils/zod';
 
 /**
  * Null = Inherit from organisation.
@@ -39,7 +40,7 @@ export const ZUpdateTeamSettingsRequestSchema = z.object({
 
     // Email related settings.
     emailId: z.string().nullish(),
-    emailReplyTo: z.string().email().nullish(),
+    emailReplyTo: ZEmail.nullish(),
     // emailReplyToName: z.string().nullish(),
     emailDocumentSettings: ZDocumentEmailSettingsSchema.nullish(),
 

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -32,6 +32,7 @@ import {
   ZTemplateManySchema,
   ZTemplateSchema,
 } from '@documenso/lib/types/template';
+import { ZEmail } from '@documenso/lib/utils/zod';
 import { LegacyTemplateDirectLinkSchema } from '@documenso/prisma/types/template-legacy-schema';
 import { ZDocumentExternalIdSchema } from '@documenso/trpc/server/document-router/schema';
 
@@ -73,7 +74,7 @@ export const ZTemplateMetaUpsertSchema = z.object({
   dateFormat: ZDocumentMetaDateFormatSchema.optional(),
   distributionMethod: ZDocumentMetaDistributionMethodSchema.optional(),
   emailId: z.string().nullish(),
-  emailReplyTo: z.string().email().nullish(),
+  emailReplyTo: ZEmail.nullish(),
   emailSettings: ZDocumentEmailSettingsSchema.optional(),
   redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
   language: ZDocumentMetaLanguageSchema.optional(),
@@ -86,14 +87,14 @@ export const ZTemplateMetaUpsertSchema = z.object({
 
 export const ZCreateDocumentFromDirectTemplateRequestSchema = z.object({
   directRecipientName: z.string().max(255).optional(),
-  directRecipientEmail: z.string().email().max(254),
+  directRecipientEmail: ZEmail.max(254),
   directTemplateToken: z.string().min(1),
   directTemplateExternalId: z.string().optional(),
   signedFieldValues: z.array(ZSignFieldWithTokenMutationSchema),
   templateUpdatedAt: z.date(),
   nextSigner: z
     .object({
-      email: z.string().email().max(254),
+      email: ZEmail.max(254),
       name: z.string().min(1).max(255),
     })
     .optional(),

--- a/packages/ui/primitives/document-flow/add-signers.types.ts
+++ b/packages/ui/primitives/document-flow/add-signers.types.ts
@@ -3,16 +3,14 @@ import { DocumentSigningOrder, RecipientRole } from '@prisma/client';
 import { z } from 'zod';
 
 import { ZRecipientActionAuthTypesSchema } from '@documenso/lib/types/document-auth';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZAddSignersFormSchema = z.object({
   signers: z.array(
     z.object({
       formId: z.string().min(1),
       nativeId: z.number().optional(),
-      email: z
-        .string()
-        .email({ message: msg`Invalid email`.id })
-        .min(1),
+      email: zEmail(msg`Invalid email`.id).min(1),
       name: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().optional(),

--- a/packages/ui/primitives/document-flow/add-subject.types.ts
+++ b/packages/ui/primitives/document-flow/add-subject.types.ts
@@ -2,14 +2,12 @@ import { DocumentDistributionMethod } from '@prisma/client';
 import { z } from 'zod';
 
 import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
+import { ZEmail } from '@documenso/lib/utils/zod';
 
 export const ZAddSubjectFormSchema = z.object({
   meta: z.object({
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess(
-      (val) => (val === '' ? undefined : val),
-      z.string().email().optional(),
-    ),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
     // emailReplyName: z.string().optional(),
     subject: z.string(),
     message: z.string(),

--- a/packages/ui/primitives/document-flow/types.ts
+++ b/packages/ui/primitives/document-flow/types.ts
@@ -4,6 +4,7 @@ import { FieldType } from '@prisma/client';
 import { z } from 'zod';
 
 import { ZFieldMetaSchema } from '@documenso/lib/types/field-meta';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZDocumentFlowFormSchema = z.object({
   title: z.string().min(1),
@@ -12,7 +13,7 @@ export const ZDocumentFlowFormSchema = z.object({
     z.object({
       formId: z.string().min(1),
       nativeId: z.number().optional(),
-      email: z.string().min(1).email(),
+      email: zEmail().min(1),
       name: z.string(),
     }),
   ),

--- a/packages/ui/primitives/template-flow/add-template-placeholder-recipients.types.ts
+++ b/packages/ui/primitives/template-flow/add-template-placeholder-recipients.types.ts
@@ -2,6 +2,7 @@ import { DocumentSigningOrder, RecipientRole } from '@prisma/client';
 import { z } from 'zod';
 
 import { ZRecipientActionAuthTypesSchema } from '@documenso/lib/types/document-auth';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZAddTemplatePlacholderRecipientsFormSchema = z
   .object({
@@ -9,7 +10,7 @@ export const ZAddTemplatePlacholderRecipientsFormSchema = z
       z.object({
         formId: z.string().min(1),
         nativeId: z.number().optional(),
-        email: z.string().min(1).email(),
+        email: zEmail().min(1),
         name: z.string().min(1, { message: 'Name is required' }),
         role: z.nativeEnum(RecipientRole),
         signingOrder: z.number().optional(),

--- a/packages/ui/primitives/template-flow/add-template-settings.types.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.types.tsx
@@ -17,6 +17,7 @@ import {
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
+import { ZEmail } from '@documenso/lib/utils/zod';
 
 export const ZAddTemplateSettingsFormSchema = z.object({
   title: z.string().trim().min(1, { message: "Title can't be empty" }),
@@ -50,10 +51,7 @@ export const ZAddTemplateSettingsFormSchema = z.object({
       .optional()
       .default('en'),
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess(
-      (val) => (val === '' ? undefined : val),
-      z.string().email().optional(),
-    ),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
     emailSettings: ZDocumentEmailSettingsSchema,
     signatureTypes: z.array(z.nativeEnum(DocumentSignatureType)).min(1, {
       message: msg`At least one signature type must be enabled`.id,


### PR DESCRIPTION
Zod's built-in .email() validator is too strict and rejects valid international email addresses (e.g. Søren@gmail.com). 

This adds a shared ZEmail const and zEmail() factory in packages/lib/utils/zod.ts using an RFC 5322 compliant regex that supports Unicode characters, and replaces all ~60 z.string().email() usages across the codebase.
