### PR TITLE
fix: Added restart unless stopped flag 

### DIFF
--- a/docker/development/compose.yml
+++ b/docker/development/compose.yml
@@ -3,6 +3,7 @@ name: documenso-development
 services:
   database:
     image: postgres:15
+    restart: unless-stopped
     container_name: database
     volumes:
       - documenso_database:/var/lib/postgresql/data
@@ -20,6 +21,7 @@ services:
 
   inbucket:
     image: inbucket/inbucket
+    restart: unless-stopped
     container_name: mailserver
     ports:
       - 9000:9000
@@ -28,6 +30,7 @@ services:
 
   redis:
     image: redis:8-alpine
+    restart: unless-stopped
     container_name: redis
     ports:
       - 63790:6379
@@ -36,6 +39,7 @@ services:
 
   minio:
     image: minio/minio
+    restart: unless-stopped
     container_name: minio
     ports:
       - 9002:9002

--- a/docker/production/compose.yml
+++ b/docker/production/compose.yml
@@ -3,6 +3,7 @@ name: documenso-production
 services:
   database:
     image: postgres:15
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:?err}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?err}
@@ -17,6 +18,7 @@ services:
 
   documenso:
     image: documenso/documenso:latest
+    restart: unless-stopped
     depends_on:
       database:
         condition: service_healthy

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -3,7 +3,6 @@ name: documenso-test
 services:
   database:
     image: postgres:15
-    restart: unless-stopped
     environment:
       - POSTGRES_USER=documenso
       - POSTGRES_PASSWORD=password
@@ -18,7 +17,6 @@ services:
 
   inbucket:
     image: inbucket/inbucket
-    restart: unless-stopped
     ports:
       - 9000:9000
       - 2500:2500
@@ -28,7 +26,6 @@ services:
     build:
       context: ../../
       dockerfile: docker/Dockerfile
-    restart: unless-stopped
     depends_on:
       database:
         condition: service_healthy

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -3,6 +3,7 @@ name: documenso-test
 services:
   database:
     image: postgres:15
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=documenso
       - POSTGRES_PASSWORD=password
@@ -17,6 +18,7 @@ services:
 
   inbucket:
     image: inbucket/inbucket
+    restart: unless-stopped
     ports:
       - 9000:9000
       - 2500:2500
@@ -26,6 +28,7 @@ services:
     build:
       context: ../../
       dockerfile: docker/Dockerfile
+    restart: unless-stopped
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
## Description

Added the feature so that docker services keeps on running unless it's crashed or stopped 

## Related Issue

this fixes : #2721 

## Changes Made
-  added the flag ``` restart : unless-stopped``` for production, testing and development docker compose yml file 

## Testing Performed

yes 



## Checklist



- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [x] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

