### PR TITLE
feat: add AcroForm field sidecar generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ yarn-error.log*
 # logs
 logs.json
 
+# local signing analysis artifacts
+artifacts/poa/
+artifacts/acroform-field-sidecar/
+
 # claude
 .claude
 CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -581,20 +581,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "apps/docs/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/docs/node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -2914,6 +2900,10 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/@documenso/acroform-field-sidecar": {
+      "resolved": "packages/acroform-field-sidecar",
+      "link": true
     },
     "node_modules/@documenso/api": {
       "resolved": "packages/api",
@@ -37474,6 +37464,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/acroform-field-sidecar": {
+      "name": "@documenso/acroform-field-sidecar",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@libpdf/core": "^0.3.3",
+        "pdfjs-dist": "5.4.296"
+      },
+      "devDependencies": {
+        "@documenso/tsconfig": "*",
+        "vitest": "^4.0.18"
       }
     },
     "packages/api": {

--- a/packages/acroform-field-sidecar/package.json
+++ b/packages/acroform-field-sidecar/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@documenso/acroform-field-sidecar",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "inspect": "node --experimental-strip-types ./src/cli.ts inspect",
+    "generate": "node --experimental-strip-types ./src/cli.ts generate",
+    "bind-payload": "node --experimental-strip-types ./src/cli.ts bind-payload",
+    "render-preview": "node --experimental-strip-types ./src/cli.ts render-preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@libpdf/core": "^0.3.3",
+    "pdfjs-dist": "5.4.296"
+  },
+  "devDependencies": {
+    "@documenso/tsconfig": "*",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/acroform-field-sidecar/src/build-overlay-plan.ts
+++ b/packages/acroform-field-sidecar/src/build-overlay-plan.ts
@@ -1,0 +1,81 @@
+import type { TFieldSpec, TOverlayPlanField, TPolicy } from './schemas.ts';
+import { getDefaultFieldMeta } from './schemas.ts';
+
+const applyGeneratedOverlay = (spec: TFieldSpec, policy: TPolicy) => {
+  const generatedOverlays = policy.generatedOverlays ?? [];
+
+  return generatedOverlays.map<TOverlayPlanField>((overlay) => {
+    const field = spec.fields.find(
+      (candidate) =>
+        (overlay.sourceKey && candidate.sourceKey === overlay.sourceKey) ||
+        (overlay.rawName && candidate.rawName === overlay.rawName),
+    );
+
+    if (!field) {
+      throw new Error(
+        `Generated overlay ${overlay.bindingKey} could not find source field ${overlay.sourceKey ?? overlay.rawName}`,
+      );
+    }
+
+    return {
+      bindingKey: overlay.bindingKey,
+      sourceKey: field.sourceKey,
+      semanticKey: overlay.semanticKey ?? field.semanticKey,
+      semanticLabel: overlay.semanticLabel ?? field.semanticLabel ?? overlay.bindingKey,
+      classification: overlay.classification,
+      confidence: field.confidence === 'none' ? 'low' : field.confidence,
+      evidence: [...field.evidence, `generated overlay created from ${field.sourceKey}`],
+      generationRole: 'overlay-generated',
+      recipientKey: overlay.recipientKey,
+      envelopeItemKey: overlay.envelopeItemKey,
+      type: overlay.type,
+      page: field.page,
+      positionX: field.rectDocumenso.positionX,
+      positionY: field.rectDocumenso.positionY,
+      width: field.rectDocumenso.width,
+      height: field.rectDocumenso.height,
+      fieldMeta: overlay.fieldMeta ?? getDefaultFieldMeta(overlay.type),
+    };
+  });
+};
+
+const applyManualOverlay = (policy: TPolicy) =>
+  policy.manualOverlays.map<TOverlayPlanField>((overlay) => ({
+    bindingKey: overlay.bindingKey,
+    sourceKey: null,
+    semanticKey: overlay.semanticKey,
+    semanticLabel: overlay.semanticLabel,
+    classification: overlay.classification,
+    confidence: 'high',
+    evidence: [`manual overlay from policy for ${overlay.bindingKey}`, ...(overlay.note ? [overlay.note] : [])],
+    generationRole: 'overlay-manual',
+    recipientKey: overlay.recipientKey,
+    envelopeItemKey: overlay.envelopeItemKey,
+    type: overlay.type,
+    page: overlay.page,
+    positionX: overlay.positionX,
+    positionY: overlay.positionY,
+    width: overlay.width,
+    height: overlay.height,
+    fieldMeta: overlay.fieldMeta ?? getDefaultFieldMeta(overlay.type),
+  }));
+
+export const buildOverlayPlan = (spec: TFieldSpec, policy: TPolicy): TFieldSpec => {
+  const overlayPlan = [...applyGeneratedOverlay(spec, policy), ...applyManualOverlay(policy)];
+
+  if (overlayPlan.length === 0) {
+    throw new Error('Overlay plan is empty; at least one signing-layer field must be generated');
+  }
+
+  const hasSignatureField = overlayPlan.some((field) => field.type === 'SIGNATURE');
+
+  if (!hasSignatureField) {
+    throw new Error('Overlay plan is missing a required SIGNATURE field');
+  }
+
+  return {
+    ...spec,
+    overlayPlan,
+    unresolved: spec.fields.filter((field) => field.generationRole === 'unresolved'),
+  };
+};

--- a/packages/acroform-field-sidecar/src/cli.ts
+++ b/packages/acroform-field-sidecar/src/cli.ts
@@ -1,0 +1,227 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { buildOverlayPlan } from './build-overlay-plan.ts';
+import { extractAcroformInventory } from './extract-acroform.ts';
+import { bindDocumensoPayload, renderDocumensoFieldTemplate, renderSamplePayload } from './render-documenso-payload.ts';
+import {
+  getDefaultInputPdfPath,
+  getDefaultOutputDir,
+  getDefaultPolicyPath,
+  toStableJson,
+  type TBindings,
+  type TDocumensoFieldTemplate,
+  type TFieldSpec,
+  type TValidationMode,
+  validateWithDocumensoSchemasIfAvailable,
+} from './schemas.ts';
+import { loadPolicy, resolveSemantics } from './resolve-semantics.ts';
+
+type TCommand = 'inspect' | 'generate' | 'bind-payload' | 'render-preview';
+
+type TArgs = {
+  command: TCommand;
+  inputPath: string;
+  outputDir: string;
+  policyPath: string;
+  templatePath: string;
+  fieldSpecPath: string;
+  bindingsPath: string;
+  previewOutputPath: string;
+};
+
+const resolveArgs = (): TArgs => {
+  const [, , commandValue, ...rest] = process.argv;
+  const command = commandValue as TCommand;
+
+  if (
+    command !== 'inspect' &&
+    command !== 'generate' &&
+    command !== 'bind-payload' &&
+    command !== 'render-preview'
+  ) {
+    throw new Error(
+      'Usage: cli.ts <inspect|generate|bind-payload|render-preview> [--input path] [--out-dir path] [--policy path] [--template path] [--field-spec path] [--bindings path] [--out path]',
+    );
+  }
+
+  const args = new Map<string, string>();
+
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+
+    if (key?.startsWith('--') && value) {
+      args.set(key.slice(2), value);
+    }
+  }
+
+  return {
+    command,
+    inputPath: path.resolve(args.get('input') ?? getDefaultInputPdfPath()),
+    outputDir: path.resolve(args.get('out-dir') ?? getDefaultOutputDir()),
+    policyPath: path.resolve(args.get('policy') ?? getDefaultPolicyPath()),
+    templatePath: path.resolve(
+      args.get('template') ?? path.join(getDefaultOutputDir(), 'documenso-field-template.json'),
+    ),
+    fieldSpecPath: path.resolve(args.get('field-spec') ?? path.join(getDefaultOutputDir(), 'field-spec.json')),
+    bindingsPath: path.resolve(
+      args.get('bindings') ?? path.join(getDefaultOutputDir(), 'bindings.sample.json'),
+    ),
+    previewOutputPath: path.resolve(
+      args.get('out') ?? path.join(getDefaultOutputDir(), 'acroform-field-preview.pdf'),
+    ),
+  };
+};
+
+const writeFile = async (filePath: string, contents: string) => {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, contents);
+};
+
+const buildReport = (
+  inputPath: string,
+  spec: TFieldSpec,
+  policyPath: string,
+  validationMode: TValidationMode,
+) => {
+  const counts = {
+    total: spec.fields.length,
+    text: spec.fields.filter((field) => field.rawType === 'Tx').length,
+    button: spec.fields.filter((field) => field.rawType === 'Btn').length,
+    unresolved: spec.unresolved.length,
+    overlayManual: spec.overlayPlan.filter((field) => field.generationRole === 'overlay-manual').length,
+    policyOverrides: spec.fields.filter((field) =>
+      field.evidence.some((evidence) => evidence.startsWith('policy override applied')),
+    ).length,
+  };
+  const maintenanceRisky = counts.policyOverrides > 10 || counts.overlayManual > 3;
+  const verdict = maintenanceRisky
+    ? 'maintenance-risky, compare back to Option A'
+    : 'Option B still looks maintainable and remains preferred';
+
+  return [
+    '# AcroForm Field Sidecar Report',
+    '',
+    `- Input PDF: \`${inputPath}\``,
+    `- Policy: \`${policyPath}\``,
+    `- PDF SHA-256: \`${spec.source.sha256}\``,
+    `- Extraction method: \`${spec.source.extractionMethod}\``,
+    `- Parser mode: \`${spec.source.extractionMethod}\``,
+    `- Total widgets: \`${counts.total}\``,
+    `- Text widgets: \`${counts.text}\``,
+    `- Button widgets: \`${counts.button}\``,
+    `- Unresolved fields: \`${counts.unresolved}\``,
+    `- Manual overlay fields: \`${counts.overlayManual}\``,
+    `- Policy override count: \`${counts.policyOverrides}\``,
+    `- Payload validation mode: \`${validationMode}\``,
+    '',
+    '## Overlay Plan',
+    ...spec.overlayPlan.map(
+      (field) =>
+        `- ${field.bindingKey}: ${field.type} on page ${field.page} at (${field.positionX}, ${field.positionY}) size ${field.width}x${field.height}`,
+    ),
+    '',
+    '## Unresolved',
+    ...(spec.unresolved.length > 0
+      ? spec.unresolved.map((field) => `- ${field.sourceKey}: ${field.evidence.join('; ')}`)
+      : ['- none']),
+    '',
+    '## Verdict',
+    `- ${verdict}`,
+  ].join('\n') + '\n';
+};
+
+const runInspect = async ({ inputPath, outputDir }: TArgs) => {
+  const inventory = await extractAcroformInventory(inputPath);
+
+  await writeFile(path.join(outputDir, 'acroform-inventory.json'), toStableJson(inventory));
+};
+
+const runGenerate = async ({ inputPath, outputDir, policyPath }: TArgs) => {
+  const inventory = await extractAcroformInventory(inputPath);
+  const policy = await loadPolicy(policyPath);
+  const resolved = resolveSemantics(inventory, policy);
+  const spec = buildOverlayPlan(resolved, policy);
+  const template = renderDocumensoFieldTemplate(spec, policy);
+  const samplePayload = renderSamplePayload(template, policy);
+  const validationMode = await validateWithDocumensoSchemasIfAvailable(samplePayload);
+  const sampleBindings: TBindings = {
+    envelopeId: 'env_sample',
+    envelopeType: 'TEMPLATE',
+    recipientIds: {
+      [policy.signerRecipientKey]: 1001,
+    },
+    envelopeItemIds: {
+      [policy.primaryEnvelopeItemKey]: 'item_primary_pdf',
+    },
+  };
+
+  await writeFile(path.join(outputDir, 'acroform-inventory.json'), toStableJson(inventory));
+  await writeFile(path.join(outputDir, 'field-spec.json'), toStableJson(spec));
+  await writeFile(path.join(outputDir, 'documenso-field-template.json'), toStableJson(template));
+  await writeFile(path.join(outputDir, 'bindings.sample.json'), toStableJson(sampleBindings));
+  await writeFile(path.join(outputDir, 'documenso-field-payload.sample.json'), toStableJson(samplePayload));
+  await writeFile(path.join(outputDir, 'report.md'), buildReport(inputPath, spec, policyPath, validationMode));
+};
+
+const runBindPayload = async ({ templatePath, bindingsPath, outputDir }: TArgs) => {
+  const template = JSON.parse(await fs.readFile(templatePath, 'utf8')) as TDocumensoFieldTemplate;
+  const bindings = JSON.parse(await fs.readFile(bindingsPath, 'utf8')) as TBindings;
+  const payload = bindDocumensoPayload(template, bindings);
+
+  await validateWithDocumensoSchemasIfAvailable(payload);
+
+  await writeFile(path.join(outputDir, 'documenso-field-payload.sample.json'), toStableJson(payload));
+};
+
+const runRenderPreview = async ({
+  inputPath,
+  templatePath,
+  fieldSpecPath,
+  previewOutputPath,
+}: TArgs) => {
+  const { renderPreviewPdf } = await import('./render-preview.ts');
+  const result = await renderPreviewPdf({
+    inputPath,
+    templatePath,
+    fieldSpecPath,
+    outputPath: previewOutputPath,
+  });
+
+  console.log(
+    [
+      `Wrote debug preview PDF to ${result.outputPath}`,
+      `Imported fields: ${result.importedCount}`,
+      `Skipped fields: ${result.skippedCount}`,
+      `Candidate fields: ${result.candidateCount}`,
+      `Unresolved fields: ${result.unresolvedCount}`,
+    ].join('\n'),
+  );
+};
+
+const main = async () => {
+  const args = resolveArgs();
+
+  if (args.command === 'inspect') {
+    await runInspect(args);
+    return;
+  }
+
+  if (args.command === 'generate') {
+    await runGenerate(args);
+    return;
+  }
+
+  if (args.command === 'render-preview') {
+    await runRenderPreview(args);
+    return;
+  }
+
+  await runBindPayload(args);
+};
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/acroform-field-sidecar/src/extract-acroform.ts
+++ b/packages/acroform-field-sidecar/src/extract-acroform.ts
@@ -46,6 +46,12 @@ type TPdfJsInventoryResult = {
   fields: TPdfJsField[];
 } | null;
 
+type TPageTreeNode = {
+  ref: string;
+  mediaBox: number[];
+  annots: string[];
+};
+
 const INDIRECT_OBJECT_REGEX = /(\d+)\s+(\d+)\s+obj\b([\s\S]*?)endobj/g;
 
 const round = (value: number) => Math.round(value * 10000) / 10000;
@@ -389,44 +395,51 @@ const buildPageList = (objects: Map<string, TObjectRecord>) => {
     throw new Error('Could not locate page tree root');
   }
 
-  const orderedPageRefs: string[] = [];
+  const orderedPages: TPageTreeNode[] = [];
 
-  const walkPageTree = (ref: string) => {
+  const walkPageTree = (ref: string, inheritedMediaBox: number[] | null) => {
     const object = objects.get(ref);
 
     if (!object) {
       throw new Error(`Missing page tree object: ${ref}`);
     }
 
+    const localMediaBox = extractNumberArrayForKey(object.rawBody, 'MediaBox');
+    const resolvedMediaBox = localMediaBox.length === 4 ? localMediaBox : inheritedMediaBox;
+
     if (/\/Type\s*\/Page\b/.test(object.rawBody)) {
-      orderedPageRefs.push(ref);
+      if (!resolvedMediaBox || resolvedMediaBox.length !== 4) {
+        throw new Error(`Page ${ref} is missing a valid MediaBox`);
+      }
+
+      orderedPages.push({
+        ref,
+        mediaBox: resolvedMediaBox,
+        annots: extractRefsFromArrayForKey(object.rawBody, 'Annots'),
+      });
+
       return;
     }
 
     const children = extractRefsFromArrayForKey(object.rawBody, 'Kids');
 
     for (const child of children) {
-      walkPageTree(child);
+      walkPageTree(child, resolvedMediaBox);
     }
   };
 
-  walkPageTree(rootPagesRef);
+  walkPageTree(rootPagesRef, null);
 
-  const pages = orderedPageRefs.map((ref, pageIndex) => {
+  const pages = orderedPages.map((page, pageIndex) => {
+    const ref = page.ref;
     const pageObject = objects.get(ref);
 
     if (!pageObject) {
       throw new Error(`Missing page object: ${ref}`);
     }
 
-    const mediaBox = extractNumberArrayForKey(pageObject.rawBody, 'MediaBox');
-
-    if (mediaBox.length !== 4) {
-      throw new Error(`Page ${ref} is missing a valid MediaBox`);
-    }
-
-    const width = round(Math.abs(mediaBox[2] - mediaBox[0]));
-    const height = round(Math.abs(mediaBox[3] - mediaBox[1]));
+    const width = round(Math.abs(page.mediaBox[2] - page.mediaBox[0]));
+    const height = round(Math.abs(page.mediaBox[3] - page.mediaBox[1]));
 
     return {
       ref,
@@ -438,10 +451,21 @@ const buildPageList = (objects: Map<string, TObjectRecord>) => {
     };
   });
 
+  const widgetPageRefByWidgetRef = new Map<string, string>();
+
+  for (const page of orderedPages) {
+    for (const annotRef of page.annots) {
+      if (!widgetPageRefByWidgetRef.has(annotRef)) {
+        widgetPageRefByWidgetRef.set(annotRef, page.ref);
+      }
+    }
+  }
+
   return {
     pages,
     pageNumberByRef: new Map(pages.map((page) => [page.ref, page.info.pageNumber])),
     pageInfoByRef: new Map(pages.map((page) => [page.ref, page.info])),
+    widgetPageRefByWidgetRef,
   };
 };
 
@@ -449,6 +473,7 @@ const extractAcroformFields = (
   objects: Map<string, TObjectRecord>,
   pageNumberByRef: Map<string, number>,
   pageInfoByRef: Map<string, TPageInfo>,
+  widgetPageRefByWidgetRef: Map<string, string>,
 ) => {
   const catalog = [...objects.values()].find((object) => /\/Type\s*\/Catalog/.test(object.rawBody));
 
@@ -481,7 +506,8 @@ const extractAcroformFields = (
     const localName = extractPdfStringForKey(object.rawBody, 'T');
     const localTooltip = extractPdfStringForKey(object.rawBody, 'TU');
     const fieldType = extractNameForKey(object.rawBody, 'FT') ?? context.rawType;
-    const pageRef = extractRefForKey(object.rawBody, 'P') ?? context.pageRef;
+    const explicitPageRef = extractRefForKey(object.rawBody, 'P');
+    const inheritedPageRef = explicitPageRef ?? context.pageRef;
     const rectNumbers = extractNumberArrayForKey(object.rawBody, 'Rect');
     const kids = extractRefsFromArrayForKey(object.rawBody, 'Kids');
     const hasWidgetRect = rectNumbers.length === 4;
@@ -490,10 +516,12 @@ const extractAcroformFields = (
       nameParts: localName ? [...context.nameParts, localName] : context.nameParts,
       rawType: fieldType,
       rawTooltip: localTooltip ?? context.rawTooltip,
-      pageRef,
+      pageRef: inheritedPageRef,
     };
 
     if (isWidget && rectNumbers.length === 4) {
+      const pageRef = explicitPageRef ?? context.pageRef ?? widgetPageRefByWidgetRef.get(ref) ?? null;
+
       if (!pageRef) {
         throw new Error(`Widget ${ref} is missing a page reference`);
       }
@@ -691,11 +719,12 @@ export const extractAcroformInventory = async (pdfPath: string): Promise<TAcrofo
   const sha256 = crypto.createHash('sha256').update(pdfBytes).digest('hex');
   const pdfJsInventory = await tryExtractWithPdfJs(pdfBytes);
   const objects = parseIndirectObjects(pdfBytes);
-  const { pages, pageNumberByRef, pageInfoByRef } = buildPageList(objects);
+  const { pages, pageNumberByRef, pageInfoByRef, widgetPageRefByWidgetRef } = buildPageList(objects);
   const fallbackFields = extractAcroformFields(
     objects,
     pageNumberByRef,
     pageInfoByRef,
+    widgetPageRefByWidgetRef,
   );
   const merged = mergePdfJsWithFallback(
     pdfJsInventory,

--- a/packages/acroform-field-sidecar/src/extract-acroform.ts
+++ b/packages/acroform-field-sidecar/src/extract-acroform.ts
@@ -1,0 +1,724 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import zlib from 'node:zlib';
+
+import type { TAcroformInventory, TPageInfo, TRectDocumenso, TRectPdf } from './schemas.ts';
+import { EXTRACTOR_VERSION } from './schemas.ts';
+
+type TObjectRecord = {
+  objectNumber: number;
+  generationNumber: number;
+  ref: string;
+  rawBody: string;
+  decodedStream: Buffer | null;
+};
+
+type TLowLevelFieldContext = {
+  nameParts: string[];
+  rawType: string | null;
+  rawTooltip: string | null;
+  pageRef: string | null;
+};
+
+type TLowLevelWidget = {
+  ref: string;
+  sourceKey: string;
+  rawName: string | null;
+  rawType: string | null;
+  rawTooltip: string | null;
+  page: number;
+  rectPdf: TRectPdf;
+  rectDocumenso: TRectDocumenso;
+};
+
+type TPdfJsField = {
+  sourceKey: string;
+  rawName: string | null;
+  rawType: string | null;
+  rawTooltip: string | null;
+  page: number;
+  rectPdf: TRectPdf;
+  rectDocumenso: TRectDocumenso;
+};
+
+type TPdfJsInventoryResult = {
+  pages: TPageInfo[];
+  fields: TPdfJsField[];
+} | null;
+
+const INDIRECT_OBJECT_REGEX = /(\d+)\s+(\d+)\s+obj\b([\s\S]*?)endobj/g;
+
+const round = (value: number) => Math.round(value * 10000) / 10000;
+
+const normalizeRect = (rawRect: number[]) => {
+  const [left, bottom, right, top] = rawRect;
+
+  return {
+    x1: Math.min(left, right),
+    y1: Math.min(bottom, top),
+    x2: Math.max(left, right),
+    y2: Math.max(bottom, top),
+  };
+};
+
+const toDocumensoRect = (rect: TRectPdf, pageWidth: number, pageHeight: number): TRectDocumenso => ({
+  positionX: round((rect.x1 / pageWidth) * 100),
+  positionY: round(((pageHeight - rect.y2) / pageHeight) * 100),
+  width: round(((rect.x2 - rect.x1) / pageWidth) * 100),
+  height: round(((rect.y2 - rect.y1) / pageHeight) * 100),
+});
+
+const bufferFromLatin1 = (value: string) => Buffer.from(value, 'latin1');
+
+const decodePdfStringBytes = (bytes: Buffer) => {
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return bytes.subarray(2).swap16().toString('utf16le');
+  }
+
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return bytes.subarray(2).toString('utf16le');
+  }
+
+  return bytes.toString('latin1');
+};
+
+const decodeLiteralString = (raw: string) => {
+  const bytes: number[] = [];
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const current = raw[index];
+
+    if (current !== '\\') {
+      bytes.push(current.charCodeAt(0));
+      continue;
+    }
+
+    const next = raw[index + 1];
+
+    if (!next) {
+      break;
+    }
+
+    if (next >= '0' && next <= '7') {
+      let octal = next;
+      let octalIndex = index + 2;
+
+      while (octal.length < 3 && octalIndex < raw.length) {
+        const octalChar = raw[octalIndex];
+
+        if (octalChar < '0' || octalChar > '7') {
+          break;
+        }
+
+        octal += octalChar;
+        octalIndex += 1;
+      }
+
+      bytes.push(parseInt(octal, 8));
+      index += octal.length;
+      continue;
+    }
+
+    if (next === '\r') {
+      if (raw[index + 2] === '\n') {
+        index += 2;
+      } else {
+        index += 1;
+      }
+
+      continue;
+    }
+
+    if (next === '\n') {
+      index += 1;
+      continue;
+    }
+
+    const mapped =
+      next === 'n'
+        ? '\n'
+        : next === 'r'
+          ? '\r'
+          : next === 't'
+            ? '\t'
+            : next === 'b'
+              ? '\b'
+              : next === 'f'
+                ? '\f'
+                : next;
+
+    bytes.push(mapped.charCodeAt(0));
+    index += 1;
+  }
+
+  return decodePdfStringBytes(Buffer.from(bytes));
+};
+
+const extractBalancedSection = (value: string, startIndex: number, open: string, close: string) => {
+  let depth = 1;
+  let escaped = false;
+
+  for (let index = startIndex + 1; index < value.length; index += 1) {
+    const current = value[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (current === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (current === open) {
+      depth += 1;
+      continue;
+    }
+
+    if (current === close) {
+      depth -= 1;
+
+      if (depth === 0) {
+        return {
+          body: value.slice(startIndex + 1, index),
+          endIndex: index,
+        };
+      }
+    }
+  }
+
+  return null;
+};
+
+const extractPdfStringForKey = (body: string, key: string) => {
+  const keyRegex = new RegExp(`/${key}(?![A-Za-z0-9])`, 'g');
+  const keyMatch = keyRegex.exec(body);
+
+  if (!keyMatch) {
+    return null;
+  }
+
+  let cursor = keyMatch.index + keyMatch[0].length;
+
+  while (cursor < body.length && /\s/.test(body[cursor])) {
+    cursor += 1;
+  }
+
+  if (body[cursor] === '(') {
+    const literal = extractBalancedSection(body, cursor, '(', ')');
+
+    return literal ? decodeLiteralString(literal.body) : null;
+  }
+
+  if (body[cursor] === '<' && body[cursor + 1] !== '<') {
+    const endIndex = body.indexOf('>', cursor + 1);
+
+    if (endIndex === -1) {
+      return null;
+    }
+
+    const hex = body.slice(cursor + 1, endIndex).replace(/\s+/g, '');
+
+    return decodePdfStringBytes(Buffer.from(hex, 'hex'));
+  }
+
+  return null;
+};
+
+const extractNameForKey = (body: string, key: string) => {
+  const nameRegex = new RegExp(`/${key}(?![A-Za-z0-9])\\s*/([A-Za-z0-9_.-]+)`);
+  const match = body.match(nameRegex);
+
+  return match?.[1] ?? null;
+};
+
+const extractRefForKey = (body: string, key: string) => {
+  const refRegex = new RegExp(`/${key}(?![A-Za-z0-9])\\s+(\\d+)\\s+(\\d+)\\s+R`);
+  const match = body.match(refRegex);
+
+  return match ? `${match[1]} ${match[2]} R` : null;
+};
+
+const extractRefsFromArrayForKey = (body: string, key: string) => {
+  const arrayRegex = new RegExp(`/${key}(?![A-Za-z0-9])\\s*\\[([^\\]]*)\\]`, 's');
+  const arrayMatch = body.match(arrayRegex);
+
+  if (!arrayMatch) {
+    return [];
+  }
+
+  return Array.from(arrayMatch[1].matchAll(/(\d+)\s+(\d+)\s+R/g)).map(
+    (match) => `${match[1]} ${match[2]} R`,
+  );
+};
+
+const extractNumberArrayForKey = (body: string, key: string) => {
+  const arrayRegex = new RegExp(`/${key}(?![A-Za-z0-9])\\s*\\[([^\\]]*)\\]`, 's');
+  const match = body.match(arrayRegex);
+
+  if (!match) {
+    return [];
+  }
+
+  return match[1]
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+};
+
+const extractDecodedStream = (body: string) => {
+  const streamStart = body.search(/stream\r?\n/);
+
+  if (streamStart === -1) {
+    return null;
+  }
+
+  const headerLength = body.slice(streamStart).startsWith('stream\r\n') ? 8 : 7;
+  const streamDataStart = streamStart + headerLength;
+  const streamEnd = body.indexOf('endstream', streamDataStart);
+
+  if (streamEnd === -1) {
+    return null;
+  }
+
+  const rawStream = bufferFromLatin1(body.slice(streamDataStart, streamEnd));
+  const hasFlateFilter =
+    /\/Filter\s*\/FlateDecode/.test(body) ||
+    /\/Filter\s*\[\s*\/FlateDecode/.test(body) ||
+    /\/Filter\s*<</.test(body);
+
+  if (!hasFlateFilter) {
+    return rawStream;
+  }
+
+  return zlib.inflateSync(rawStream);
+};
+
+const decodeObjectStreamEntries = (decodedStream: Buffer, first: number, count: number) => {
+  const extractedObjects: TObjectRecord[] = [];
+  const header = decodedStream.subarray(0, first).toString('latin1').trim();
+  const body = decodedStream.subarray(first);
+  const headerNumbers = header
+    .split(/\s+/)
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+
+  for (let index = 0; index < count; index += 1) {
+    const objectNumber = headerNumbers[index * 2];
+    const offset = headerNumbers[index * 2 + 1];
+    const nextOffset =
+      index === count - 1 ? body.length : headerNumbers[index * 2 + 3] ?? body.length;
+
+    if (!Number.isFinite(objectNumber) || !Number.isFinite(offset)) {
+      continue;
+    }
+
+    const rawBody = body.subarray(offset, nextOffset).toString('latin1').trim();
+
+    extractedObjects.push({
+      objectNumber,
+      generationNumber: 0,
+      ref: `${objectNumber} 0 R`,
+      rawBody,
+      decodedStream: extractDecodedStream(rawBody),
+    });
+  }
+
+  return extractedObjects;
+};
+
+const parseIndirectObjects = (pdfBytes: Buffer) => {
+  const pdfText = pdfBytes.toString('latin1');
+  const objects = new Map<string, TObjectRecord>();
+
+  for (const match of pdfText.matchAll(INDIRECT_OBJECT_REGEX)) {
+    const objectNumber = Number(match[1]);
+    const generationNumber = Number(match[2]);
+    const ref = `${objectNumber} ${generationNumber} R`;
+    const rawBody = match[3];
+
+    objects.set(ref, {
+      objectNumber,
+      generationNumber,
+      ref,
+      rawBody,
+      decodedStream: extractDecodedStream(rawBody),
+    });
+  }
+
+  const objectStreams = [...objects.values()].filter((object) =>
+    /\/Type\s*\/ObjStm/.test(object.rawBody),
+  );
+
+  for (const objectStream of objectStreams) {
+    if (!objectStream.decodedStream) {
+      continue;
+    }
+
+    const firstMatch = objectStream.rawBody.match(/\/First\s+(\d+)/);
+    const countMatch = objectStream.rawBody.match(/\/N\s+(\d+)/);
+    const first = Number(firstMatch?.[1] ?? '');
+    const count = Number(countMatch?.[1] ?? '');
+
+    if (!Number.isFinite(first) || !Number.isFinite(count)) {
+      continue;
+    }
+
+    const extracted = decodeObjectStreamEntries(objectStream.decodedStream, first, count);
+
+    for (const entry of extracted) {
+      objects.set(entry.ref, entry);
+    }
+  }
+
+  return objects;
+};
+
+const buildPageList = (objects: Map<string, TObjectRecord>) => {
+  const catalog = [...objects.values()].find((object) => /\/Type\s*\/Catalog/.test(object.rawBody));
+
+  if (!catalog) {
+    throw new Error('Could not locate PDF catalog');
+  }
+
+  const rootPagesRef = extractRefForKey(catalog.rawBody, 'Pages');
+
+  if (!rootPagesRef) {
+    throw new Error('Could not locate page tree root');
+  }
+
+  const orderedPageRefs: string[] = [];
+
+  const walkPageTree = (ref: string) => {
+    const object = objects.get(ref);
+
+    if (!object) {
+      throw new Error(`Missing page tree object: ${ref}`);
+    }
+
+    if (/\/Type\s*\/Page\b/.test(object.rawBody)) {
+      orderedPageRefs.push(ref);
+      return;
+    }
+
+    const children = extractRefsFromArrayForKey(object.rawBody, 'Kids');
+
+    for (const child of children) {
+      walkPageTree(child);
+    }
+  };
+
+  walkPageTree(rootPagesRef);
+
+  const pages = orderedPageRefs.map((ref, pageIndex) => {
+    const pageObject = objects.get(ref);
+
+    if (!pageObject) {
+      throw new Error(`Missing page object: ${ref}`);
+    }
+
+    const mediaBox = extractNumberArrayForKey(pageObject.rawBody, 'MediaBox');
+
+    if (mediaBox.length !== 4) {
+      throw new Error(`Page ${ref} is missing a valid MediaBox`);
+    }
+
+    const width = round(Math.abs(mediaBox[2] - mediaBox[0]));
+    const height = round(Math.abs(mediaBox[3] - mediaBox[1]));
+
+    return {
+      ref,
+      info: {
+        pageNumber: pageIndex + 1,
+        width,
+        height,
+      },
+    };
+  });
+
+  return {
+    pages,
+    pageNumberByRef: new Map(pages.map((page) => [page.ref, page.info.pageNumber])),
+    pageInfoByRef: new Map(pages.map((page) => [page.ref, page.info])),
+  };
+};
+
+const extractAcroformFields = (
+  objects: Map<string, TObjectRecord>,
+  pageNumberByRef: Map<string, number>,
+  pageInfoByRef: Map<string, TPageInfo>,
+) => {
+  const catalog = [...objects.values()].find((object) => /\/Type\s*\/Catalog/.test(object.rawBody));
+
+  if (!catalog) {
+    throw new Error('Could not locate PDF catalog for AcroForm extraction');
+  }
+
+  const acroFormRef = extractRefForKey(catalog.rawBody, 'AcroForm');
+
+  if (!acroFormRef) {
+    throw new Error('Could not locate AcroForm object');
+  }
+
+  const acroFormObject = objects.get(acroFormRef);
+
+  if (!acroFormObject) {
+    throw new Error('Could not load AcroForm object');
+  }
+
+  const rootFieldRefs = extractRefsFromArrayForKey(acroFormObject.rawBody, 'Fields');
+  const widgets: TLowLevelWidget[] = [];
+
+  const walkFieldTree = (ref: string, context: TLowLevelFieldContext) => {
+    const object = objects.get(ref);
+
+    if (!object) {
+      throw new Error(`Missing field object: ${ref}`);
+    }
+
+    const localName = extractPdfStringForKey(object.rawBody, 'T');
+    const localTooltip = extractPdfStringForKey(object.rawBody, 'TU');
+    const fieldType = extractNameForKey(object.rawBody, 'FT') ?? context.rawType;
+    const pageRef = extractRefForKey(object.rawBody, 'P') ?? context.pageRef;
+    const rectNumbers = extractNumberArrayForKey(object.rawBody, 'Rect');
+    const kids = extractRefsFromArrayForKey(object.rawBody, 'Kids');
+    const hasWidgetRect = rectNumbers.length === 4;
+    const isWidget = hasWidgetRect || /\/Subtype\s*\/Widget/.test(object.rawBody);
+    const nextContext: TLowLevelFieldContext = {
+      nameParts: localName ? [...context.nameParts, localName] : context.nameParts,
+      rawType: fieldType,
+      rawTooltip: localTooltip ?? context.rawTooltip,
+      pageRef,
+    };
+
+    if (isWidget && rectNumbers.length === 4) {
+      if (!pageRef) {
+        throw new Error(`Widget ${ref} is missing a page reference`);
+      }
+
+      const pageNumber = pageNumberByRef.get(pageRef);
+      const pageInfo = pageInfoByRef.get(pageRef);
+
+      if (!pageNumber || !pageInfo) {
+        throw new Error(`Widget ${ref} references an unknown page: ${pageRef}`);
+      }
+
+      const rectPdf = normalizeRect(rectNumbers);
+      const rawName = nextContext.nameParts.length > 0 ? nextContext.nameParts.join('.') : null;
+
+      widgets.push({
+        ref,
+        sourceKey: rawName ?? ref.replaceAll(' ', '_'),
+        rawName,
+        rawType: fieldType,
+        rawTooltip: localTooltip ?? context.rawTooltip,
+        page: pageNumber,
+        rectPdf,
+        rectDocumenso: toDocumensoRect(rectPdf, pageInfo.width, pageInfo.height),
+      });
+    }
+
+    for (const kid of kids) {
+      walkFieldTree(kid, nextContext);
+    }
+  };
+
+  for (const fieldRef of rootFieldRefs) {
+    walkFieldTree(fieldRef, {
+      nameParts: [],
+      rawType: null,
+      rawTooltip: null,
+      pageRef: null,
+    });
+  }
+
+  return widgets.sort((left, right) => {
+    if (left.page !== right.page) {
+      return left.page - right.page;
+    }
+
+    if (left.rectPdf.y2 !== right.rectPdf.y2) {
+      return right.rectPdf.y2 - left.rectPdf.y2;
+    }
+
+    return left.rectPdf.x1 - right.rectPdf.x1;
+  });
+};
+
+const normalizePdfJsFieldType = (value: string) => {
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized === 'text') {
+    return 'Tx';
+  }
+
+  if (normalized === 'button' || normalized === 'checkbox' || normalized === 'radiobutton') {
+    return 'Btn';
+  }
+
+  if (normalized === 'signature') {
+    return 'Sig';
+  }
+
+  return value;
+};
+
+const tryExtractWithPdfJs = async (pdfBytes: Buffer): Promise<TPdfJsInventoryResult> => {
+  try {
+    const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    const task = pdfjs.getDocument({ data: new Uint8Array(pdfBytes) });
+    const document = await task.promise;
+    const pages: TPageInfo[] = [];
+    const fields: TPdfJsField[] = [];
+
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber);
+      const viewport = page.getViewport({ scale: 1 });
+
+      pages.push({
+        pageNumber,
+        width: round(viewport.width),
+        height: round(viewport.height),
+      });
+
+      const annotations = await page.getAnnotations();
+
+      for (const annotation of annotations as Array<Record<string, unknown>>) {
+        const isWidget = annotation.subtype === 'Widget' || annotation.annotationType === 20;
+        const rect = Array.isArray(annotation.rect)
+          ? annotation.rect.map((value) => Number(value)).filter((value) => Number.isFinite(value))
+          : [];
+
+        if (!isWidget || rect.length !== 4) {
+          continue;
+        }
+
+        const fieldName =
+          typeof annotation.fieldName === 'string'
+            ? annotation.fieldName
+            : typeof annotation.fullName === 'string'
+              ? annotation.fullName
+              : null;
+        const rawType =
+          typeof annotation.fieldType === 'string'
+            ? normalizePdfJsFieldType(annotation.fieldType)
+            : typeof annotation.buttonValue === 'string'
+              ? 'Btn'
+              : null;
+        const rawTooltip =
+          typeof annotation.alternativeText === 'string'
+            ? annotation.alternativeText
+            : typeof annotation.title === 'string'
+              ? annotation.title
+              : null;
+        const rectPdf = normalizeRect(rect);
+
+        fields.push({
+          sourceKey: fieldName ?? `page${pageNumber}-widget-${fields.length + 1}`,
+          rawName: fieldName,
+          rawType,
+          rawTooltip,
+          page: pageNumber,
+          rectPdf,
+          rectDocumenso: toDocumensoRect(rectPdf, viewport.width, viewport.height),
+        });
+      }
+    }
+
+    await document.destroy();
+    await task.destroy();
+
+    return {
+      pages,
+      fields,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const mergePdfJsWithFallback = (
+  pdfJsInventory: TPdfJsInventoryResult,
+  fallbackPages: TPageInfo[],
+  fallbackFields: TLowLevelWidget[],
+) => {
+  if (!pdfJsInventory) {
+    return {
+      pages: fallbackPages,
+      fields: fallbackFields,
+      extractionMethod: 'fallback-structure',
+    };
+  }
+
+  const completePdfJs =
+    pdfJsInventory.fields.length === fallbackFields.length &&
+    pdfJsInventory.fields.every(
+      (field) => field.rawName && field.rawType && Number.isInteger(field.page) && field.rectDocumenso.width > 0,
+    );
+
+  if (completePdfJs) {
+    return {
+      pages: pdfJsInventory.pages,
+      fields: pdfJsInventory.fields,
+      extractionMethod: 'pdfjs-dist',
+    };
+  }
+
+  const mergedFields = fallbackFields.map((fallbackField, index) => {
+    const pdfJsField = pdfJsInventory.fields[index];
+
+    if (!pdfJsField) {
+      return fallbackField;
+    }
+
+    return {
+      ...fallbackField,
+      rawTooltip: pdfJsField.rawTooltip ?? fallbackField.rawTooltip,
+    };
+  });
+
+  return {
+    pages: fallbackPages,
+    fields: mergedFields,
+    extractionMethod: 'pdfjs-dist+fallback-structure',
+  };
+};
+
+export const extractAcroformInventory = async (pdfPath: string): Promise<TAcroformInventory> => {
+  const pdfBytes = await fs.readFile(pdfPath);
+  const sha256 = crypto.createHash('sha256').update(pdfBytes).digest('hex');
+  const pdfJsInventory = await tryExtractWithPdfJs(pdfBytes);
+  const objects = parseIndirectObjects(pdfBytes);
+  const { pages, pageNumberByRef, pageInfoByRef } = buildPageList(objects);
+  const fallbackFields = extractAcroformFields(
+    objects,
+    pageNumberByRef,
+    pageInfoByRef,
+  );
+  const merged = mergePdfJsWithFallback(
+    pdfJsInventory,
+    pages.map((page) => page.info),
+    fallbackFields,
+  );
+
+  return {
+    source: {
+      pdfPath,
+      sha256,
+      extractorVersion: EXTRACTOR_VERSION,
+      extractionMethod: merged.extractionMethod,
+    },
+    pages: merged.pages,
+    fields: merged.fields.map((field) => ({
+      sourceKey: field.sourceKey,
+      rawName: field.rawName,
+      rawType: field.rawType,
+      rawTooltip: field.rawTooltip,
+      page: field.page,
+      rectPdf: field.rectPdf,
+      rectDocumenso: field.rectDocumenso,
+    })),
+  };
+};

--- a/packages/acroform-field-sidecar/src/profiles/sample-acroform.policy.json
+++ b/packages/acroform-field-sidecar/src/profiles/sample-acroform.policy.json
@@ -1,0 +1,65 @@
+{
+  "profile": "sample-acroform",
+  "envelopeType": "TEMPLATE",
+  "signerRecipientKey": "signer",
+  "primaryEnvelopeItemKey": "primary-pdf",
+  "fieldOverrides": {
+    "sampleDateYear": {
+      "semanticKey": "sampleDateYear",
+      "semanticLabel": "Sample date year",
+      "classification": "overlay-candidate",
+      "confidence": "high",
+      "generationRole": "ignored",
+      "evidence": [
+        "sample policy treats sampleDateYear as a signer-date candidate, not a default overlay field"
+      ]
+    },
+    "sampleDateMonth": {
+      "semanticKey": "sampleDateMonth",
+      "semanticLabel": "Sample date month",
+      "classification": "overlay-candidate",
+      "confidence": "high",
+      "generationRole": "ignored",
+      "evidence": [
+        "sample policy treats sampleDateMonth as a signer-date candidate, not a default overlay field"
+      ]
+    },
+    "sampleDateDay": {
+      "semanticKey": "sampleDateDay",
+      "semanticLabel": "Sample date day",
+      "classification": "overlay-candidate",
+      "confidence": "high",
+      "generationRole": "ignored",
+      "evidence": [
+        "sample policy treats sampleDateDay as a signer-date candidate, not a default overlay field"
+      ]
+    },
+    "signatureAnchor": {
+      "semanticKey": "signatureAnchor",
+      "semanticLabel": "Signature anchor",
+      "classification": "signer-overlay-signature",
+      "confidence": "high",
+      "generationRole": "overlay-generated",
+      "evidence": [
+        "sample policy treats signatureAnchor as the Documenso signer signature anchor"
+      ]
+    }
+  },
+  "manualOverlays": [],
+  "generatedOverlays": [
+    {
+      "bindingKey": "signer-signature",
+      "rawName": "signatureAnchor",
+      "semanticKey": "signatureAnchor",
+      "semanticLabel": "Signature anchor",
+      "classification": "signer-overlay-signature",
+      "recipientKey": "signer",
+      "envelopeItemKey": "primary-pdf",
+      "type": "SIGNATURE",
+      "fieldMeta": {
+        "type": "signature",
+        "fontSize": 18
+      }
+    }
+  ]
+}

--- a/packages/acroform-field-sidecar/src/render-documenso-payload.ts
+++ b/packages/acroform-field-sidecar/src/render-documenso-payload.ts
@@ -1,0 +1,87 @@
+import type {
+  TBindings,
+  TBoundPayload,
+  TDocumensoFieldTemplate,
+  TFieldSpec,
+  TPolicy,
+} from './schemas.ts';
+import {
+  assertValidBoundPayload,
+  assertValidTemplate,
+  getDefaultFieldMeta,
+} from './schemas.ts';
+
+const createSampleBindings = (policy: TPolicy): TBindings => ({
+  envelopeId: 'env_sample',
+  envelopeType: 'TEMPLATE',
+  recipientIds: {
+    [policy.signerRecipientKey]: 1001,
+  },
+  envelopeItemIds: {
+    [policy.primaryEnvelopeItemKey]: 'item_primary_pdf',
+  },
+});
+
+export const renderDocumensoFieldTemplate = (spec: TFieldSpec, policy: TPolicy): TDocumensoFieldTemplate => {
+  const template: TDocumensoFieldTemplate = {
+    profile: policy.profile,
+    envelopeType: policy.envelopeType,
+    fields: spec.overlayPlan.map((field) => ({
+      bindingKey: field.bindingKey,
+      recipientKey: field.recipientKey,
+      envelopeItemKey: field.envelopeItemKey,
+      type: field.type,
+      page: field.page,
+      positionX: field.positionX,
+      positionY: field.positionY,
+      width: field.width,
+      height: field.height,
+      fieldMeta: field.fieldMeta ?? getDefaultFieldMeta(field.type),
+    })),
+  };
+
+  assertValidTemplate(template);
+
+  return template;
+};
+
+export const bindDocumensoPayload = (
+  template: TDocumensoFieldTemplate,
+  bindings: TBindings,
+): TBoundPayload => {
+  const payload: TBoundPayload = {
+    envelopeId: bindings.envelopeId,
+    envelopeType: bindings.envelopeType ?? template.envelopeType,
+    fields: template.fields.map((field) => {
+      const recipientId = bindings.recipientIds[field.recipientKey];
+      const envelopeItemId = bindings.envelopeItemIds[field.envelopeItemKey];
+
+      if (!recipientId) {
+        throw new Error(`No recipientId binding found for key ${field.recipientKey}`);
+      }
+
+      if (!envelopeItemId) {
+        throw new Error(`No envelopeItemId binding found for key ${field.envelopeItemKey}`);
+      }
+
+      return {
+        envelopeItemId,
+        recipientId,
+        type: field.type,
+        page: field.page,
+        positionX: field.positionX,
+        positionY: field.positionY,
+        width: field.width,
+        height: field.height,
+        fieldMeta: field.fieldMeta,
+      };
+    }),
+  };
+
+  assertValidBoundPayload(payload);
+
+  return payload;
+};
+
+export const renderSamplePayload = (template: TDocumensoFieldTemplate, policy: TPolicy) =>
+  bindDocumensoPayload(template, createSampleBindings(policy));

--- a/packages/acroform-field-sidecar/src/render-preview.ts
+++ b/packages/acroform-field-sidecar/src/render-preview.ts
@@ -1,0 +1,233 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { PDF, StandardFonts, rgb } from '@libpdf/core';
+
+import type {
+  TDocumensoFieldTemplate,
+  TDocumensoFieldTemplateField,
+  TFieldSpec,
+  TRectDocumenso,
+  TResolvedField,
+} from './schemas.ts';
+
+export type TPreviewStyleKind = 'imported' | 'skipped' | 'candidate' | 'unresolved';
+
+export type TPreviewBox = {
+  kind: TPreviewStyleKind;
+  label: string;
+  page: number;
+  rectDocumenso: TRectDocumenso;
+};
+
+export type TRenderPreviewOptions = {
+  inputPath: string;
+  templatePath: string;
+  fieldSpecPath: string;
+  outputPath: string;
+};
+
+export type TPreviewPdfRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+const PREVIEW_STYLES: Record<
+  TPreviewStyleKind,
+  {
+    borderColor: ReturnType<typeof rgb>;
+    labelColor: ReturnType<typeof rgb>;
+    borderWidth: number;
+  }
+> = {
+  imported: {
+    borderColor: rgb(22 / 255, 163 / 255, 74 / 255),
+    labelColor: rgb(22 / 255, 101 / 255, 52 / 255),
+    borderWidth: 1.8,
+  },
+  skipped: {
+    borderColor: rgb(107 / 255, 114 / 255, 128 / 255),
+    labelColor: rgb(75 / 255, 85 / 255, 99 / 255),
+    borderWidth: 0.6,
+  },
+  candidate: {
+    borderColor: rgb(217 / 255, 119 / 255, 6 / 255),
+    labelColor: rgb(146 / 255, 64 / 255, 14 / 255),
+    borderWidth: 1.1,
+  },
+  unresolved: {
+    borderColor: rgb(220 / 255, 38 / 255, 38 / 255),
+    labelColor: rgb(153 / 255, 27 / 255, 27 / 255),
+    borderWidth: 1.3,
+  },
+};
+
+const clampLabel = (label: string) => (label.length > 72 ? `${label.slice(0, 69)}...` : label);
+
+const getPageDimensions = (page: unknown) => {
+  const candidate = page as {
+    getSize?: () => { width: number; height: number };
+    getCropBox?: () => { width: number; height: number };
+    width?: number;
+    height?: number;
+  };
+
+  if (candidate.getSize) {
+    return candidate.getSize();
+  }
+
+  if (candidate.getCropBox) {
+    return candidate.getCropBox();
+  }
+
+  if (typeof candidate.width === 'number' && typeof candidate.height === 'number') {
+    return {
+      width: candidate.width,
+      height: candidate.height,
+    };
+  }
+
+  throw new Error('Could not determine PDF page dimensions');
+};
+
+export const documensoRectToPdfRect = (
+  rectDocumenso: TRectDocumenso,
+  pageWidth: number,
+  pageHeight: number,
+): TPreviewPdfRect => {
+  const width = pageWidth * (rectDocumenso.width / 100);
+  const height = pageHeight * (rectDocumenso.height / 100);
+  const x = pageWidth * (rectDocumenso.positionX / 100);
+  const yFromTop = pageHeight * (rectDocumenso.positionY / 100);
+
+  return {
+    x,
+    y: pageHeight - yFromTop - height,
+    width,
+    height,
+  };
+};
+
+const getPreviewKindForResolvedField = (field: TResolvedField): TPreviewStyleKind => {
+  if (field.generationRole === 'unresolved') {
+    return 'unresolved';
+  }
+
+  if (field.classification === 'overlay-candidate') {
+    return 'candidate';
+  }
+
+  return 'skipped';
+};
+
+export const getPreviewLabel = (box: Pick<TPreviewBox, 'kind' | 'label'>) => {
+  if (box.kind === 'imported') {
+    return `IMPORTED ${box.label}`;
+  }
+
+  if (box.kind === 'candidate') {
+    return `CANDIDATE ${box.label}`;
+  }
+
+  if (box.kind === 'unresolved') {
+    return `UNRESOLVED ${box.label}`;
+  }
+
+  return `SKIPPED ${box.label}`;
+};
+
+const templateFieldToPreviewBox = (field: TDocumensoFieldTemplateField): TPreviewBox => ({
+  kind: 'imported',
+  label: `${field.type} ${field.bindingKey}`,
+  page: field.page,
+  rectDocumenso: {
+    positionX: field.positionX,
+    positionY: field.positionY,
+    width: field.width,
+    height: field.height,
+  },
+});
+
+const resolvedFieldToPreviewBox = (field: TResolvedField): TPreviewBox => {
+  const kind = getPreviewKindForResolvedField(field);
+
+  return {
+    kind,
+    label:
+      kind === 'candidate'
+        ? (field.semanticKey ?? field.sourceKey)
+        : `${field.classification} ${field.semanticKey ?? field.sourceKey}`,
+    page: field.page,
+    rectDocumenso: field.rectDocumenso,
+  };
+};
+
+const buildPreviewBoxes = (template: TDocumensoFieldTemplate, fieldSpec: TFieldSpec): TPreviewBox[] => [
+  ...fieldSpec.fields
+    .filter((field) => field.generationRole !== 'overlay-generated')
+    .map(resolvedFieldToPreviewBox),
+  ...template.fields.map(templateFieldToPreviewBox),
+];
+
+export const renderPreviewPdf = async ({
+  inputPath,
+  templatePath,
+  fieldSpecPath,
+  outputPath,
+}: TRenderPreviewOptions) => {
+  const [pdfBytes, template, fieldSpec] = await Promise.all([
+    fs.readFile(inputPath),
+    fs.readFile(templatePath, 'utf8').then((value) => JSON.parse(value) as TDocumensoFieldTemplate),
+    fs.readFile(fieldSpecPath, 'utf8').then((value) => JSON.parse(value) as TFieldSpec),
+  ]);
+  const pdf = await PDF.load(pdfBytes);
+  const pages = pdf.getPages();
+  const boxes = buildPreviewBoxes(template, fieldSpec);
+
+  for (const box of boxes) {
+    const page = pages[box.page - 1];
+
+    if (!page) {
+      throw new Error(`Preview box ${box.label} references missing page ${box.page}`);
+    }
+
+    const { width: pageWidth, height: pageHeight } = getPageDimensions(page);
+    const rect = documensoRectToPdfRect(box.rectDocumenso, pageWidth, pageHeight);
+    const style = PREVIEW_STYLES[box.kind];
+    const label = clampLabel(getPreviewLabel(box));
+    const labelY = Math.min(pageHeight - 10, rect.y + rect.height + 2);
+
+    page.drawRectangle({
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+      borderColor: style.borderColor,
+      borderWidth: style.borderWidth,
+    });
+
+    page.drawText(label, {
+      x: rect.x,
+      y: labelY,
+      size: 5.5,
+      font: StandardFonts.Helvetica,
+      color: style.labelColor,
+    });
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, await pdf.save());
+
+  return {
+    outputPath,
+    boxCount: boxes.length,
+    importedCount: boxes.filter((box) => box.kind === 'imported').length,
+    skippedCount: boxes.filter((box) => box.kind === 'skipped').length,
+    candidateCount: boxes.filter((box) => box.kind === 'candidate').length,
+    unresolvedCount: boxes.filter((box) => box.kind === 'unresolved').length,
+  };
+};
+
+export const getPreviewStyleKind = getPreviewKindForResolvedField;

--- a/packages/acroform-field-sidecar/src/resolve-semantics.ts
+++ b/packages/acroform-field-sidecar/src/resolve-semantics.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs/promises';
+
+import type {
+  TAcroformInventory,
+  TClassification,
+  TConfidence,
+  TFieldSpec,
+  TGenerationRole,
+  TPolicy,
+  TResolvedField,
+} from './schemas.ts';
+
+const humanizeIdentifier = (value: string) =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[._-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const isGenericToggle = (value: string | null) => Boolean(value && /^toggle_\d+$/i.test(value));
+
+const getDefaultClassification = (field: TAcroformInventory['fields'][number]): TClassification => {
+  if (!field.rawName && !field.rawTooltip) {
+    return 'unresolved';
+  }
+
+  if (field.rawType === 'Tx') {
+    return /date(Year|Month|Day)$/i.test(field.rawName ?? '') ? 'overlay-candidate' : 'prefill-text';
+  }
+
+  if (field.rawType === 'Btn') {
+    return 'prefill-checkbox';
+  }
+
+  if (field.rawType === 'Sig') {
+    return 'signer-overlay-signature';
+  }
+
+  return 'unresolved';
+};
+
+const getDefaultGenerationRole = (classification: TClassification): TGenerationRole => {
+  if (classification === 'prefill-text' || classification === 'prefill-checkbox') {
+    return 'prefill-only';
+  }
+
+  if (classification === 'ignored' || classification === 'overlay-candidate') {
+    return 'ignored';
+  }
+
+  if (classification === 'signer-overlay-signature' || classification === 'signer-overlay-date') {
+    return 'overlay-generated';
+  }
+
+  return 'unresolved';
+};
+
+const resolveBaseSemantic = (field: TAcroformInventory['fields'][number]) => {
+  if (field.rawName && !isGenericToggle(field.rawName)) {
+    return {
+      semanticKey: field.rawName,
+      semanticLabel: field.rawTooltip ?? field.rawName,
+      confidence: 'high' as const,
+      evidence: [`resolved from field name ${field.rawName}`],
+    };
+  }
+
+  if (field.rawTooltip) {
+    return {
+      semanticKey: field.rawName,
+      semanticLabel: field.rawTooltip,
+      confidence: 'medium' as const,
+      evidence: [
+        field.rawName
+          ? `resolved from tooltip ${field.rawTooltip} for generic field ${field.rawName}`
+          : `resolved from tooltip ${field.rawTooltip}`,
+      ],
+    };
+  }
+
+  return {
+    semanticKey: field.rawName,
+    semanticLabel: field.rawName ? humanizeIdentifier(field.rawName) : null,
+    confidence: 'none' as const,
+    evidence: ['semantic meaning could not be recovered from field name or tooltip'],
+  };
+};
+
+export const loadPolicy = async (policyPath: string): Promise<TPolicy> =>
+  JSON.parse(await fs.readFile(policyPath, 'utf8')) as TPolicy;
+
+export const resolveSemantics = (inventory: TAcroformInventory, policy: TPolicy): TFieldSpec => {
+  const fields: TResolvedField[] = inventory.fields.map((field) => {
+    const baseSemantic = resolveBaseSemantic(field);
+    const policyOverride = policy.fieldOverrides?.[field.sourceKey] ?? policy.fieldOverrides?.[field.rawName ?? ''];
+    const classification = policyOverride?.classification ?? getDefaultClassification(field);
+    const generationRole = policyOverride?.generationRole ?? getDefaultGenerationRole(classification);
+    const confidence: TConfidence = policyOverride?.confidence ?? baseSemantic.confidence;
+    const evidence = [...baseSemantic.evidence, ...(policyOverride?.evidence ?? [])];
+
+    if (policyOverride) {
+      evidence.push(`policy override applied for ${field.sourceKey}`);
+    }
+
+    return {
+      sourceKey: field.sourceKey,
+      rawName: field.rawName,
+      rawType: field.rawType,
+      semanticKey: policyOverride?.semanticKey ?? baseSemantic.semanticKey,
+      semanticLabel: policyOverride?.semanticLabel ?? baseSemantic.semanticLabel,
+      classification: baseSemantic.confidence === 'none' && !policyOverride ? 'unresolved' : classification,
+      confidence,
+      evidence,
+      page: field.page,
+      rectDocumenso: field.rectDocumenso,
+      generationRole: baseSemantic.confidence === 'none' && !policyOverride ? 'unresolved' : generationRole,
+    };
+  });
+
+  return {
+    source: inventory.source,
+    pages: inventory.pages,
+    fields,
+    overlayPlan: [],
+    unresolved: fields.filter((field) => field.generationRole === 'unresolved'),
+  };
+};

--- a/packages/acroform-field-sidecar/src/schemas.ts
+++ b/packages/acroform-field-sidecar/src/schemas.ts
@@ -1,0 +1,446 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const EXTRACTOR_VERSION = '0.1.0';
+
+export const FIELD_TYPES = [
+  'SIGNATURE',
+  'FREE_SIGNATURE',
+  'INITIALS',
+  'NAME',
+  'EMAIL',
+  'DATE',
+  'TEXT',
+  'NUMBER',
+  'RADIO',
+  'CHECKBOX',
+  'DROPDOWN',
+] as const;
+
+export const CLASSIFICATIONS = [
+  'prefill-text',
+  'prefill-checkbox',
+  'signer-overlay-signature',
+  'signer-overlay-date',
+  'overlay-candidate',
+  'ignored',
+  'unresolved',
+] as const;
+
+export const CONFIDENCE_VALUES = ['high', 'medium', 'low', 'none'] as const;
+
+export const GENERATION_ROLES = [
+  'prefill-only',
+  'overlay-generated',
+  'overlay-manual',
+  'ignored',
+  'unresolved',
+] as const;
+
+export type TDocumensoFieldType = (typeof FIELD_TYPES)[number];
+export type TClassification = (typeof CLASSIFICATIONS)[number];
+export type TConfidence = (typeof CONFIDENCE_VALUES)[number];
+export type TGenerationRole = (typeof GENERATION_ROLES)[number];
+
+export type TRectPdf = {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+export type TRectDocumenso = {
+  positionX: number;
+  positionY: number;
+  width: number;
+  height: number;
+};
+
+export type TPageInfo = {
+  pageNumber: number;
+  width: number;
+  height: number;
+};
+
+export type TInventoryField = {
+  sourceKey: string;
+  rawName: string | null;
+  rawType: string | null;
+  rawTooltip: string | null;
+  page: number;
+  rectPdf: TRectPdf;
+  rectDocumenso: TRectDocumenso;
+};
+
+export type TAcroformInventory = {
+  source: {
+    pdfPath: string;
+    sha256: string;
+    extractorVersion: string;
+    extractionMethod: string;
+  };
+  pages: TPageInfo[];
+  fields: TInventoryField[];
+};
+
+export type TResolvedField = {
+  sourceKey: string;
+  rawName: string | null;
+  rawType: string | null;
+  semanticKey: string | null;
+  semanticLabel: string | null;
+  classification: TClassification;
+  confidence: TConfidence;
+  evidence: string[];
+  page: number;
+  rectDocumenso: TRectDocumenso;
+  generationRole: TGenerationRole;
+};
+
+export type TOverlayPlanField = {
+  bindingKey: string;
+  sourceKey: string | null;
+  semanticKey: string | null;
+  semanticLabel: string;
+  classification: Extract<TClassification, 'signer-overlay-signature' | 'signer-overlay-date'>;
+  confidence: Exclude<TConfidence, 'none'>;
+  evidence: string[];
+  generationRole: Extract<TGenerationRole, 'overlay-generated' | 'overlay-manual'>;
+  recipientKey: string;
+  envelopeItemKey: string;
+  type: Extract<TDocumensoFieldType, 'SIGNATURE' | 'DATE' | 'TEXT' | 'NAME' | 'EMAIL' | 'INITIALS'>;
+  page: number;
+  positionX: number;
+  positionY: number;
+  width: number;
+  height: number;
+  fieldMeta: Record<string, unknown> | undefined;
+};
+
+export type TFieldSpec = {
+  source: TAcroformInventory['source'];
+  pages: TPageInfo[];
+  fields: TResolvedField[];
+  overlayPlan: TOverlayPlanField[];
+  unresolved: TResolvedField[];
+};
+
+export type TDocumensoFieldTemplateField = {
+  bindingKey: string;
+  recipientKey: string;
+  envelopeItemKey: string;
+  type: TDocumensoFieldType;
+  page: number;
+  positionX: number;
+  positionY: number;
+  width: number;
+  height: number;
+  fieldMeta: Record<string, unknown> | undefined;
+};
+
+export type TDocumensoFieldTemplate = {
+  profile: string;
+  envelopeType: 'TEMPLATE';
+  fields: TDocumensoFieldTemplateField[];
+};
+
+export type TBindings = {
+  envelopeId: string;
+  envelopeType?: 'TEMPLATE' | 'DOCUMENT';
+  recipientIds: Record<string, number>;
+  envelopeItemIds: Record<string, string>;
+};
+
+export type TBoundPayload = {
+  envelopeId: string;
+  envelopeType: 'TEMPLATE' | 'DOCUMENT';
+  fields: Array<{
+    envelopeItemId: string;
+    recipientId: number;
+    type: TDocumensoFieldType;
+    page: number;
+    positionX: number;
+    positionY: number;
+    width: number;
+    height: number;
+    fieldMeta: Record<string, unknown> | undefined;
+  }>;
+};
+
+export type TValidationMode = 'documenso-zod' | 'local-fallback';
+
+export type TPolicyFieldOverride = {
+  semanticKey?: string;
+  semanticLabel?: string;
+  classification?: TClassification;
+  confidence?: TConfidence;
+  generationRole?: TGenerationRole;
+  evidence?: string[];
+};
+
+export type TPolicyManualOverlay = {
+  bindingKey: string;
+  semanticKey: string;
+  semanticLabel: string;
+  classification: Extract<TClassification, 'signer-overlay-signature' | 'signer-overlay-date'>;
+  recipientKey: string;
+  envelopeItemKey: string;
+  type: Extract<TDocumensoFieldType, 'SIGNATURE' | 'DATE' | 'TEXT' | 'NAME' | 'EMAIL' | 'INITIALS'>;
+  page: number;
+  positionX: number;
+  positionY: number;
+  width: number;
+  height: number;
+  fieldMeta?: Record<string, unknown>;
+  note?: string;
+};
+
+export type TPolicyGeneratedOverlay = {
+  sourceKey?: string;
+  rawName?: string;
+  bindingKey: string;
+  semanticKey?: string;
+  semanticLabel?: string;
+  classification: Extract<TClassification, 'signer-overlay-signature' | 'signer-overlay-date'>;
+  recipientKey: string;
+  envelopeItemKey: string;
+  type: Extract<TDocumensoFieldType, 'SIGNATURE' | 'DATE' | 'TEXT' | 'NAME' | 'EMAIL' | 'INITIALS'>;
+  fieldMeta?: Record<string, unknown>;
+};
+
+export type TPolicy = {
+  profile: string;
+  envelopeType: 'TEMPLATE';
+  signerRecipientKey: string;
+  primaryEnvelopeItemKey: string;
+  fieldOverrides?: Record<string, TPolicyFieldOverride>;
+  manualOverlays: TPolicyManualOverlay[];
+  generatedOverlays?: TPolicyGeneratedOverlay[];
+};
+
+export const DEFAULT_FIELD_FONT_SIZE = 12;
+export const DEFAULT_SIGNATURE_TEXT_FONT_SIZE = 18;
+
+export const DEFAULT_FIELD_META_BY_TYPE: Record<TDocumensoFieldType, Record<string, unknown> | undefined> = {
+  SIGNATURE: {
+    type: 'signature',
+    fontSize: DEFAULT_SIGNATURE_TEXT_FONT_SIZE,
+  },
+  FREE_SIGNATURE: undefined,
+  INITIALS: {
+    type: 'initials',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    textAlign: 'left',
+  },
+  NAME: {
+    type: 'name',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    textAlign: 'left',
+  },
+  EMAIL: {
+    type: 'email',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    textAlign: 'left',
+  },
+  DATE: {
+    type: 'date',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    textAlign: 'left',
+  },
+  TEXT: {
+    type: 'text',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    textAlign: 'left',
+    label: '',
+    placeholder: '',
+    text: '',
+    required: false,
+    readOnly: false,
+  },
+  NUMBER: {
+    type: 'number',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    textAlign: 'left',
+    label: '',
+    placeholder: '',
+    required: false,
+    readOnly: false,
+  },
+  RADIO: {
+    type: 'radio',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    values: [{ id: 1, checked: false, value: '' }],
+    required: false,
+    readOnly: false,
+    direction: 'vertical',
+  },
+  CHECKBOX: {
+    type: 'checkbox',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    values: [{ id: 1, checked: false, value: '' }],
+    validationRule: '',
+    validationLength: 0,
+    required: false,
+    readOnly: false,
+    direction: 'vertical',
+  },
+  DROPDOWN: {
+    type: 'dropdown',
+    fontSize: DEFAULT_FIELD_FONT_SIZE,
+    values: [{ value: 'Option 1' }],
+    defaultValue: '',
+    required: false,
+    readOnly: false,
+  },
+};
+
+export const getRepoRoot = () => {
+  const currentFile = fileURLToPath(import.meta.url);
+
+  return path.resolve(path.dirname(currentFile), '..', '..', '..');
+};
+
+export const getDefaultInputPdfPath = () =>
+  path.join(getRepoRoot(), 'artifacts', 'acroform-field-sidecar', 'canonical', 'sample-acroform-form.pdf');
+
+export const getDefaultOutputDir = () => path.join(getRepoRoot(), 'artifacts', 'acroform-field-sidecar', 'working');
+
+export const getDefaultPolicyPath = () =>
+  path.join(path.dirname(fileURLToPath(import.meta.url)), 'profiles', 'sample-acroform.policy.json');
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const assertCoordinate = (value: number, label: string) => {
+  if (!isFiniteNumber(value) || value < 0 || value > 100) {
+    throw new Error(`${label} must be a number between 0 and 100`);
+  }
+};
+
+const assertFieldType: (value: unknown) => asserts value is TDocumensoFieldType = (value) => {
+  if (typeof value !== 'string' || !FIELD_TYPES.includes(value as TDocumensoFieldType)) {
+    throw new Error(`Invalid Documenso field type: ${String(value)}`);
+  }
+};
+
+export const getDefaultFieldMeta = (type: TDocumensoFieldType) => {
+  const base = DEFAULT_FIELD_META_BY_TYPE[type];
+
+  if (!base) {
+    return undefined;
+  }
+
+  return structuredClone(base);
+};
+
+export const assertValidTemplate = (template: TDocumensoFieldTemplate) => {
+  if (template.envelopeType !== 'TEMPLATE') {
+    throw new Error('Template envelopeType must be TEMPLATE');
+  }
+
+  for (const field of template.fields) {
+    assertFieldType(field.type);
+
+    if (!field.bindingKey) {
+      throw new Error('Template field bindingKey is required');
+    }
+
+    if (!field.recipientKey) {
+      throw new Error(`Template field ${field.bindingKey} is missing recipientKey`);
+    }
+
+    if (!field.envelopeItemKey) {
+      throw new Error(`Template field ${field.bindingKey} is missing envelopeItemKey`);
+    }
+
+    if (!Number.isInteger(field.page) || field.page < 1) {
+      throw new Error(`Template field ${field.bindingKey} must have page >= 1`);
+    }
+
+    assertCoordinate(field.positionX, `Template field ${field.bindingKey} positionX`);
+    assertCoordinate(field.positionY, `Template field ${field.bindingKey} positionY`);
+    assertCoordinate(field.width, `Template field ${field.bindingKey} width`);
+    assertCoordinate(field.height, `Template field ${field.bindingKey} height`);
+  }
+};
+
+export const assertValidBoundPayload = (payload: TBoundPayload) => {
+  if (!payload.envelopeId) {
+    throw new Error('Payload envelopeId is required');
+  }
+
+  if (payload.envelopeType !== 'TEMPLATE' && payload.envelopeType !== 'DOCUMENT') {
+    throw new Error('Payload envelopeType must be TEMPLATE or DOCUMENT');
+  }
+
+  for (const field of payload.fields) {
+    assertFieldType(field.type);
+
+    if (!field.envelopeItemId) {
+      throw new Error('Payload field envelopeItemId is required');
+    }
+
+    if (!Number.isInteger(field.recipientId) || field.recipientId <= 0) {
+      throw new Error(`Payload field recipientId must be a positive integer: ${field.recipientId}`);
+    }
+
+    if (!Number.isInteger(field.page) || field.page < 1) {
+      throw new Error(`Payload field page must be >= 1: ${field.page}`);
+    }
+
+    assertCoordinate(field.positionX, `Payload field ${field.type} positionX`);
+    assertCoordinate(field.positionY, `Payload field ${field.type} positionY`);
+    assertCoordinate(field.width, `Payload field ${field.type} width`);
+    assertCoordinate(field.height, `Payload field ${field.type} height`);
+  }
+};
+
+export const validateWithDocumensoSchemasIfAvailable = async (
+  payload: TBoundPayload,
+): Promise<TValidationMode> => {
+  try {
+    const schemaModulePath = '../../trpc/server/envelope-router/set-envelope-fields.types.ts';
+    const module = (await import(schemaModulePath)) as {
+      ZSetEnvelopeFieldsRequestSchema: {
+        parse: (payload: TBoundPayload) => unknown;
+      };
+    };
+
+    module.ZSetEnvelopeFieldsRequestSchema.parse(payload);
+
+    return 'documenso-zod';
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : '';
+
+    if (
+      code === 'ERR_MODULE_NOT_FOUND' ||
+      message.includes('Cannot find package') ||
+      message.includes('Cannot find module') ||
+      message.includes('Failed to resolve module')
+    ) {
+      return 'local-fallback';
+    }
+
+    throw error;
+  }
+};
+
+export const stableSortObject = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(stableSortObject);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, stableSortObject(nestedValue)]),
+    );
+  }
+
+  return value;
+};
+
+export const toStableJson = (value: unknown) => JSON.stringify(stableSortObject(value), null, 2) + '\n';

--- a/packages/acroform-field-sidecar/src/sidecar.test.ts
+++ b/packages/acroform-field-sidecar/src/sidecar.test.ts
@@ -1,0 +1,245 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildOverlayPlan } from './build-overlay-plan.ts';
+import { extractAcroformInventory } from './extract-acroform.ts';
+import { documensoRectToPdfRect, getPreviewStyleKind, renderPreviewPdf } from './render-preview.ts';
+import { bindDocumensoPayload, renderDocumensoFieldTemplate } from './render-documenso-payload.ts';
+import {
+  assertValidBoundPayload,
+  getDefaultPolicyPath,
+  toStableJson,
+  type TBindings,
+} from './schemas.ts';
+import { loadPolicy, resolveSemantics } from './resolve-semantics.ts';
+
+const buildSyntheticAcroformPdf = () => {
+  const objects = [
+    ['1 0', '<< /Type /Catalog /Pages 2 0 R /AcroForm 3 0 R >>'],
+    ['2 0', '<< /Type /Pages /Kids [5 0 R] /Count 1 >>'],
+    ['3 0', '<< /Fields [4 0 R 6 0 R 7 0 R 8 0 R] >>'],
+    [
+      '4 0',
+      '<< /Type /Annot /Subtype /Widget /FT /Tx /T (customerName) /TU (Customer name) /P 5 0 R /Rect [60 700 240 720] >>',
+    ],
+    [
+      '5 0',
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] /Resources << >> /Annots [4 0 R 6 0 R 7 0 R 8 0 R] >>',
+    ],
+    [
+      '6 0',
+      '<< /Type /Annot /Subtype /Widget /FT /Btn /T (toggle_1) /TU (Marketing consent) /P 5 0 R /Rect [60 650 72 662] >>',
+    ],
+    [
+      '7 0',
+      '<< /Type /Annot /Subtype /Widget /FT /Tx /T (sampleDateYear) /TU (Sample date year) /P 5 0 R /Rect [60 100 100 120] >>',
+    ],
+    [
+      '8 0',
+      '<< /Type /Annot /Subtype /Widget /FT /Tx /T (signatureAnchor) /TU (Signature anchor) /P 5 0 R /Rect [390 100 540 120] >>',
+    ],
+  ];
+  const offsets = [0];
+  let body = '%PDF-1.7\n';
+
+  for (const [ref, objectBody] of objects) {
+    offsets.push(Buffer.byteLength(body, 'latin1'));
+    body += `${ref} obj\n${objectBody}\nendobj\n`;
+  }
+
+  const xrefOffset = Buffer.byteLength(body, 'latin1');
+  body += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+
+  for (const offset of offsets.slice(1)) {
+    body += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+
+  body += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return body;
+};
+
+const writeSyntheticAcroformPdf = async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'acroform-field-sidecar-'));
+  const inputPath = path.join(directory, 'sample-acroform-form.pdf');
+
+  await fs.writeFile(inputPath, buildSyntheticAcroformPdf(), 'latin1');
+
+  return {
+    directory,
+    inputPath,
+  };
+};
+
+describe('acroform-field-sidecar', () => {
+  it('extracts the expected AcroForm inventory from a synthetic fixture', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const inventory = await extractAcroformInventory(inputPath);
+
+    expect(inventory.fields).toHaveLength(4);
+    expect(inventory.fields.filter((field) => field.rawType === 'Tx')).toHaveLength(3);
+    expect(inventory.fields.filter((field) => field.rawType === 'Btn')).toHaveLength(1);
+    expect(new Set(inventory.fields.map((field) => field.page))).toEqual(new Set([1]));
+  });
+
+  it('normalizes coordinates deterministically for key text fields', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const inventory = await extractAcroformInventory(inputPath);
+    const customerNameField = inventory.fields.find((field) => field.rawName === 'customerName');
+
+    expect(customerNameField).toBeDefined();
+    expect(customerNameField?.rectDocumenso.positionX).toBeCloseTo(10, 4);
+    expect(customerNameField?.rectDocumenso.positionY).toBeCloseTo(10, 4);
+    expect(customerNameField?.rectDocumenso.width).toBeCloseTo(30, 4);
+    expect(customerNameField?.rectDocumenso.height).toBeCloseTo(2.5, 4);
+  });
+
+  it('resolves named fields from /T and generic toggles from /TU', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const inventory = await extractAcroformInventory(inputPath);
+    const policy = await loadPolicy(getDefaultPolicyPath());
+    const spec = resolveSemantics(inventory, policy);
+    const namedField = spec.fields.find((field) => field.sourceKey === 'customerName');
+    const toggleField = spec.fields.find((field) => field.sourceKey === 'toggle_1');
+
+    expect(namedField?.confidence).toBe('high');
+    expect(namedField?.semanticKey).toBe('customerName');
+    expect(toggleField?.confidence).toBe('medium');
+    expect(toggleField?.semanticLabel).toBe('Marketing consent');
+  });
+
+  it('keeps unresolved fields explicit instead of silently coercing them', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const inventory = await extractAcroformInventory(inputPath);
+
+    inventory.fields.push({
+      sourceKey: 'mysteryField',
+      rawName: null,
+      rawType: null,
+      rawTooltip: null,
+      page: 1,
+      rectPdf: { x1: 0, y1: 0, x2: 1, y2: 1 },
+      rectDocumenso: { positionX: 0, positionY: 0, width: 1, height: 1 },
+    });
+
+    const policy = await loadPolicy(getDefaultPolicyPath());
+    const spec = resolveSemantics(inventory, policy);
+    const unresolved = spec.unresolved.find((field) => field.sourceKey === 'mysteryField');
+
+    expect(unresolved).toBeDefined();
+    expect(unresolved?.generationRole).toBe('unresolved');
+  });
+
+  it('builds only the signing-layer overlay subset', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const inventory = await extractAcroformInventory(inputPath);
+    const policy = await loadPolicy(getDefaultPolicyPath());
+    const spec = buildOverlayPlan(resolveSemantics(inventory, policy), policy);
+
+    expect(spec.overlayPlan).toHaveLength(1);
+    expect(spec.overlayPlan[0].type).toBe('SIGNATURE');
+    expect(spec.overlayPlan[0].generationRole).toBe('overlay-generated');
+    expect(spec.overlayPlan[0].sourceKey).toBe('signatureAnchor');
+    expect(spec.overlayPlan[0].positionX).toBeCloseTo(65, 4);
+    expect(spec.overlayPlan[0].positionY).toBeCloseTo(85, 4);
+    expect(spec.overlayPlan[0].width).toBeCloseTo(25, 4);
+    expect(spec.overlayPlan[0].height).toBeCloseTo(2.5, 4);
+  });
+
+  it('binds a valid Documenso payload', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const inventory = await extractAcroformInventory(inputPath);
+    const policy = await loadPolicy(getDefaultPolicyPath());
+    const spec = buildOverlayPlan(resolveSemantics(inventory, policy), policy);
+    const template = renderDocumensoFieldTemplate(spec, policy);
+    const bindings: TBindings = {
+      envelopeId: 'env_live',
+      envelopeType: 'TEMPLATE',
+      recipientIds: { signer: 2001 },
+      envelopeItemIds: { 'primary-pdf': 'item_live' },
+    };
+    const payload = bindDocumensoPayload(template, bindings);
+
+    expect(() => assertValidBoundPayload(payload)).not.toThrow();
+  });
+
+  it('is deterministic for the same PDF input', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf();
+    const first = await extractAcroformInventory(inputPath);
+    const second = await extractAcroformInventory(inputPath);
+
+    expect(first).toEqual(second);
+  });
+
+  it('has a valid policy file in the expected location', async () => {
+    const policyPath = getDefaultPolicyPath();
+    const policyContents = await fs.readFile(policyPath, 'utf8');
+
+    expect(path.basename(policyPath)).toBe('sample-acroform.policy.json');
+    expect(policyContents).toContain('"bindingKey": "signer-signature"');
+  });
+
+  it('converts Documenso percentages into PDF drawing coordinates', () => {
+    const rect = documensoRectToPdfRect(
+      { positionX: 10, positionY: 20, width: 30, height: 5 },
+      600,
+      800,
+    );
+
+    expect(rect).toEqual({
+      x: 60,
+      y: 600,
+      width: 180,
+      height: 40,
+    });
+  });
+
+  it('maps preview classifications to distinct visual style kinds', () => {
+    expect(
+      getPreviewStyleKind({
+        generationRole: 'unresolved',
+        classification: 'unresolved',
+      } as never),
+    ).toBe('unresolved');
+    expect(
+      getPreviewStyleKind({
+        generationRole: 'ignored',
+        classification: 'overlay-candidate',
+      } as never),
+    ).toBe('candidate');
+    expect(
+      getPreviewStyleKind({
+        generationRole: 'prefill-only',
+        classification: 'prefill-text',
+      } as never),
+    ).toBe('skipped');
+  });
+
+  it('renders a debug preview PDF artifact', async () => {
+    const { directory, inputPath } = await writeSyntheticAcroformPdf();
+    const policy = await loadPolicy(getDefaultPolicyPath());
+    const inventory = await extractAcroformInventory(inputPath);
+    const spec = buildOverlayPlan(resolveSemantics(inventory, policy), policy);
+    const template = renderDocumensoFieldTemplate(spec, policy);
+    const templatePath = path.join(directory, 'documenso-field-template.json');
+    const fieldSpecPath = path.join(directory, 'field-spec.json');
+    const outputPath = path.join(directory, 'acroform-field-preview.test.pdf');
+
+    await fs.writeFile(templatePath, toStableJson(template));
+    await fs.writeFile(fieldSpecPath, toStableJson(spec));
+
+    const result = await renderPreviewPdf({
+      inputPath,
+      templatePath,
+      fieldSpecPath,
+      outputPath,
+    });
+    const output = await fs.readFile(result.outputPath);
+
+    expect(output.byteLength).toBeGreaterThan(1000);
+    expect(output.subarray(0, 5).toString()).toBe('%PDF-');
+  });
+});

--- a/packages/acroform-field-sidecar/src/sidecar.test.ts
+++ b/packages/acroform-field-sidecar/src/sidecar.test.ts
@@ -16,30 +16,40 @@ import {
 } from './schemas.ts';
 import { loadPolicy, resolveSemantics } from './resolve-semantics.ts';
 
-const buildSyntheticAcroformPdf = () => {
+type TSyntheticPdfOptions = {
+  inheritPageMediaBox?: boolean;
+  widgetWithoutPageRef?: 'customerName' | 'toggle_1' | 'sampleDateYear' | 'signatureAnchor';
+};
+
+const buildSyntheticAcroformPdf = (options: TSyntheticPdfOptions = {}) => {
+  const pageMediaBox = options.inheritPageMediaBox ? '' : ' /MediaBox [0 0 600 800]';
+  const customerNamePageRef = options.widgetWithoutPageRef === 'customerName' ? '' : ' /P 5 0 R';
+  const togglePageRef = options.widgetWithoutPageRef === 'toggle_1' ? '' : ' /P 5 0 R';
+  const sampleDateYearPageRef = options.widgetWithoutPageRef === 'sampleDateYear' ? '' : ' /P 5 0 R';
+  const signatureAnchorPageRef = options.widgetWithoutPageRef === 'signatureAnchor' ? '' : ' /P 5 0 R';
   const objects = [
     ['1 0', '<< /Type /Catalog /Pages 2 0 R /AcroForm 3 0 R >>'],
-    ['2 0', '<< /Type /Pages /Kids [5 0 R] /Count 1 >>'],
+    ['2 0', '<< /Type /Pages /Kids [5 0 R] /Count 1 /MediaBox [0 0 600 800] >>'],
     ['3 0', '<< /Fields [4 0 R 6 0 R 7 0 R 8 0 R] >>'],
     [
       '4 0',
-      '<< /Type /Annot /Subtype /Widget /FT /Tx /T (customerName) /TU (Customer name) /P 5 0 R /Rect [60 700 240 720] >>',
+      `<< /Type /Annot /Subtype /Widget /FT /Tx /T (customerName) /TU (Customer name)${customerNamePageRef} /Rect [60 700 240 720] >>`,
     ],
     [
       '5 0',
-      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] /Resources << >> /Annots [4 0 R 6 0 R 7 0 R 8 0 R] >>',
+      `<< /Type /Page /Parent 2 0 R${pageMediaBox} /Resources << >> /Annots [4 0 R 6 0 R 7 0 R 8 0 R] >>`,
     ],
     [
       '6 0',
-      '<< /Type /Annot /Subtype /Widget /FT /Btn /T (toggle_1) /TU (Marketing consent) /P 5 0 R /Rect [60 650 72 662] >>',
+      `<< /Type /Annot /Subtype /Widget /FT /Btn /T (toggle_1) /TU (Marketing consent)${togglePageRef} /Rect [60 650 72 662] >>`,
     ],
     [
       '7 0',
-      '<< /Type /Annot /Subtype /Widget /FT /Tx /T (sampleDateYear) /TU (Sample date year) /P 5 0 R /Rect [60 100 100 120] >>',
+      `<< /Type /Annot /Subtype /Widget /FT /Tx /T (sampleDateYear) /TU (Sample date year)${sampleDateYearPageRef} /Rect [60 100 100 120] >>`,
     ],
     [
       '8 0',
-      '<< /Type /Annot /Subtype /Widget /FT /Tx /T (signatureAnchor) /TU (Signature anchor) /P 5 0 R /Rect [390 100 540 120] >>',
+      `<< /Type /Annot /Subtype /Widget /FT /Tx /T (signatureAnchor) /TU (Signature anchor)${signatureAnchorPageRef} /Rect [390 100 540 120] >>`,
     ],
   ];
   const offsets = [0];
@@ -62,11 +72,11 @@ const buildSyntheticAcroformPdf = () => {
   return body;
 };
 
-const writeSyntheticAcroformPdf = async () => {
+const writeSyntheticAcroformPdf = async (options: TSyntheticPdfOptions = {}) => {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'acroform-field-sidecar-'));
   const inputPath = path.join(directory, 'sample-acroform-form.pdf');
 
-  await fs.writeFile(inputPath, buildSyntheticAcroformPdf(), 'latin1');
+  await fs.writeFile(inputPath, buildSyntheticAcroformPdf(options), 'latin1');
 
   return {
     directory,
@@ -95,6 +105,31 @@ describe('acroform-field-sidecar', () => {
     expect(customerNameField?.rectDocumenso.positionY).toBeCloseTo(10, 4);
     expect(customerNameField?.rectDocumenso.width).toBeCloseTo(30, 4);
     expect(customerNameField?.rectDocumenso.height).toBeCloseTo(2.5, 4);
+  });
+
+  it('inherits the page MediaBox from parent Pages nodes', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf({ inheritPageMediaBox: true });
+    const inventory = await extractAcroformInventory(inputPath);
+
+    expect(inventory.pages).toEqual([
+      {
+        pageNumber: 1,
+        width: 600,
+        height: 800,
+      },
+    ]);
+    expect(inventory.fields[0]?.page).toBe(1);
+  });
+
+  it('derives widget page ownership from the page Annots array when /P is missing', async () => {
+    const { inputPath } = await writeSyntheticAcroformPdf({ widgetWithoutPageRef: 'signatureAnchor' });
+    const inventory = await extractAcroformInventory(inputPath);
+    const signatureField = inventory.fields.find((field) => field.rawName === 'signatureAnchor');
+
+    expect(signatureField).toBeDefined();
+    expect(signatureField?.page).toBe(1);
+    expect(signatureField?.rectDocumenso.positionX).toBeCloseTo(65, 4);
+    expect(signatureField?.rectDocumenso.positionY).toBeCloseTo(85, 4);
   });
 
   it('resolves named fields from /T and generic toggles from /TU', async () => {

--- a/packages/acroform-field-sidecar/tsconfig.json
+++ b/packages/acroform-field-sidecar/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@documenso/tsconfig/base.json",
+  "include": ["src/**/*.ts", "src/**/*.json"],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "lib": ["esnext"]
+  }
+}

--- a/packages/acroform-field-sidecar/vitest.config.ts
+++ b/packages/acroform-field-sidecar/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Adds a small reusable AcroForm sidecar package that can inspect an existing AcroForm PDF, recover widget metadata, generate a Documenso-shaped field payload/template, and render a visual preview for debugging.

This is intended as tooling for AcroForm-to-Documenso field-layer workflows. It does not change Documenso’s upload behavior or add native AcroForm field import in the editor UI.

## What this adds

- an `@documenso/acroform-field-sidecar` workspace package
- CLI commands to:
  - inspect AcroForm widgets
  - generate a stable field spec and Documenso field template
  - bind runtime payloads
  - render a debug preview PDF
- parser hardening for real-world AcroForm PDFs:
  - inherited `/MediaBox` support from ancestor `/Pages`
  - widget-to-page fallback lookup through page `/Annots`

## Why

Some PDFs already exist as AcroForm documents, but Documenso’s current PDF upload flow is centered around uploaded page content and placeholder-based field placement rather than Acrobat widget import.

This package provides a narrow, reusable bridge:
- read the AcroForm contract
- recover stable widget coordinates
- turn that into a Documenso field-layer artifact
- visually inspect the output before runtime use

## What this does not do

- no automatic AcroForm import during PDF upload
- no change to editor behavior when a user uploads an AcroForm PDF
- no replacement for placeholder-based PDF field detection
- no Documenso product decision about whether native AcroForm import should exist

## Intended use

This is most useful for integrations or migration tooling where:
1. an existing AcroForm PDF must remain unchanged
2. field positions need to be recovered deterministically
3. Documenso fields will be created separately through API/runtime orchestration

## Validation

- sidecar Vitest suite covers:
  - inventory extraction
  - coordinate normalization
  - semantic resolution
  - unresolved-field behavior
  - overlay policy
  - payload validation
  - deterministic output
  - inherited page metadata
  - missing-widget-`/P` fallback via page annotations
