### PR TITLE
fix: prevent info icon tooltips from triggering form submission in settings dialog (fixes #2684)

### DIFF
--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx
@@ -440,7 +440,7 @@ export const EnvelopeEditorSettingsDialog = ({
                               <FormLabel className="inline-flex items-center">
                                 <Trans>Language</Trans>
                                 <Tooltip>
-                                  <TooltipTrigger>
+                                  <TooltipTrigger type="button">
                                     <InfoIcon className="mx-2 h-4 w-4" />
                                   </TooltipTrigger>
 
@@ -581,7 +581,7 @@ export const EnvelopeEditorSettingsDialog = ({
                             <FormLabel className="flex flex-row items-center">
                               <Trans>External ID</Trans>{' '}
                               <Tooltip>
-                                <TooltipTrigger>
+                                <TooltipTrigger type="button">
                                   <InfoIcon className="mx-2 h-4 w-4" />
                                 </TooltipTrigger>
 
@@ -611,7 +611,7 @@ export const EnvelopeEditorSettingsDialog = ({
                             <FormLabel className="flex flex-row items-center">
                               <Trans>Redirect URL</Trans>{' '}
                               <Tooltip>
-                                <TooltipTrigger>
+                                <TooltipTrigger type="button">
                                   <InfoIcon className="mx-2 h-4 w-4" />
                                 </TooltipTrigger>
 
@@ -666,7 +666,7 @@ export const EnvelopeEditorSettingsDialog = ({
                               <FormLabel className="flex flex-row items-center">
                                 <Trans>Document Distribution Method</Trans>
                                 <Tooltip>
-                                  <TooltipTrigger>
+                                  <TooltipTrigger type="button">
                                     <InfoIcon className="mx-2 h-4 w-4" />
                                   </TooltipTrigger>
 
@@ -739,7 +739,7 @@ export const EnvelopeEditorSettingsDialog = ({
                               <FormLabel className="flex flex-row items-center">
                                 <Trans>Expiration</Trans>
                                 <Tooltip>
-                                  <TooltipTrigger>
+                                  <TooltipTrigger type="button">
                                     <InfoIcon className="mx-2 h-4 w-4" />
                                   </TooltipTrigger>
 
@@ -778,7 +778,7 @@ export const EnvelopeEditorSettingsDialog = ({
                             <FormLabel className="flex flex-row items-center">
                               <Trans>Signing Reminders</Trans>
                               <Tooltip>
-                                <TooltipTrigger>
+                                <TooltipTrigger type="button">
                                   <InfoIcon className="mx-2 h-4 w-4" />
                                 </TooltipTrigger>
 
@@ -906,7 +906,7 @@ export const EnvelopeEditorSettingsDialog = ({
                                   Message <span className="text-muted-foreground">(Optional)</span>
                                 </Trans>
                                 <Tooltip>
-                                  <TooltipTrigger>
+                                  <TooltipTrigger type="button">
                                     <InfoIcon className="mx-2 h-4 w-4" />
                                   </TooltipTrigger>
                                   <TooltipContent className="p-4 text-muted-foreground">


### PR DESCRIPTION
## Background

In the Document Settings dialog (General/Email/Security tabs), clicking on info (i) icon tooltips unexpectedly triggers the envelope update API and closes the modal. This happens because Radix UI's `TooltipTrigger` renders as a `<button>` element by default, and buttons inside a `<form>` submit the form on click.

## Solution

Add `type="button"` to all `TooltipTrigger` instances in the `EnvelopeEditorSettingsDialog` component. This prevents the tooltip triggers from acting as form submit buttons while preserving the tooltip functionality.

## Changes

- **`apps/remix/app/components/general/envelope-editor/envelope-editor-settings-dialog.tsx`**: Added `type="button"` to all 7 `TooltipTrigger` instances wrapping `InfoIcon` elements across the General, Email, Reminders, and Security tabs.

## Verification

1. Open Document Settings dialog
2. Navigate to General tab
3. Click the info (i) icon next to "Language" → tooltip should appear, form should NOT submit, modal should stay open
4. Repeat for info icons on "External ID", "Redirect URL", "Document Distribution Method", "Expiration", "Message", and "Signing Reminders"
5. Verify the "Update" button still submits the form correctly

Closes #2684