### PR TITLE
fix(ui): add container-type to field root for correct cqw resolution

### DIFF
--- a/packages/ui/components/field/field.tsx
+++ b/packages/ui/components/field/field.tsx
@@ -137,7 +137,7 @@ export function FieldRootContainer({
         data-inserted={field.inserted ? 'true' : 'false'}
         data-readonly={readonly ? 'true' : 'false'}
         className={cn(
-          'field--FieldRootContainer field-card-container dark-mode-disabled group relative z-20 flex h-full w-full items-center rounded-[2px] bg-white/90 ring-2 ring-gray-200 transition-all',
+          'field--FieldRootContainer field-card-container dark-mode-disabled group relative z-20 flex h-full w-full [container-type:inline-size] items-center rounded-[2px] bg-white/90 ring-2 ring-gray-200 transition-all',
           color?.base,
           {
             'px-2': field.type !== FieldType.SIGNATURE && field.type !== FieldType.FREE_SIGNATURE,


### PR DESCRIPTION
## Summary
Adds `container-type: inline-size` to the field root container so that `cqw` units in pre-filled text fields resolve relative to the field box instead of the viewport/page.

## Issue
Fixes #2669

## Changes
- Added `[container-type:inline-size]` Tailwind class to the `FieldRootContainer` div in `packages/ui/components/field/field.tsx`

## Testing
- Create a TEXT field with `readOnly: true` and a long pre-filled `text` value
- Verify text wraps within the field border in the signing preview instead of overflowing