### PR TITLE
chore: update French translations

### DIFF
--- a/packages/lib/translations/fr/web.po
+++ b/packages/lib/translations/fr/web.po
@@ -43,7 +43,7 @@ msgstr "« {documentName} » a été signé"
 
 #: packages/email/template-components/template-document-completed.tsx
 msgid "“{documentName}” was signed by all signers"
-msgstr "“{documentName}” a été signé par tous les signataires"
+msgstr "« {documentName} » a été signé par tous les signataires"
 
 #: apps/remix/app/components/forms/document-preferences-form.tsx
 msgid "\"{placeholderEmail}\" on behalf of \"Team Name\" has invited you to sign \"example document\"."
@@ -393,11 +393,11 @@ msgstr "{maximumEnvelopeItemCount, plural, one {Vous ne pouvez pas téléverser 
 
 #: apps/remix/app/components/general/direct-template/direct-template-page.tsx
 msgid "{recipientActionVerb} document"
-msgstr "{recipientActionVerb} document"
+msgstr "{recipientActionVerb} le document"
 
 #: apps/remix/app/components/general/direct-template/direct-template-page.tsx
 msgid "{recipientActionVerb} the document to complete the process."
-msgstr "{recipientActionVerb} the document to complete the process."
+msgstr "{recipientActionVerb} le document pour terminer le processus."
 
 #: apps/remix/app/components/general/document/document-certificate-qr-view.tsx
 #: apps/remix/app/components/general/document/document-certificate-qr-view.tsx
@@ -903,7 +903,7 @@ msgstr "Un appareil capable d'accéder, d'ouvrir et de lire des documents"
 
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 msgid "A document was created by your direct template that requires you to {recipientActionVerb} it."
-msgstr "Un document a été créé par votre modèle direct qui vous oblige à {recipientActionVerb}."
+msgstr "Un document a été créé par votre modèle direct et vous devez le {recipientActionVerb}."
 
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 msgid "A draft document will be created"
@@ -2892,7 +2892,7 @@ msgstr "Continuer en approuvant le document."
 #: packages/email/template-components/template-document-invite.tsx
 #: packages/email/template-components/template-document-reminder.tsx
 msgid "Continue by assisting with the document."
-msgstr "Continuez en aidant avec le document."
+msgstr "Continuer en collaborant sur le document."
 
 #: packages/email/template-components/template-document-completed.tsx
 msgid "Continue by downloading the document."
@@ -11908,15 +11908,15 @@ msgstr "Voir le document"
 
 #: packages/email/template-components/template-document-invite.tsx
 msgid "View Document to approve"
-msgstr "Voir Document à approuver"
+msgstr "Voir le document à approuver"
 
 #: packages/email/template-components/template-document-invite.tsx
 msgid "View Document to assist"
-msgstr "Voir Document pour assister"
+msgstr "Voir le document pour collaborer"
 
 #: packages/email/template-components/template-document-invite.tsx
 msgid "View Document to sign"
-msgstr "Voir Document pour signature"
+msgstr "Voir le document à signer"
 
 #: apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings._index.tsx
 msgid "View documents associated with this email"
@@ -12932,7 +12932,7 @@ msgstr "Vous avez refusé l'invitation de <0>{0}</0> à rejoindre leur organisat
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 #: packages/lib/server-only/document/resend-document.ts
 msgid "You have initiated the document {0} that requires you to {recipientActionVerb} it."
-msgstr "Vous avez initié le document {0} qui nécessite que vous {recipientActionVerb} celui-ci."
+msgstr "Vous avez initié le document {0} et devez le {recipientActionVerb}."
 
 #: apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks._index.tsx
 msgid "You have no webhooks yet. Your webhooks will be shown here once you create them."
@@ -12992,7 +12992,7 @@ msgstr "Vous avez rejeté ce document"
 
 #: packages/email/template-components/template-document-self-signed.tsx
 msgid "You have signed “{documentName}”"
-msgstr "Vous avez signé “{documentName}”"
+msgstr "Vous avez signé « {documentName} »"
 
 #: apps/remix/app/components/dialogs/organisation-leave-dialog.tsx
 msgid "You have successfully left this organisation."


### PR DESCRIPTION
## Description

Improves French translations in recipient-facing email templates and the direct template signing flow. The original translations had several inconsistencies: missing articles, broken subjunctive grammar around the `{recipientActionVerb}` placeholder, mismatched typographic quotes, and one verb-form inconsistency in the `Continue by ...` family.

## Related Issue

N/A

## Changes Made

All changes are in `packages/lib/translations/fr/web.po`.

**1. Direct template signing page (`direct-template-page.tsx`):**
- `{recipientActionVerb} document` → `{recipientActionVerb} le document` (article was missing — rendered "Signer document" instead of "Signer le document").
- `{recipientActionVerb} the document to complete the process.` was still in English → translated to `{recipientActionVerb} le document pour terminer le processus.`

**2. Email template buttons (`template-document-invite.tsx`):**
- `View Document to approve` → `Voir le document à approuver` (was `Voir Document à approuver`).
- `View Document to assist` → `Voir le document pour collaborer` (was `Voir Document pour assister`).
- `View Document to sign` → `Voir le document à signer` (was `Voir Document pour signature`).

  Three issues fixed at once: missing article, inconsistent preposition (`à` / `pour`), and inconsistency with the standalone `View Document` entry already translated as `Voir le document`. For the `assist` variant, `assister un document` is not idiomatic French (the verb `assister` does not naturally take an inanimate direct object); `collaborer` better fits both the recipient role's intent and natural French construction.

**3. `Continue by ...` family consistency (`template-document-invite.tsx`):**
- `Continue by assisting with the document.` → `Continuer en collaborant sur le document.` (was `Continuez en aidant avec le document.`)

  The four sibling entries (`approving`, `signing`, `viewing`, `downloading`) all use the infinitive `Continuer en <gerund>`. This entry used the imperative `Continuez` and the awkward construction `aider avec`. Switched to `collaborer sur` for both grammatical consistency with siblings and lexical consistency with the `View Document to assist` button above.

**4. Broken subjunctive around `{recipientActionVerb}` (`send-signing-email.handler.ts`):**

  `{recipientActionVerb}` resolves to a lowercase infinitive verb (`signer`, `voir`, `approuver`, `assister`, `cc`). Sentences that placed it after `que vous` or `vous oblige à` produced ungrammatical French. Reworded to avoid the subjunctive while keeping the same meaning:

- `You have initiated the document {0} that requires you to {recipientActionVerb} it.` → `Vous avez initié le document {0} et devez le {recipientActionVerb}.` (was `... qui nécessite que vous {recipientActionVerb} celui-ci.` → rendered "que vous signer celui-ci".)
- `A document was created by your direct template that requires you to {recipientActionVerb} it.` → `Un document a été créé par votre modèle direct et vous devez le {recipientActionVerb}.` (was `... qui vous oblige à {recipientActionVerb}.` → no object, awkward.)

**5. French typographic quotes (`template-document-completed.tsx`, `template-document-self-signed.tsx`):**
- `“{documentName}” was signed by all signers` → `« {documentName} » a été signé par tous les signataires` (was using English curly quotes; the sibling `“{documentName}” has been signed` already used `« »`).
- `You have signed “{documentName}”` → `Vous avez signé « {documentName} »` (same fix).

## Testing Performed

- Cross-checked `{recipientActionVerb}` resolution in `packages/lib/constants/recipient-roles.ts` and the existing French translations of the action verbs (`Sign` → `Signer`, `View` → `Voir`, `Approve` → `Approuver`, `Assist` → `Assister`) to confirm grammatical agreement after lowercasing.
- Verified consistency with sibling translations (`Continue by ...`, `View Document`, `« {documentName} »`) within the same file.
- Confirmed no other languages were touched.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

Only the French file is touched. No source code changes — translation strings only. Other quality issues exist in `fr/web.po` (missing French typographic spaces before `:` `?` `!`) but are kept out of scope here to keep this PR focused on grammar and consistency in recipient-facing flows.