### PR TITLE
fix: admin org sorting

### DIFF
--- a/packages/trpc/server/admin-router/find-admin-organisations.ts
+++ b/packages/trpc/server/admin-router/find-admin-organisations.ts
@@ -120,14 +120,16 @@ export const findAdminOrganisations = async ({
     };
   }
 
+  const orderBy: Prisma.OrganisationOrderByWithRelationInput[] = query
+    ? [{ subscription: { status: 'asc' } }, { name: 'asc' }]
+    : [{ createdAt: 'desc' }];
+
   const [data, count] = await Promise.all([
     prisma.organisation.findMany({
       where: whereClause,
       skip: Math.max(page - 1, 0) * perPage,
       take: perPage,
-      orderBy: {
-        createdAt: 'desc',
-      },
+      orderBy,
       select: {
         id: true,
         createdAt: true,


### PR DESCRIPTION
## Description

Sort the organisations in the admin panel by the subscription status first, then by name.

Only applies when a search input is passed in, otherwise will sort by createdAt.