### PR TITLE
fix: replace z.string().email() with RFC 5322 compliant zEmail()

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-distribute-dialog.tsx
@@ -16,7 +16,7 @@ import { useCurrentOrganisation } from '@documenso/lib/client-only/providers/org
 import { DO_NOT_INVALIDATE_QUERY_ON_MUTATION } from '@documenso/lib/constants/trpc';
 import { extractDocumentAuthMethods } from '@documenso/lib/utils/document-auth';
 import { getRecipientsWithMissingFields } from '@documenso/lib/utils/recipients';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { trpc, trpc as trpcReact } from '@documenso/trpc/react';
 import { DocumentSendEmailMessageHelper } from '@documenso/ui/components/document/document-send-email-message-helper';
 import { cn } from '@documenso/ui/lib/utils';
@@ -63,7 +63,7 @@ export type EnvelopeDistributeDialogProps = {
 export const ZEnvelopeDistributeFormSchema = z.object({
   meta: z.object({
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), zEmail().optional()),
     subject: z.string(),
     message: z.string(),
     distributionMethod: z

--- a/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
@@ -17,7 +17,7 @@ import { IS_BILLING_ENABLED, SUPPORT_EMAIL } from '@documenso/lib/constants/app'
 import { ORGANISATION_MEMBER_ROLE_HIERARCHY } from '@documenso/lib/constants/organisations';
 import { ORGANISATION_MEMBER_ROLE_MAP } from '@documenso/lib/constants/organisations-translations';
 import { INTERNAL_CLAIM_ID } from '@documenso/lib/types/subscription';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { ZCreateOrganisationMemberInvitesRequestSchema } from '@documenso/trpc/server/organisation-router/create-organisation-member-invites.types';
 import { cn } from '@documenso/ui/lib/utils';
@@ -95,7 +95,7 @@ type TabTypes = 'INDIVIDUAL' | 'BULK';
 
 const ZImportOrganisationMemberSchema = z.array(
   z.object({
-    email: ZEmail,
+    email: zEmail(),
     organisationRole: z.nativeEnum(OrganisationMemberRole),
   }),
 );

--- a/apps/remix/app/components/dialogs/sign-field-email-dialog.tsx
+++ b/apps/remix/app/components/dialogs/sign-field-email-dialog.tsx
@@ -5,7 +5,7 @@ import { createCallable } from 'react-call';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { Button } from '@documenso/ui/primitives/button';
 import {
   Dialog,
@@ -25,7 +25,7 @@ import {
 import { Input } from '@documenso/ui/primitives/input';
 
 const ZSignFieldEmailFormSchema = z.object({
-  email: ZEmail.min(1, { message: msg`Email is required`.id }),
+  email: zEmail().min(1, { message: msg`Email is required`.id }),
 });
 
 type TSignFieldEmailFormSchema = z.infer<typeof ZSignFieldEmailFormSchema>;

--- a/apps/remix/app/components/embed/embed-direct-template-client-page.tsx
+++ b/apps/remix/app/components/embed/embed-direct-template-client-page.tsx
@@ -29,7 +29,7 @@ import {
 import { getDocumentDataUrlForPdfViewer } from '@documenso/lib/utils/envelope-download';
 import { sortFieldsByPosition, validateFieldsInserted } from '@documenso/lib/utils/fields';
 import { dynamicActivate } from '@documenso/lib/utils/i18n';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { isSignatureFieldType } from '@documenso/prisma/guards/is-signature-field';
 import { trpc } from '@documenso/trpc/react';
 import type {
@@ -211,7 +211,7 @@ export const EmbedDirectTemplateClientPage = ({
         return;
       }
 
-      const { success: isEmailValid } = ZEmail.safeParse(email);
+      const { success: isEmailValid } = zEmail().safeParse(email);
 
       if (!isEmailValid) {
         setEmailError(_(msg`A valid email is required`));

--- a/apps/remix/app/components/forms/email-preferences-form.tsx
+++ b/apps/remix/app/components/forms/email-preferences-form.tsx
@@ -10,7 +10,7 @@ import {
   DEFAULT_DOCUMENT_EMAIL_SETTINGS,
   ZDocumentEmailSettingsSchema,
 } from '@documenso/lib/types/document-email';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { DocumentEmailCheckboxes } from '@documenso/ui/components/document/document-email-checkboxes';
 import { Button } from '@documenso/ui/primitives/button';
@@ -34,7 +34,7 @@ import {
 
 const ZEmailPreferencesFormSchema = z.object({
   emailId: z.string().nullable(),
-  emailReplyTo: ZEmail.nullable(),
+  emailReplyTo: zEmail().nullable(),
   // emailReplyToName: z.string(),
   emailDocumentSettings: ZDocumentEmailSettingsSchema.nullable(),
 });

--- a/apps/remix/app/components/forms/forgot-password.tsx
+++ b/apps/remix/app/components/forms/forgot-password.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router';
 import { z } from 'zod';
 
 import { authClient } from '@documenso/auth/client';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -22,7 +22,7 @@ import { Input } from '@documenso/ui/primitives/input';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export const ZForgotPasswordFormSchema = z.object({
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
 });
 
 export type TForgotPasswordFormSchema = z.infer<typeof ZForgotPasswordFormSchema>;

--- a/apps/remix/app/components/forms/send-confirmation-email.tsx
+++ b/apps/remix/app/components/forms/send-confirmation-email.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { authClient } from '@documenso/auth/client';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -21,7 +21,7 @@ import { Input } from '@documenso/ui/primitives/input';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 export const ZSendConfirmationEmailFormSchema = z.object({
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
 });
 
 export type TSendConfirmationEmailFormSchema = z.infer<typeof ZSendConfirmationEmailFormSchema>;

--- a/apps/remix/app/components/forms/signin.tsx
+++ b/apps/remix/app/components/forms/signin.tsx
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { authClient } from '@documenso/auth/client';
 import { AuthenticationErrorCode } from '@documenso/auth/server/lib/errors/error-codes';
 import { AppError } from '@documenso/lib/errors/app-error';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { ZCurrentPasswordSchema } from '@documenso/trpc/server/auth-router/schema';
 import { cn } from '@documenso/ui/lib/utils';
@@ -59,7 +59,7 @@ const handleFallbackErrorMessages = (code: string) => {
 const LOGIN_REDIRECT_PATH = '/';
 
 export const ZSignInFormSchema = z.object({
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
   password: ZCurrentPasswordSchema,
   totpCode: z.string().trim().optional(),
   backupCode: z.string().trim().optional(),

--- a/apps/remix/app/components/forms/signup.tsx
+++ b/apps/remix/app/components/forms/signup.tsx
@@ -15,7 +15,7 @@ import communityCardsImage from '@documenso/assets/images/community-cards.png';
 import { authClient } from '@documenso/auth/client';
 import { useAnalytics } from '@documenso/lib/client-only/hooks/use-analytics';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { ZPasswordSchema } from '@documenso/trpc/server/auth-router/schema';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
@@ -40,7 +40,7 @@ export const ZSignUpFormSchema = z
       .string()
       .trim()
       .min(1, { message: msg`Please enter a valid name.`.id }),
-    email: ZEmail.min(1),
+    email: zEmail().min(1),
     password: ZPasswordSchema,
     signature: z.string().min(1, { message: msg`We need your signature to sign documents`.id }),
   })

--- a/apps/remix/app/components/general/claim-account.tsx
+++ b/apps/remix/app/components/general/claim-account.tsx
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { authClient } from '@documenso/auth/client';
 import { useAnalytics } from '@documenso/lib/client-only/hooks/use-analytics';
 import { AppError } from '@documenso/lib/errors/app-error';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { ZPasswordSchema } from '@documenso/trpc/server/auth-router/schema';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -38,7 +38,7 @@ export const ZClaimAccountFormSchema = z
       .string()
       .trim()
       .min(1, { message: msg`Please enter a valid name.`.id }),
-    email: ZEmail.min(1),
+    email: zEmail().min(1),
     password: ZPasswordSchema,
   })
   .refine(

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
@@ -51,7 +51,7 @@ import {
   canAccessTeamDocument,
   extractTeamSignatureSettings,
 } from '@documenso/lib/utils/teams';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { DocumentEmailCheckboxes } from '@documenso/ui/components/document/document-email-checkboxes';
 import {
@@ -139,7 +139,7 @@ export const ZAddSettingsFormSchema = z.object({
       .optional()
       .default('en'),
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), zEmail().optional()),
     emailSettings: ZDocumentEmailSettingsSchema,
     signatureTypes: z.array(z.nativeEnum(DocumentSignatureType)).min(1, {
       message: msg`At least one signature type must be enabled`.id,

--- a/apps/remix/app/components/tables/admin-document-recipient-item-table.tsx
+++ b/apps/remix/app/components/tables/admin-document-recipient-item-table.tsx
@@ -14,7 +14,7 @@ import { useForm } from 'react-hook-form';
 import { useRevalidator } from 'react-router';
 import { z } from 'zod';
 
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
 import type { DataTableColumnDef } from '@documenso/ui/primitives/data-table';
@@ -47,7 +47,7 @@ const RECIPIENT_ROLE_LABELS: Record<RecipientRole, string> = {
 
 const ZAdminUpdateRecipientFormSchema = z.object({
   name: z.string().min(1),
-  email: ZEmail,
+  email: zEmail(),
   role: z.nativeEnum(RecipientRole),
 });
 

--- a/packages/api/v1/schema.ts
+++ b/packages/api/v1/schema.ts
@@ -24,7 +24,7 @@ import {
 import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
 import { ZEnvelopeAttachmentTypeSchema } from '@documenso/lib/types/envelope-attachment';
 import { ZFieldMetaPrefillFieldsSchema, ZFieldMetaSchema } from '@documenso/lib/types/field-meta';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 extendZodWithOpenApi(z);
 
@@ -151,7 +151,7 @@ export const ZCreateDocumentMutationSchema = z.object({
   recipients: z.array(
     z.object({
       name: z.string().min(1),
-      email: ZEmail.min(1),
+      email: zEmail().min(1),
       role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
       signingOrder: z.number().nullish(),
     }),
@@ -225,7 +225,7 @@ export const ZCreateDocumentMutationResponseSchema = z.object({
     z.object({
       recipientId: z.number(),
       name: z.string(),
-      email: ZEmail.min(1),
+      email: zEmail().min(1),
       token: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().nullish(),
@@ -245,7 +245,7 @@ export const ZCreateDocumentFromTemplateMutationSchema = z.object({
   recipients: z.array(
     z.object({
       name: z.string().min(1),
-      email: ZEmail.min(1),
+      email: zEmail().min(1),
       role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
       signingOrder: z.number().nullish(),
     }),
@@ -300,7 +300,7 @@ export const ZCreateDocumentFromTemplateMutationResponseSchema = z.object({
     z.object({
       recipientId: z.number(),
       name: z.string(),
-      email: ZEmail.min(1),
+      email: zEmail().min(1),
       token: z.string(),
       role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
       signingOrder: z.number().nullish(),
@@ -327,7 +327,7 @@ export const ZGenerateDocumentFromTemplateMutationSchema = z.object({
     .array(
       z.object({
         id: z.number(),
-        email: ZEmail,
+        email: zEmail(),
         name: z.string().optional(),
         signingOrder: z.number().optional(),
       }),
@@ -387,7 +387,7 @@ export const ZGenerateDocumentFromTemplateMutationResponseSchema = z.object({
     z.object({
       recipientId: z.number(),
       name: z.string(),
-      email: ZEmail.min(1),
+      email: zEmail().min(1),
       token: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().nullish(),
@@ -403,7 +403,7 @@ export type TGenerateDocumentFromTemplateMutationResponseSchema = z.infer<
 
 export const ZCreateRecipientMutationSchema = z.object({
   name: z.string().min(1),
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
   role: z.nativeEnum(RecipientRole).optional().default(RecipientRole.SIGNER),
   signingOrder: z.number().nullish(),
   authOptions: z
@@ -438,7 +438,7 @@ export const ZSuccessfulRecipientResponseSchema = z.object({
   // !: This handles the fact that we have null documentId's for templates
   // !: while we won't need the default we must add it to satisfy typescript
   documentId: z.number().nullish().default(-1),
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
   name: z.string(),
   role: z.nativeEnum(RecipientRole),
   signingOrder: z.number().nullish(),
@@ -577,7 +577,7 @@ export const ZRecipientSchema = z.object({
   id: z.number(),
   documentId: z.number().nullish(),
   templateId: z.number().nullish(),
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
   name: z.string(),
   token: z.string(),
   signingOrder: z.number().nullish(),

--- a/packages/auth/server/types/email-password.ts
+++ b/packages/auth/server/types/email-password.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZCurrentPasswordSchema = z
   .string()
@@ -8,7 +8,7 @@ export const ZCurrentPasswordSchema = z
   .max(72);
 
 export const ZSignInSchema = z.object({
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
   password: ZCurrentPasswordSchema,
   totpCode: z.string().trim().optional(),
   backupCode: z.string().trim().optional(),
@@ -36,7 +36,7 @@ export const ZPasswordSchema = z
 
 export const ZSignUpSchema = z.object({
   name: z.string().min(1),
-  email: ZEmail,
+  email: zEmail(),
   password: ZPasswordSchema,
   signature: z.string().nullish(),
 });
@@ -44,7 +44,7 @@ export const ZSignUpSchema = z.object({
 export type TSignUpSchema = z.infer<typeof ZSignUpSchema>;
 
 export const ZForgotPasswordSchema = z.object({
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
 });
 
 export type TForgotPasswordSchema = z.infer<typeof ZForgotPasswordSchema>;
@@ -63,7 +63,7 @@ export const ZVerifyEmailSchema = z.object({
 export type TVerifyEmailSchema = z.infer<typeof ZVerifyEmailSchema>;
 
 export const ZResendVerifyEmailSchema = z.object({
-  email: ZEmail.min(1),
+  email: zEmail().min(1),
 });
 
 export type TResendVerifyEmailSchema = z.infer<typeof ZResendVerifyEmailSchema>;

--- a/packages/lib/jobs/definitions/emails/send-confirmation-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-confirmation-email.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
-import { ZEmail } from '../../../utils/zod';
+import { zEmail } from '../../../utils/zod';
 import type { JobDefinition } from '../../client/_internal/job';
 
 const SEND_CONFIRMATION_EMAIL_JOB_DEFINITION_ID = 'send.signup.confirmation.email';
 
 const SEND_CONFIRMATION_EMAIL_JOB_DEFINITION_SCHEMA = z.object({
-  email: ZEmail,
+  email: zEmail(),
   force: z.boolean().optional(),
 });
 

--- a/packages/lib/types/default-recipients.ts
+++ b/packages/lib/types/default-recipients.ts
@@ -1,10 +1,10 @@
 import { RecipientRole } from '@prisma/client';
 import { z } from 'zod';
 
-import { ZEmail } from '../utils/zod';
+import { zEmail } from '../utils/zod';
 
 export const ZDefaultRecipientSchema = z.object({
-  email: ZEmail,
+  email: zEmail(),
   name: z.string(),
   role: z.nativeEnum(RecipientRole),
 });

--- a/packages/lib/types/document-audit-logs.ts
+++ b/packages/lib/types/document-audit-logs.ts
@@ -7,7 +7,7 @@
 import { DocumentSource, FieldType } from '@prisma/client';
 import { z } from 'zod';
 
-import { ZEmail } from '../utils/zod';
+import { zEmail } from '../utils/zod';
 import { ZRecipientAccessAuthTypesSchema, ZRecipientActionAuthTypesSchema } from './document-auth';
 
 export const ZDocumentAuditLogTypeSchema = z.enum([
@@ -280,7 +280,7 @@ export const ZDocumentAuditLogEventDocumentCreatedSchema = z.object({
         z.object({
           type: z.literal(DocumentSource.TEMPLATE_DIRECT_LINK),
           templateId: z.number(),
-          directRecipientEmail: ZEmail,
+          directRecipientEmail: zEmail(),
         }),
       ])
       .optional(),

--- a/packages/lib/types/document-meta.ts
+++ b/packages/lib/types/document-meta.ts
@@ -6,7 +6,7 @@ import { VALID_DATE_FORMAT_VALUES } from '@documenso/lib/constants/date-formats'
 import { ZEnvelopeExpirationPeriod } from '@documenso/lib/constants/envelope-expiration';
 import { SUPPORTED_LANGUAGE_CODES } from '@documenso/lib/constants/i18n';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { DocumentMetaSchema } from '@documenso/prisma/generated/zod/modelSchema/DocumentMetaSchema';
 
 import { ZDocumentEmailSettingsSchema } from './document-email';
@@ -128,7 +128,7 @@ export const ZDocumentMetaCreateSchema = z.object({
   uploadSignatureEnabled: ZDocumentMetaUploadSignatureEnabledSchema.optional(),
   drawSignatureEnabled: ZDocumentMetaDrawSignatureEnabledSchema.optional(),
   emailId: z.string().nullish(),
-  emailReplyTo: ZEmail.nullish(),
+  emailReplyTo: zEmail().nullish(),
   emailSettings: ZDocumentEmailSettingsSchema.nullish(),
   envelopeExpirationPeriod: ZEnvelopeExpirationPeriod.nullish(),
 });

--- a/packages/lib/types/embed-direct-template-schema.ts
+++ b/packages/lib/types/embed-direct-template-schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { ZEmail } from '../utils/zod';
+import { zEmail } from '../utils/zod';
 import { ZBaseEmbedDataSchema } from './embed-base-schemas';
 
 export const ZDirectTemplateEmbedDataSchema = ZBaseEmbedDataSchema.extend({
   email: z
-    .union([z.literal(''), ZEmail])
+    .union([z.literal(''), zEmail()])
     .optional()
     .transform((value) => value || undefined),
   lockEmail: z.boolean().optional().default(false),

--- a/packages/lib/types/embed-document-sign-schema.ts
+++ b/packages/lib/types/embed-document-sign-schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { ZEmail } from '../utils/zod';
+import { zEmail } from '../utils/zod';
 import { ZBaseEmbedDataSchema } from './embed-base-schemas';
 
 export const ZSignDocumentEmbedDataSchema = ZBaseEmbedDataSchema.extend({
   email: z
-    .union([z.literal(''), ZEmail])
+    .union([z.literal(''), zEmail()])
     .optional()
     .transform((value) => value || undefined),
   lockEmail: z.boolean().optional().default(false),

--- a/packages/lib/types/embed-multisign-document-schema.ts
+++ b/packages/lib/types/embed-multisign-document-schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { ZEmail } from '../utils/zod';
+import { zEmail } from '../utils/zod';
 import { ZBaseEmbedDataSchema } from './embed-base-schemas';
 
 export const ZEmbedMultiSignDocumentSchema = ZBaseEmbedDataSchema.extend({
   email: z
-    .union([z.literal(''), ZEmail])
+    .union([z.literal(''), zEmail()])
     .optional()
     .transform((value) => value || undefined),
   lockEmail: z.boolean().optional().default(false),

--- a/packages/lib/utils/envelope-signing.ts
+++ b/packages/lib/utils/envelope-signing.ts
@@ -21,7 +21,7 @@ import {
   ZTextFieldMeta,
 } from '@documenso/lib/types/field-meta';
 import { toCheckboxCustomText, toRadioCustomText } from '@documenso/lib/utils/fields';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import type { TSignEnvelopeFieldValue } from '@documenso/trpc/server/envelope-router/sign-envelope-field.types';
 import { checkboxValidationSigns } from '@documenso/ui/primitives/document-flow/field-items-advanced-settings/constants';
 
@@ -38,7 +38,7 @@ export const extractFieldInsertionValues = ({
 }: ExtractFieldInsertionValuesOptions): { customText: string; inserted: boolean } => {
   return match(fieldValue)
     .with({ type: FieldType.EMAIL }, (fieldValue) => {
-      const parsedEmailValue = ZEmail.nullable().safeParse(fieldValue.value);
+      const parsedEmailValue = zEmail().nullable().safeParse(fieldValue.value);
 
       if (!parsedEmailValue.success) {
         throw new AppError(AppErrorCode.INVALID_BODY, {

--- a/packages/lib/utils/recipients.ts
+++ b/packages/lib/utils/recipients.ts
@@ -6,7 +6,7 @@ import { isSignatureFieldType } from '@documenso/prisma/guards/is-signature-fiel
 import { NEXT_PUBLIC_WEBAPP_URL } from '../constants/app';
 import { AppError, AppErrorCode } from '../errors/app-error';
 import { extractLegacyIds } from '../universal/id';
-import { ZEmail } from './zod';
+import { zEmail } from './zod';
 
 /**
  * Roles that require fields to be assigned before a document can be distributed.
@@ -93,7 +93,7 @@ export const mapRecipientToLegacyRecipient = (
 };
 
 export const isRecipientEmailValidForSending = (recipient: Pick<Recipient, 'email'>) => {
-  return ZEmail.safeParse(recipient.email).success;
+  return zEmail().safeParse(recipient.email).success;
 };
 
 /**

--- a/packages/lib/utils/zod.ts
+++ b/packages/lib/utils/zod.ts
@@ -14,27 +14,20 @@ const EMAIL_REGEX =
 const DEFAULT_EMAIL_MESSAGE = 'Invalid email address';
 
 /**
- * A Zod schema for validating email addresses using an RFC 5322 compliant regex.
+ * Creates a Zod email schema using an RFC 5322 compliant regex.
  *
- * This supports international characters in the local part and domain
+ * Supports international characters in the local part and domain
  * (e.g. "Søren@gmail.com", "user@dömain.com").
  *
- * Use `zEmail()` if you need to pass a custom error message.
- */
-export const ZEmail = z.string().regex(EMAIL_REGEX, { message: DEFAULT_EMAIL_MESSAGE });
-
-/**
- * Creates a Zod email schema with an optional custom error message.
+ * Returns a standard `ZodString` so all string methods are chainable:
+ * `.min()`, `.max()`, `.trim()`, `.toLowerCase()`, `.optional()`, `.nullish()`, etc.
  *
  * @example
  * ```ts
- * // With default message
  * zEmail()
- *
- * // With custom message string
+ * zEmail().min(1).max(254)
+ * zEmail().trim().toLowerCase()
  * zEmail('Email is invalid')
- *
- * // With message object
  * zEmail({ message: 'Email is invalid' })
  * ```
  */

--- a/packages/trpc/server/admin-router/update-recipient.types.ts
+++ b/packages/trpc/server/admin-router/update-recipient.types.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZUpdateRecipientRequestSchema = z.object({
   id: z.number().min(1),
   name: z.string().optional(),
-  email: ZEmail.optional(),
+  email: zEmail().optional(),
   role: z.enum(['CC', 'SIGNER', 'VIEWER', 'APPROVER', 'ASSISTANT']).optional(),
 });
 

--- a/packages/trpc/server/admin-router/update-user.types.ts
+++ b/packages/trpc/server/admin-router/update-user.types.ts
@@ -1,12 +1,12 @@
 import { Role } from '@prisma/client';
 import { z } from 'zod';
 
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZUpdateUserRequestSchema = z.object({
   id: z.number().min(1),
   name: z.string().nullish(),
-  email: ZEmail.optional(),
+  email: zEmail().optional(),
   roles: z.array(z.nativeEnum(Role)).optional(),
 });
 

--- a/packages/trpc/server/document-router/distribute-document.types.ts
+++ b/packages/trpc/server/document-router/distribute-document.types.ts
@@ -11,7 +11,7 @@ import {
   ZDocumentMetaSubjectSchema,
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 import type { TrpcRouteMeta } from '../trpc';
 
@@ -37,7 +37,7 @@ export const ZDistributeDocumentRequestSchema = z.object({
       redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
       language: ZDocumentMetaLanguageSchema.optional(),
       emailId: z.string().nullish(),
-      emailReplyTo: ZEmail.nullish(),
+      emailReplyTo: zEmail().nullish(),
       emailSettings: ZDocumentEmailSettingsSchema.optional(),
     })
     .optional(),

--- a/packages/trpc/server/embedding-router/create-embedding-document.types.ts
+++ b/packages/trpc/server/embedding-router/create-embedding-document.types.ts
@@ -21,7 +21,7 @@ import {
   ZFieldWidthSchema,
 } from '@documenso/lib/types/field';
 import { ZFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { RecipientRole } from '@documenso/prisma/client';
 import { DocumentSigningOrder } from '@documenso/prisma/generated/types';
 
@@ -34,7 +34,7 @@ export const ZCreateEmbeddingDocumentRequestSchema = z.object({
   recipients: z.array(
     z.object({
       id: z.number().optional(),
-      email: ZEmail,
+      email: zEmail(),
       name: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().optional(),

--- a/packages/trpc/server/embedding-router/update-embedding-document.types.ts
+++ b/packages/trpc/server/embedding-router/update-embedding-document.types.ts
@@ -21,7 +21,7 @@ import {
   ZFieldWidthSchema,
 } from '@documenso/lib/types/field';
 import { ZFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { DocumentSigningOrder, RecipientRole } from '@documenso/prisma/generated/types';
 
 import { ZDocumentExternalIdSchema, ZDocumentTitleSchema } from '../document-router/schema';
@@ -33,7 +33,7 @@ export const ZUpdateEmbeddingDocumentRequestSchema = z.object({
   recipients: z.array(
     z.object({
       id: z.number().optional(),
-      email: ZEmail,
+      email: zEmail(),
       name: z.string(),
       role: z.nativeEnum(RecipientRole),
       signingOrder: z.number().optional(),

--- a/packages/trpc/server/organisation-router/update-organisation-settings.types.ts
+++ b/packages/trpc/server/organisation-router/update-organisation-settings.types.ts
@@ -9,7 +9,7 @@ import {
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
 import { DocumentVisibility } from '@documenso/lib/types/document-visibility';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZUpdateOrganisationSettingsRequestSchema = z.object({
   organisationId: z.string(),
@@ -37,7 +37,7 @@ export const ZUpdateOrganisationSettingsRequestSchema = z.object({
 
     // Email related settings.
     emailId: z.string().nullish(),
-    emailReplyTo: ZEmail.nullish(),
+    emailReplyTo: zEmail().nullish(),
     // emailReplyToName: z.string().optional(),
     emailDocumentSettings: ZDocumentEmailSettingsSchema.optional(),
 

--- a/packages/trpc/server/recipient-router/find-recipient-suggestions.types.ts
+++ b/packages/trpc/server/recipient-router/find-recipient-suggestions.types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZGetRecipientSuggestionsRequestSchema = z.object({
   query: z.string().default(''),
@@ -10,7 +10,7 @@ export const ZGetRecipientSuggestionsResponseSchema = z.object({
   results: z.array(
     z.object({
       name: z.string().nullable(),
-      email: z.union([ZEmail, z.literal('')]),
+      email: z.union([zEmail(), z.literal('')]),
     }),
   ),
 });

--- a/packages/trpc/server/recipient-router/schema.ts
+++ b/packages/trpc/server/recipient-router/schema.ts
@@ -9,7 +9,7 @@ import {
   ZRecipientActionAuthTypesSchema,
 } from '@documenso/lib/types/document-auth';
 import { ZRecipientLiteSchema, ZRecipientSchema } from '@documenso/lib/types/recipient';
-import { ZEmail, zEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZGetRecipientRequestSchema = z.object({
   recipientId: z.number(),
@@ -143,7 +143,7 @@ export const ZSetTemplateRecipientsRequestSchema = z.object({
         .toLowerCase()
         .refine(
           (email) => {
-            return isTemplateRecipientEmailPlaceholder(email) || ZEmail.safeParse(email).success;
+            return isTemplateRecipientEmailPlaceholder(email) || zEmail().safeParse(email).success;
           },
           { message: 'Please enter a valid email address' },
         ),
@@ -165,7 +165,7 @@ export const ZCompleteDocumentWithTokenMutationSchema = z.object({
   accessAuthOptions: ZRecipientAccessAuthSchema.optional(),
   nextSigner: z
     .object({
-      email: ZEmail.max(254),
+      email: zEmail().max(254),
       name: z.string().min(1).max(255),
     })
     .optional(),

--- a/packages/trpc/server/team-router/update-team-settings.types.ts
+++ b/packages/trpc/server/team-router/update-team-settings.types.ts
@@ -9,7 +9,7 @@ import {
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
 import { DocumentVisibility } from '@documenso/lib/types/document-visibility';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 /**
  * Null = Inherit from organisation.
@@ -40,7 +40,7 @@ export const ZUpdateTeamSettingsRequestSchema = z.object({
 
     // Email related settings.
     emailId: z.string().nullish(),
-    emailReplyTo: ZEmail.nullish(),
+    emailReplyTo: zEmail().nullish(),
     // emailReplyToName: z.string().nullish(),
     emailDocumentSettings: ZDocumentEmailSettingsSchema.nullish(),
 

--- a/packages/trpc/server/template-router/schema.ts
+++ b/packages/trpc/server/template-router/schema.ts
@@ -32,7 +32,7 @@ import {
   ZTemplateManySchema,
   ZTemplateSchema,
 } from '@documenso/lib/types/template';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 import { LegacyTemplateDirectLinkSchema } from '@documenso/prisma/types/template-legacy-schema';
 import { ZDocumentExternalIdSchema } from '@documenso/trpc/server/document-router/schema';
 
@@ -74,7 +74,7 @@ export const ZTemplateMetaUpsertSchema = z.object({
   dateFormat: ZDocumentMetaDateFormatSchema.optional(),
   distributionMethod: ZDocumentMetaDistributionMethodSchema.optional(),
   emailId: z.string().nullish(),
-  emailReplyTo: ZEmail.nullish(),
+  emailReplyTo: zEmail().nullish(),
   emailSettings: ZDocumentEmailSettingsSchema.optional(),
   redirectUrl: ZDocumentMetaRedirectUrlSchema.optional(),
   language: ZDocumentMetaLanguageSchema.optional(),
@@ -87,14 +87,14 @@ export const ZTemplateMetaUpsertSchema = z.object({
 
 export const ZCreateDocumentFromDirectTemplateRequestSchema = z.object({
   directRecipientName: z.string().max(255).optional(),
-  directRecipientEmail: ZEmail.max(254),
+  directRecipientEmail: zEmail().max(254),
   directTemplateToken: z.string().min(1),
   directTemplateExternalId: z.string().optional(),
   signedFieldValues: z.array(ZSignFieldWithTokenMutationSchema),
   templateUpdatedAt: z.date(),
   nextSigner: z
     .object({
-      email: ZEmail.max(254),
+      email: zEmail().max(254),
       name: z.string().min(1).max(255),
     })
     .optional(),

--- a/packages/ui/primitives/document-flow/add-subject.types.ts
+++ b/packages/ui/primitives/document-flow/add-subject.types.ts
@@ -2,12 +2,12 @@ import { DocumentDistributionMethod } from '@prisma/client';
 import { z } from 'zod';
 
 import { ZDocumentEmailSettingsSchema } from '@documenso/lib/types/document-email';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZAddSubjectFormSchema = z.object({
   meta: z.object({
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), zEmail().optional()),
     // emailReplyName: z.string().optional(),
     subject: z.string(),
     message: z.string(),

--- a/packages/ui/primitives/template-flow/add-template-settings.types.tsx
+++ b/packages/ui/primitives/template-flow/add-template-settings.types.tsx
@@ -17,7 +17,7 @@ import {
   ZDocumentMetaTimezoneSchema,
 } from '@documenso/lib/types/document-meta';
 import { isValidRedirectUrl } from '@documenso/lib/utils/is-valid-redirect-url';
-import { ZEmail } from '@documenso/lib/utils/zod';
+import { zEmail } from '@documenso/lib/utils/zod';
 
 export const ZAddTemplateSettingsFormSchema = z.object({
   title: z.string().trim().min(1, { message: "Title can't be empty" }),
@@ -51,7 +51,7 @@ export const ZAddTemplateSettingsFormSchema = z.object({
       .optional()
       .default('en'),
     emailId: z.string().nullable(),
-    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), ZEmail.optional()),
+    emailReplyTo: z.preprocess((val) => (val === '' ? undefined : val), zEmail().optional()),
     emailSettings: ZDocumentEmailSettingsSchema,
     signatureTypes: z.array(z.nativeEnum(DocumentSignatureType)).min(1, {
       message: msg`At least one signature type must be enabled`.id,


### PR DESCRIPTION
Zod's built-in .email() validator is too strict and rejects valid
international email addresses (e.g. Søren@gmail.com). This adds a
shared zEmail() factory in packages/lib/utils/zod.ts using an RFC 5322
compliant regex that supports Unicode characters, and replaces all ~60
z.string().email() usages across the codebase.

zEmail() returns a standard ZodString so all methods chain naturally:
zEmail().min(1).max(254).trim().toLowerCase().optional()
zEmail('Custom error message')
