### PR TITLE
fix: add confirmation before duplicating fields on all pages

### DIFF
--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
@@ -23,6 +23,16 @@ import {
 import { renderField } from '@documenso/lib/universal/field-renderer/render-field';
 import { getClientSideFieldTranslations } from '@documenso/lib/utils/fields';
 import { canRecipientFieldsBeModified } from '@documenso/lib/utils/recipients';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@documenso/ui/primitives/alert-dialog';
 import { CommandDialog } from '@documenso/ui/primitives/command';
 
 import { fieldButtonList } from './envelope-editor-fields-drag-drop';
@@ -650,6 +660,7 @@ const FieldActionButtons = ({
   const { t } = useLingui();
 
   const [showRecipientSelector, setShowRecipientSelector] = useState(false);
+  const [showDuplicateAllPagesDialog, setShowDuplicateAllPagesDialog] = useState(false);
 
   const { editorFields, envelope } = useCurrentEnvelopeEditor();
 
@@ -714,8 +725,8 @@ const FieldActionButtons = ({
         <button
           title={t`Duplicate on all pages`}
           className="rounded-sm p-1.5 text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-100"
-          onClick={handleDuplicateSelectedFieldsOnAllPages}
-          onTouchEnd={handleDuplicateSelectedFieldsOnAllPages}
+          onClick={() => setShowDuplicateAllPagesDialog(true)}
+          onTouchEnd={() => setShowDuplicateAllPagesDialog(true)}
         >
           <SquareStackIcon className="h-3 w-3" />
         </button>
@@ -747,6 +758,28 @@ const FieldActionButtons = ({
           fields={envelope.fields}
         />
       </CommandDialog>
+
+      <AlertDialog open={showDuplicateAllPagesDialog} onOpenChange={setShowDuplicateAllPagesDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t`Duplicate on all pages?`}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t`This will duplicate the selected field(s) to the same position on all other pages. This action cannot be undone.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t`Cancel`}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                handleDuplicateSelectedFieldsOnAllPages();
+                setShowDuplicateAllPagesDialog(false);
+              }}
+            >
+              {t`Duplicate`}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/packages/ui/primitives/document-flow/field-item.tsx
+++ b/packages/ui/primitives/document-flow/field-item.tsx
@@ -17,6 +17,16 @@ import { ZCheckboxFieldMeta, ZRadioFieldMeta } from '@documenso/lib/types/field-
 
 import { getRecipientColorStyles } from '../../lib/recipient-colors';
 import { cn } from '../../lib/utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../alert-dialog';
 import { FieldContent } from './field-content';
 import type { TDocumentFlowFormSchema } from './types';
 
@@ -94,6 +104,7 @@ const FieldItemInner = ({
     pageWidth: defaultWidth || 0,
   });
   const [settingsActive, setSettingsActive] = useState(false);
+  const [duplicateAllPagesAlertOpen, setDuplicateAllPagesAlertOpen] = useState(false);
   const $el = useRef<HTMLDivElement>(null);
 
   const $pageBounds = useElementBounds(
@@ -404,8 +415,8 @@ const FieldItemInner = ({
             <button
               title={_(msg`Duplicate on all pages`)}
               className="rounded-sm p-1.5 text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-100"
-              onClick={onDuplicateAllPages}
-              onTouchEnd={onDuplicateAllPages}
+              onClick={() => setDuplicateAllPagesAlertOpen(true)}
+              onTouchEnd={() => setDuplicateAllPagesAlertOpen(true)}
             >
               <SquareStack className="h-3 w-3" />
             </button>
@@ -421,6 +432,35 @@ const FieldItemInner = ({
           </div>
         </div>
       )}
+
+      <AlertDialog open={duplicateAllPagesAlertOpen} onOpenChange={setDuplicateAllPagesAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              <Trans>Duplicate on all pages?</Trans>
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <Trans>
+                This will duplicate the selected field(s) to the same position on all other pages.
+                This action cannot be undone.
+              </Trans>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              <Trans>Cancel</Trans>
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onDuplicateAllPages?.();
+                setDuplicateAllPagesAlertOpen(false);
+              }}
+            >
+              <Trans>Duplicate</Trans>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Rnd>,
     document.body,
   );


### PR DESCRIPTION
Closes #2674

## Summary
Adds a confirmation dialog before executing "duplicate to all pages" to prevent accidental actions.

## Changes
- Wrapped `duplicatedSelectedFieldsOnAllPages` with a confirmation dialog
- Uses existing Alert-Dialog component for consistency

## UX
- User must confirm before duplication
- No change to existing flow beyond safeguard

## Testing
- Verified manually by triggering duplication
- Ensured cancel does not perform action