### PR TITLE
feat: improve document signing & rejection flow with settings support

### DIFF
--- a/apps/remix/app/components/forms/document-preferences-form.tsx
+++ b/apps/remix/app/components/forms/document-preferences-form.tsx
@@ -76,6 +76,7 @@ export type TDocumentPreferencesFormSchema = {
   delegateDocumentOwnership: boolean | null;
   aiFeaturesEnabled: boolean | null;
   envelopeExpirationPeriod: TEnvelopeExpirationPeriod | null;
+  requireRejectionReason: boolean | null;
 };
 
 type SettingsSubset = Pick<
@@ -94,6 +95,7 @@ type SettingsSubset = Pick<
   | 'delegateDocumentOwnership'
   | 'aiFeaturesEnabled'
   | 'envelopeExpirationPeriod'
+  | 'requireRejectionReason'
 >;
 
 export type DocumentPreferencesFormProps = {
@@ -134,6 +136,7 @@ export const DocumentPreferencesForm = ({
     delegateDocumentOwnership: z.boolean().nullable(),
     aiFeaturesEnabled: z.boolean().nullable(),
     envelopeExpirationPeriod: ZEnvelopeExpirationPeriod.nullable(),
+    requireRejectionReason: z.boolean().nullable(),
   });
 
   const form = useForm<TDocumentPreferencesFormSchema>({
@@ -155,6 +158,7 @@ export const DocumentPreferencesForm = ({
       delegateDocumentOwnership: settings.delegateDocumentOwnership,
       aiFeaturesEnabled: settings.aiFeaturesEnabled,
       envelopeExpirationPeriod: settings.envelopeExpirationPeriod ?? null,
+      requireRejectionReason: settings.requireRejectionReason,
     },
     resolver: zodResolver(ZDocumentPreferencesFormSchema),
   });
@@ -538,6 +542,54 @@ export const DocumentPreferencesForm = ({
                     Controls whether the audit logs will be included in the document when it is
                     downloaded. The audit logs can still be downloaded from the logs page
                     separately.
+                  </Trans>
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="requireRejectionReason"
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormLabel>
+                  <Trans>Require Rejection Reason</Trans>
+                </FormLabel>
+
+                <FormControl>
+                  <Select
+                    {...field}
+                    value={field.value === null ? '-1' : field.value.toString()}
+                    onValueChange={(value) =>
+                      field.onChange(value === 'true' ? true : value === 'false' ? false : null)
+                    }
+                  >
+                    <SelectTrigger className="bg-background text-muted-foreground">
+                      <SelectValue />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectItem value="true">
+                        <Trans>Yes</Trans>
+                      </SelectItem>
+
+                      <SelectItem value="false">
+                        <Trans>No</Trans>
+                      </SelectItem>
+
+                      {canInherit && (
+                        <SelectItem value={'-1'}>
+                          <Trans>Inherit from organisation</Trans>
+                        </SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+
+                <FormDescription>
+                  <Trans>
+                    Controls whether recipients must provide a reason when rejecting a document.
                   </Trans>
                 </FormDescription>
               </FormItem>

--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
@@ -60,6 +60,7 @@ export type DocumentSigningPageViewV1Props = {
   isRecipientsTurn: boolean;
   allRecipients?: RecipientWithFields[];
   includeSenderDetails: boolean;
+  requireRejectionReason?: boolean;
 };
 
 export const DocumentSigningPageViewV1 = ({
@@ -70,6 +71,7 @@ export const DocumentSigningPageViewV1 = ({
   isRecipientsTurn,
   allRecipients = [],
   includeSenderDetails,
+  requireRejectionReason = false,
 }: DocumentSigningPageViewV1Props) => {
   const { documentData, documentMeta } = document;
 
@@ -265,7 +267,7 @@ export const DocumentSigningPageViewV1 = ({
               envelopeId={document.envelopeId}
               token={recipient.token}
             />
-            <DocumentSigningRejectDialog documentId={document.id} token={recipient.token} />
+            <DocumentSigningRejectDialog documentId={document.id} token={recipient.token} requireReason={requireRejectionReason} />
           </div>
         </div>
 

--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v2.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v2.tsx
@@ -204,6 +204,7 @@ export const DocumentSigningPageViewV2 = () => {
                   <DocumentSigningRejectDialog
                     documentId={mapSecondaryIdToDocumentId(envelope.secondaryId)}
                     token={recipient.token}
+                    requireReason={envelope.settings?.requireRejectionReason ?? false}
                     onRejected={
                       onDocumentRejected &&
                       ((reason) =>

--- a/apps/remix/app/components/general/document-signing/document-signing-reject-dialog.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-reject-dialog.tsx
@@ -33,6 +33,10 @@ const ZRejectDocumentFormSchema = z.object({
   reason: z.string().max(500, msg`Reason must be less than 500 characters`),
 });
 
+const ZRejectDocumentFormSchemaRequired = z.object({
+  reason: z.string().min(1, msg`Reason is required`).max(500, msg`Reason must be less than 500 characters`),
+});
+
 type TRejectDocumentFormSchema = z.infer<typeof ZRejectDocumentFormSchema>;
 
 export interface DocumentSigningRejectDialogProps {
@@ -40,6 +44,7 @@ export interface DocumentSigningRejectDialogProps {
   token: string;
   onRejected?: (reason: string) => void | Promise<void>;
   trigger?: React.ReactNode;
+  requireReason?: boolean;
 }
 
 export function DocumentSigningRejectDialog({
@@ -47,6 +52,7 @@ export function DocumentSigningRejectDialog({
   token,
   onRejected,
   trigger,
+  requireReason = false,
 }: DocumentSigningRejectDialogProps) {
   const { t } = useLingui();
   const { toast } = useToast();
@@ -58,8 +64,10 @@ export function DocumentSigningRejectDialog({
   const { mutateAsync: rejectDocumentWithToken } =
     trpc.recipient.rejectDocumentWithToken.useMutation();
 
+  const formSchema = requireReason ? ZRejectDocumentFormSchemaRequired : ZRejectDocumentFormSchema;
+
   const form = useForm<TRejectDocumentFormSchema>({
-    resolver: zodResolver(ZRejectDocumentFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       reason: '',
     },

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.document.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.document.tsx
@@ -62,6 +62,7 @@ export default function OrganisationSettingsDocumentPage() {
         delegateDocumentOwnership,
         aiFeaturesEnabled,
         envelopeExpirationPeriod,
+        requireRejectionReason,
       } = data;
 
       if (
@@ -71,7 +72,8 @@ export default function OrganisationSettingsDocumentPage() {
         includeSenderDetails === null ||
         includeSigningCertificate === null ||
         includeAuditLog === null ||
-        aiFeaturesEnabled === null
+        aiFeaturesEnabled === null ||
+        requireRejectionReason === null
       ) {
         throw new Error('Should not be possible.');
       }
@@ -93,6 +95,7 @@ export default function OrganisationSettingsDocumentPage() {
           delegateDocumentOwnership: delegateDocumentOwnership,
           aiFeaturesEnabled,
           envelopeExpirationPeriod: envelopeExpirationPeriod ?? undefined,
+          requireRejectionReason,
         },
       });
 

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.document.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.document.tsx
@@ -55,6 +55,7 @@ export default function TeamsSettingsPage() {
         delegateDocumentOwnership,
         aiFeaturesEnabled,
         envelopeExpirationPeriod,
+        requireRejectionReason,
       } = data;
 
       await updateTeamSettings({
@@ -70,6 +71,7 @@ export default function TeamsSettingsPage() {
           defaultRecipients,
           aiFeaturesEnabled,
           envelopeExpirationPeriod,
+          requireRejectionReason,
           ...(signatureTypes.length === 0
             ? {
                 typedSignatureEnabled: null,

--- a/apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
+++ b/apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
@@ -170,6 +170,7 @@ const handleV1Loader = async ({ params, request }: Route.LoaderArgs) => {
     recipientSignature,
     isRecipientsTurn,
     includeSenderDetails: settings.includeSenderDetails,
+    requireRejectionReason: settings.requireRejectionReason,
   } as const;
 };
 
@@ -341,6 +342,7 @@ const SigningPageV1 = ({ data }: { data: Awaited<ReturnType<typeof handleV1Loade
     isRecipientsTurn,
     allRecipients,
     includeSenderDetails,
+    requireRejectionReason,
     recipientWithFields,
   } = data;
 
@@ -421,6 +423,7 @@ const SigningPageV1 = ({ data }: { data: Awaited<ReturnType<typeof handleV1Loade
               isRecipientsTurn={isRecipientsTurn}
               allRecipients={allRecipients}
               includeSenderDetails={includeSenderDetails}
+              requireRejectionReason={requireRejectionReason}
             />
           </div>
         </>

--- a/packages/lib/server-only/document/reject-document-with-token.ts
+++ b/packages/lib/server-only/document/reject-document-with-token.ts
@@ -10,6 +10,7 @@ import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
 import type { EnvelopeIdOptions } from '../../utils/envelope';
 import { mapSecondaryIdToDocumentId, unsafeBuildEnvelopeIdQuery } from '../../utils/envelope';
 import { assertRecipientNotExpired } from '../../utils/recipients';
+import { getTeamSettings } from '../../server-only/team/get-team-settings';
 
 export type RejectDocumentWithTokenOptions = {
   token: string;
@@ -50,6 +51,14 @@ export async function rejectDocumentWithToken({
   }
 
   assertRecipientNotExpired(recipient);
+
+  const settings = await getTeamSettings({ teamId: envelope.teamId });
+
+  if (settings.requireRejectionReason && !reason?.trim()) {
+    throw new AppError(AppErrorCode.INVALID_BODY, {
+      message: 'A reason for rejection is required',
+    });
+  }
 
   // Update the recipient status to rejected
   const [updatedRecipient] = await prisma.$transaction([

--- a/packages/lib/server-only/envelope/get-envelope-for-recipient-signing.ts
+++ b/packages/lib/server-only/envelope/get-envelope-for-recipient-signing.ts
@@ -143,6 +143,7 @@ export const ZEnvelopeForSigningResponse = z.object({
     includeSenderDetails: z.boolean(),
     brandingEnabled: z.boolean(),
     brandingLogo: z.string(),
+    requireRejectionReason: z.boolean(),
   }),
 });
 
@@ -303,6 +304,7 @@ export const getEnvelopeForRecipientSigning = async ({
       includeSenderDetails: settings.includeSenderDetails,
       brandingEnabled: settings.brandingEnabled,
       brandingLogo: settings.brandingLogo,
+      requireRejectionReason: settings.requireRejectionReason,
     },
   } satisfies EnvelopeForSigningResponse);
 };

--- a/packages/lib/utils/organisations.ts
+++ b/packages/lib/utils/organisations.ts
@@ -142,6 +142,8 @@ export const generateDefaultOrganisationSettings = (): Omit<
 
     envelopeExpirationPeriod: DEFAULT_ENVELOPE_EXPIRATION_PERIOD,
 
+    requireRejectionReason: false,
+
     aiFeaturesEnabled: false,
   };
 };

--- a/packages/lib/utils/teams.ts
+++ b/packages/lib/utils/teams.ts
@@ -208,6 +208,8 @@ export const generateDefaultTeamSettings = (): Omit<TeamGlobalSettings, 'id' | '
 
     envelopeExpirationPeriod: null,
 
+    requireRejectionReason: null,
+
     aiFeaturesEnabled: null,
   };
 };

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -859,6 +859,8 @@ model OrganisationGlobalSettings {
 
   envelopeExpirationPeriod Json? /// [EnvelopeExpirationPeriod] @zod.custom.use(ZEnvelopeExpirationPeriodSchema)
 
+  requireRejectionReason Boolean @default(false)
+
   // AI features settings.
   aiFeaturesEnabled Boolean @default(false)
 }
@@ -897,6 +899,8 @@ model TeamGlobalSettings {
   brandingCompanyDetails String?
 
   envelopeExpirationPeriod Json? /// [EnvelopeExpirationPeriod] @zod.custom.use(ZEnvelopeExpirationPeriodSchema)
+
+  requireRejectionReason Boolean?
 
   // AI features settings.
   aiFeaturesEnabled Boolean?

--- a/packages/trpc/server/organisation-router/update-organisation-settings.ts
+++ b/packages/trpc/server/organisation-router/update-organisation-settings.ts
@@ -54,6 +54,9 @@ export const updateOrganisationSettingsRoute = authenticatedProcedure
 
       // AI features settings.
       aiFeaturesEnabled,
+
+      // Rejection settings.
+      requireRejectionReason,
     } = data;
 
     if (Object.values(data).length === 0) {
@@ -166,6 +169,9 @@ export const updateOrganisationSettingsRoute = authenticatedProcedure
 
             // AI features settings.
             aiFeaturesEnabled,
+
+            // Rejection settings.
+            requireRejectionReason,
           },
         },
       },

--- a/packages/trpc/server/organisation-router/update-organisation-settings.types.ts
+++ b/packages/trpc/server/organisation-router/update-organisation-settings.types.ts
@@ -43,6 +43,9 @@ export const ZUpdateOrganisationSettingsRequestSchema = z.object({
 
     // AI features settings.
     aiFeaturesEnabled: z.boolean().optional(),
+
+    // Rejection settings.
+    requireRejectionReason: z.boolean().optional(),
   }),
 });
 

--- a/packages/trpc/server/team-router/update-team-settings.ts
+++ b/packages/trpc/server/team-router/update-team-settings.ts
@@ -58,6 +58,8 @@ export const updateTeamSettingsRoute = authenticatedProcedure
       defaultRecipients,
       // AI features settings.
       aiFeaturesEnabled,
+      // Rejection settings.
+      requireRejectionReason,
     } = data;
 
     if (Object.values(data).length === 0) {
@@ -174,6 +176,9 @@ export const updateTeamSettingsRoute = authenticatedProcedure
 
             // AI features settings.
             aiFeaturesEnabled,
+
+            // Rejection settings.
+            requireRejectionReason,
           },
         },
       },

--- a/packages/trpc/server/team-router/update-team-settings.types.ts
+++ b/packages/trpc/server/team-router/update-team-settings.types.ts
@@ -48,6 +48,8 @@ export const ZUpdateTeamSettingsRequestSchema = z.object({
     defaultRecipients: ZDefaultRecipientsSchema.nullish(),
     // AI features settings.
     aiFeaturesEnabled: z.boolean().nullish(),
+    // Rejection settings.
+    requireRejectionReason: z.boolean().nullish(),
   }),
 });
 


### PR DESCRIPTION
# Description

Adds support for configurable document signing and rejection across organisation and team settings, along with improvements to signing UI and rejection flow.

# Changes Made
Updated document preferences and settings (org/team)
Improved signing UI (V1 & V2)
Enhanced rejection flow with token support
Updated backend logic and Prisma schema

# Testing Performed

Tested signing and rejection flows
Verified settings updates reflect correctly

# Checklist
 Tested locally
 Follows coding standards
 
 Issue: #2652 