### PR TITLE
fix: prevent TooltipTrigger from submitting parent forms (fixes #2684)

### DIFF
--- a/packages/ui/primitives/tooltip.tsx
+++ b/packages/ui/primitives/tooltip.tsx
@@ -8,7 +8,14 @@ const TooltipProvider = TooltipPrimitive.Provider;
 
 const Tooltip = TooltipPrimitive.Root;
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
+const TooltipTrigger = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Trigger>
+>(({ type = 'button', ...props }, ref) => (
+  <TooltipPrimitive.Trigger ref={ref} type={type} {...props} />
+));
+
+TooltipTrigger.displayName = TooltipPrimitive.Trigger.displayName;
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,


### PR DESCRIPTION
## Background

Clicking the info (i) icon in the Document Settings modal (e.g., next to "Language", "External ID", etc.) unexpectedly triggers the envelope update API and closes the modal. This happens because Radix UI's `TooltipPrimitive.Trigger` renders as an HTML `<button>` element, which defaults to `type="submit"` when placed inside a `<form>`. Since the settings dialog uses a `<form onSubmit={form.handleSubmit(onFormSubmit)}>`, clicking any info icon submits the form.

## Solution

Wrap `TooltipTrigger` with `React.forwardRef` and default its `type` prop to `"button"`. This prevents accidental form submission while still allowing callers to override the type if needed.

## Changes

- `packages/ui/primitives/tooltip.tsx` — Wrapped `TooltipTrigger` in `forwardRef` with `type="button"` default

## Verification

1. Open Document Settings dialog
2. Navigate to General tab
3. Click any info (i) icon (e.g., next to "Language")
4. Previously: Modal closes and envelope update API is triggered
5. Now: Tooltip appears normally without any side effects