### PR TITLE
fix: handle corrupted backup codes gracefully in getBackupCodes

### DIFF
--- a/packages/lib/server-only/2fa/get-backup-code.ts
+++ b/packages/lib/server-only/2fa/get-backup-code.ts
@@ -25,17 +25,21 @@ export const getBackupCodes = ({ user }: GetBackupCodesOptions) => {
     throw new Error('User has no backup codes');
   }
 
-  const secret = Buffer.from(symmetricDecrypt({ key, data: user.twoFactorBackupCodes })).toString(
-    'utf-8',
-  );
+  try {
+    const secret = Buffer.from(
+      symmetricDecrypt({ key, data: user.twoFactorBackupCodes }),
+    ).toString('utf-8');
 
-  const data = JSON.parse(secret);
+    const data = JSON.parse(secret);
 
-  const result = ZBackupCodeSchema.safeParse(data);
+    const result = ZBackupCodeSchema.safeParse(data);
 
-  if (result.success) {
-    return result.data;
+    if (result.success) {
+      return result.data;
+    }
+
+    return null;
+  } catch {
+    return null;
   }
-
-  return null;
 };


### PR DESCRIPTION
Was looking into a 500 error a user on our self-hosted instance hit when trying to view their 2FA backup codes. Turned out the encrypted blob in the database had gotten corrupted during a migration, and `JSON.parse(secret)` on line 32 of `get-backup-code.ts` threw an unhandled `SyntaxError`.

Both callers (`viewBackupCodes` and `verifyBackupCode`) check for a `null` return, but neither catches a parse exception from `getBackupCodes` itself — so the error bubbles up as a raw 500 instead of the expected `MISSING_BACKUP_CODE` response.

The fix wraps the decrypt → parse → validate sequence in a try-catch that returns `null` on failure. This matches the exact pattern already used in `decryptSecondaryData` (`packages/lib/server-only/crypto/decrypt.ts` lines 16-36), which does the same decrypt → `JSON.parse` → schema validate flow but correctly catches parse errors.