### PR TITLE
feat: Redaction

### DIFF
--- a/apps/docs/content/docs/users/documents/meta.json
+++ b/apps/docs/content/docs/users/documents/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Documents",
-  "pages": ["upload", "add-recipients", "add-fields", "send", "direct-links", "advanced"]
+  "pages": ["upload", "add-recipients", "add-fields", "redact", "send", "direct-links", "advanced"]
 }

--- a/apps/docs/content/docs/users/documents/redact.mdx
+++ b/apps/docs/content/docs/users/documents/redact.mdx
@@ -1,0 +1,151 @@
+---
+title: Redact
+description: Permanently remove sensitive content from a PDF before sending it for signing.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+## Overview
+
+Redaction lets you mark regions of a PDF to be permanently removed before the document is distributed to recipients. Unlike drawing a black rectangle on top of content — which leaves the underlying text in the file and recoverable by any PDF parser — Documenso performs **true redaction**: the entire affected page is rasterized and the redaction regions are painted solid black into the pixels. The original text, annotations, and form data on that page are no longer in the PDF in any form.
+
+Redactions are applied exactly once, at the moment you send the document. Before that, they're editable and reversible. After that, they're permanent.
+
+<Callout type="warn">
+  Redaction is a one-way operation. Once you send a document with redactions, the original content is
+  destroyed and cannot be recovered — not by you, not by support, not by re-downloading. Review
+  carefully before sending.
+</Callout>
+
+## Add a Redaction
+
+{/* prettier-ignore */}
+<Steps>
+<Step>
+### Open the document in the editor
+
+Upload your PDF and proceed to the **Add Fields** step as you would for any document.
+
+</Step>
+
+<Step>
+### Click the Redact button
+
+Scroll the sidebar below the field palette to find the **Redact** section. Click the **Redact** button — the cursor becomes a small black preview rectangle that follows your mouse over the document.
+
+</Step>
+
+<Step>
+### Click to place
+
+Click anywhere on the document to drop a redaction at that position. The redaction appears as a solid black rectangle labelled "REDACTED".
+
+</Step>
+
+<Step>
+### Adjust size and position
+
+Click the redaction to select it. Drag the rectangle to reposition, or drag the corner handles to resize so it fully covers the content you want removed.
+
+</Step>
+</Steps>
+
+<Callout type="info">
+  You can place as many redactions as you need, across any pages of any document in the envelope.
+  Redactions are saved automatically as you place, move, and resize them.
+</Callout>
+
+## Move, Resize, and Delete
+
+<Tabs items={['Move', 'Resize', 'Delete']}>
+<Tab value="Move">
+
+Click a placed redaction to select it, then drag it to a new position. Redactions cannot be dragged outside the page bounds.
+
+</Tab>
+<Tab value="Resize">
+
+Click to select the redaction, then drag any of the corner handles. Make the rectangle large enough to fully cover the content you want removed — pixels just outside the edge are still visible in the final PDF.
+
+</Tab>
+<Tab value="Delete">
+
+Click the redaction to select it, then click the trash button that appears below it. Deletion is immediate and only applies while the document is still a draft.
+
+</Tab>
+</Tabs>
+
+## What Gets Removed
+
+When you send the document, Documenso applies redactions by rasterizing every affected page and baking the black rectangles into the image. As a side effect of this approach:
+
+- **Text operators on redacted pages are removed.** Text cannot be selected, copied, or extracted by any tool (`pdftotext`, search-in-viewer, screen readers, AI extraction).
+- **The entire page becomes an image.** Unredacted regions of a redacted page are also converted to pixels — they lose vector fidelity and are no longer searchable.
+- **Pages without redactions are untouched.** Their text stays selectable and the file stays small.
+- **Form fields, annotations, and layers on redacted pages are flattened before redaction**, so form values that could have contained the redacted text are erased along with everything else.
+- **Document metadata is stripped.** Title, Author, Subject, Keywords, Creator, Producer, embedded file attachments, and any JavaScript triggers are removed from the output regardless of which pages were redacted.
+- **The stored original is overwritten.** Both `data` and `initialData` on the document are replaced with the redacted version, so even an administrative reseal operation cannot resurrect the unredacted original.
+
+<Callout type="info">
+  Because the entire redacted page is rasterized, file size grows for affected pages. For most
+  documents this is negligible, but heavy documents with many redacted pages may see a noticeable
+  increase.
+</Callout>
+
+## When Redactions Are Applied
+
+Redactions are applied during the DRAFT → PENDING transition — that is, the moment you click **Send**. The sequence is:
+
+{/* prettier-ignore */}
+<Steps>
+<Step>
+### You click Send
+
+The document's status is still `DRAFT`. Recipients have not yet been notified.
+
+</Step>
+
+<Step>
+### Redactions are baked in
+
+For every page that has one or more redactions, Documenso renders the page, paints the redaction regions as solid black, and replaces the page in the PDF. Document metadata is stripped.
+
+</Step>
+
+<Step>
+### Document data is overwritten
+
+The redacted PDF replaces both the current and the original stored copies. The in-progress redaction markers are deleted because they've been fulfilled.
+
+</Step>
+
+<Step>
+### Recipients are notified
+
+Only now are signing invitations sent. The recipients receive the redacted PDF — they never have access to the unredacted version.
+
+</Step>
+</Steps>
+
+## Best Practices
+
+- **Redact generously.** Leave a small margin around sensitive content. If text clips the edge of a redaction box by even a pixel, it may remain legible in the rasterized output.
+- **Verify before sending.** Placed redactions are editable up until you click Send. Use the editor preview to confirm each redaction covers what you expect.
+- **Verify after sending.** Download the distributed PDF from your envelope list and check that the redactions landed correctly — try selecting text on redacted pages (you shouldn't be able to) and search for redacted terms in the file.
+- **Keep your working copy.** If you need the unredacted original for your own records, save a copy before uploading — Documenso deliberately destroys the original as part of the guarantee that recipients never see it.
+
+## Limitations
+
+- **Documents only.** Redactions are not available on templates in this release.
+- **No reversal.** Once sent, redactions are permanent. There is no un-redact path.
+- **Entire page rasterized.** Redactions cause the whole page to become an image, not just the marked rectangles.
+- **One appearance.** Redaction rectangles are always solid black with a "REDACTED" label. Color, reason codes, and per-recipient redactions are not configurable in this release.
+
+---
+
+## See Also
+
+- [Add Fields](/docs/users/documents/add-fields) — place signature and data-entry fields for recipients
+- [Send Documents](/docs/users/documents/send) — send the document and trigger redaction

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
@@ -8,6 +8,7 @@ import type { Transformer } from 'konva/lib/shapes/Transformer';
 import { CopyPlusIcon, SquareStackIcon, TrashIcon, UserCircleIcon } from 'lucide-react';
 
 import type { TLocalField } from '@documenso/lib/client-only/hooks/use-editor-fields';
+import type { TLocalRedaction } from '@documenso/lib/client-only/hooks/use-editor-redactions';
 import { usePageRenderer } from '@documenso/lib/client-only/hooks/use-page-renderer';
 import { useCurrentEnvelopeEditor } from '@documenso/lib/client-only/providers/envelope-editor-provider';
 import {
@@ -30,7 +31,8 @@ import { EnvelopeRecipientSelectorCommand } from './envelope-recipient-selector'
 
 export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageRenderData }) => {
   const { t, i18n } = useLingui();
-  const { envelope, editorFields, getRecipientColorKey } = useCurrentEnvelopeEditor();
+  const { envelope, editorFields, editorRedactions, getRecipientColorKey } =
+    useCurrentEnvelopeEditor();
   const { currentEnvelopeItem, setRenderError } = useCurrentEnvelopeRender();
 
   const interactiveTransformer = useRef<Transformer | null>(null);
@@ -53,6 +55,14 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
         (field) => field.page === pageNumber && field.envelopeItemId === currentEnvelopeItem?.id,
       ),
     [editorFields.localFields, pageNumber, currentEnvelopeItem?.id],
+  );
+
+  const localPageRedactions = useMemo(
+    () =>
+      editorRedactions.localRedactions.filter(
+        (r) => r.page === pageNumber && r.envelopeItemId === currentEnvelopeItem?.id,
+      ),
+    [editorRedactions.localRedactions, pageNumber, currentEnvelopeItem?.id],
   );
 
   const handleResizeOrMove = (event: KonvaEventObject<Event>) => {
@@ -161,6 +171,81 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     }
   };
 
+  const renderRedactionOnLayer = (redaction: TLocalRedaction) => {
+    if (!pageLayer.current) {
+      return;
+    }
+
+    const pageWidth = scaledViewport.width;
+    const pageHeight = scaledViewport.height;
+
+    const x = (redaction.positionX / 100) * pageWidth;
+    const y = (redaction.positionY / 100) * pageHeight;
+    const width = (redaction.width / 100) * pageWidth;
+    const height = (redaction.height / 100) * pageHeight;
+
+    const group = new Konva.Group({
+      id: redaction.formId,
+      name: 'redaction-group',
+      x,
+      y,
+      listening: true,
+    });
+
+    const rect = new Konva.Rect({
+      x: 0,
+      y: 0,
+      width,
+      height,
+      fill: '#000000',
+      opacity: 1,
+      stroke: 'transparent',
+      strokeWidth: 2,
+    });
+
+    const label = new Konva.Text({
+      x: 0,
+      y: 0,
+      width,
+      height,
+      text: 'REDACTED',
+      fontSize: Math.max(8, Math.min(12, height * 0.5)),
+      fontFamily: 'sans-serif',
+      fontStyle: 'bold',
+      fill: '#ffffff',
+      align: 'center',
+      verticalAlign: 'middle',
+      listening: false,
+    });
+
+    group.add(rect);
+    group.add(label);
+
+    group.on('mouseenter', () => {
+      rect.stroke('#ef4444');
+      pageLayer.current?.batchDraw();
+      const container = pageLayer.current?.getStage()?.container();
+      if (container) {
+        container.style.cursor = 'pointer';
+      }
+    });
+
+    group.on('mouseleave', () => {
+      rect.stroke('transparent');
+      pageLayer.current?.batchDraw();
+      const container = pageLayer.current?.getStage()?.container();
+      if (container) {
+        container.style.cursor = 'default';
+      }
+    });
+
+    group.on('click', () => {
+      editorRedactions.removeRedactionsByFormId([redaction.formId]);
+    });
+
+    pageLayer.current.add(group);
+  };
+
   /**
    * Initialize the Konva page canvas and all fields and interactions.
    */
@@ -174,6 +259,11 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     // Render the fields.
     for (const field of localPageFields) {
       renderFieldOnLayer(field);
+    }
+
+    // Render the redactions.
+    for (const redaction of localPageRedactions) {
+      renderRedactionOnLayer(redaction);
     }
 
     // Handle stage click to deselect.
@@ -442,6 +532,39 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
 
     pageLayer.current.batchDraw();
   }, [localPageFields, selectedKonvaFieldGroups]);
+
+  /**
+   * Render redactions when they are added or removed from localRedactions.
+   */
+  useEffect(() => {
+    if (!pageLayer.current || !stage.current) {
+      return;
+    }
+
+    // Destroy redaction groups that no longer exist in localPageRedactions.
+    pageLayer.current.find('Group').forEach((group) => {
+      if (
+        group.name() === 'redaction-group' &&
+        !localPageRedactions.some((r) => r.formId === group.id())
+      ) {
+        group.destroy();
+      }
+    });
+
+    // Render new redactions.
+    localPageRedactions.forEach((redaction) => {
+      const existing = pageLayer.current
+        ?.find('Group')
+        .find(
+          (group) => group.name() === 'redaction-group' && group.id() === redaction.formId,
+        );
+      if (!existing) {
+        renderRedactionOnLayer(redaction);
+      }
+    });
+
+    pageLayer.current.batchDraw();
+  }, [localPageRedactions]);
 
   const setSelectedFields = (nodes: Konva.Node[]) => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import type { FieldType } from '@prisma/client';
+import { DocumentStatus, type FieldType } from '@prisma/client';
 import Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
 import type { Transformer } from 'konva/lib/shapes/Transformer';
@@ -36,10 +36,15 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
   const { currentEnvelopeItem, setRenderError } = useCurrentEnvelopeRender();
 
   const interactiveTransformer = useRef<Transformer | null>(null);
+  const redactionTransformer = useRef<Transformer | null>(null);
 
   const [selectedKonvaFieldGroups, setSelectedKonvaFieldGroups] = useState<Konva.Group[]>([]);
+  const [selectedKonvaRedactionGroups, setSelectedKonvaRedactionGroups] = useState<Konva.Group[]>(
+    [],
+  );
 
   const [isFieldChanging, setIsFieldChanging] = useState(false);
+  const [isRedactionChanging, setIsRedactionChanging] = useState(false);
   const [pendingFieldCreation, setPendingFieldCreation] = useState<Konva.Rect | null>(null);
 
   const { stage, pageLayer, konvaContainer, scaledViewport, unscaledViewport } = usePageRenderer(
@@ -154,6 +159,7 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     // Set up field selection.
     fieldGroup.on('click', () => {
       removePendingField();
+      setSelectedRedactions([]);
       setSelectedFields([fieldGroup]);
       pageLayer.current?.batchDraw();
     });
@@ -169,6 +175,52 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
       console.error(err);
       setRenderError(true);
     }
+  };
+
+  const handleRedactionResizeOrMove = (event: KonvaEventObject<Event>) => {
+    const isDragEvent = event.type === 'dragend';
+
+    const group = event.target as Konva.Group;
+    const formId = group.id();
+
+    // Note: getClientRect returns POST-transform (scaled) pixels.
+    const {
+      width: scaledPixelWidth,
+      height: scaledPixelHeight,
+      x: scaledX,
+      y: scaledY,
+    } = group.getClientRect({
+      skipStroke: true,
+      skipShadow: true,
+    });
+
+    const pageWidth = scaledViewport.width;
+    const pageHeight = scaledViewport.height;
+
+    const positionPercentX = (scaledX / pageWidth) * 100;
+    const positionPercentY = (scaledY / pageHeight) * 100;
+
+    const updates: Partial<TLocalRedaction> = {
+      positionX: positionPercentX,
+      positionY: positionPercentY,
+    };
+
+    // Only update width/height on resize (not on drag). Same rationale as
+    // handleResizeOrMove — percentage/pixel round-tripping would otherwise
+    // nudge the size on every drag.
+    if (!isDragEvent) {
+      updates.width = (scaledPixelWidth / pageWidth) * 100;
+      updates.height = (scaledPixelHeight / pageHeight) * 100;
+    }
+
+    editorRedactions.updateRedactionByFormId(formId, updates);
+
+    // Select on drag-end if nothing was explicitly selected.
+    if (isDragEvent && redactionTransformer.current?.nodes().length === 0) {
+      setSelectedRedactions([group]);
+    }
+
+    pageLayer.current?.batchDraw();
   };
 
   const renderRedactionOnLayer = (redaction: TLocalRedaction) => {
@@ -188,12 +240,26 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     const width = (redaction.width / 100) * pageWidth;
     const height = (redaction.height / 100) * pageHeight;
 
+    const isEditable = envelope.status === DocumentStatus.DRAFT;
+
+    const maxXPosition = pageWidth - width;
+    const maxYPosition = pageHeight - height;
+
     const group = new Konva.Group({
       id: redaction.formId,
       name: 'redaction-group',
       x,
       y,
+      draggable: isEditable,
       listening: true,
+      dragBoundFunc: (pos) => {
+        // Konva calls dragBoundFunc with stage (post-scale) pixel coords.
+        const maxX = maxXPosition * scale;
+        const maxY = maxYPosition * scale;
+        const newX = Math.max(0, Math.min(maxX, pos.x));
+        const newY = Math.max(0, Math.min(maxY, pos.y));
+        return { x: newX, y: newY };
+      },
     });
 
     const rect = new Konva.Rect({
@@ -205,6 +271,7 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
       opacity: 1,
       stroke: 'transparent',
       strokeWidth: 2,
+      strokeScaleEnabled: false,
     });
 
     const label = new Konva.Text({
@@ -225,27 +292,71 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     group.add(rect);
     group.add(label);
 
-    group.on('mouseenter', () => {
-      rect.stroke('#ef4444');
-      pageLayer.current?.batchDraw();
-      const container = pageLayer.current?.getStage()?.container();
-      if (container) {
-        container.style.cursor = 'pointer';
-      }
+    // Keep the label sized to the rect while resizing (so the 'REDACTED'
+    // text doesn't stretch mid-transform) and bake the scale into the rect
+    // on transform-end so subsequent drags start from a clean scale of 1.
+    group.on('transform', () => {
+      const sx = group.scaleX();
+      const sy = group.scaleY();
+
+      label.scaleX(1 / sx);
+      label.scaleY(1 / sy);
+
+      const rectWidth = rect.width() * sx;
+      const rectHeight = rect.height() * sy;
+      label.width(rectWidth);
+      label.height(rectHeight);
+      label.fontSize(Math.max(8, Math.min(12, rectHeight * 0.5)));
     });
 
-    group.on('mouseleave', () => {
-      rect.stroke('transparent');
-      pageLayer.current?.batchDraw();
-      const container = pageLayer.current?.getStage()?.container();
-      if (container) {
-        container.style.cursor = 'default';
-      }
+    group.on('transformend', () => {
+      const sx = group.scaleX();
+      const sy = group.scaleY();
+
+      const newWidth = rect.width() * sx;
+      const newHeight = rect.height() * sy;
+
+      rect.width(newWidth);
+      rect.height(newHeight);
+      label.width(newWidth);
+      label.height(newHeight);
+      label.scaleX(1);
+      label.scaleY(1);
+      label.fontSize(Math.max(8, Math.min(12, newHeight * 0.5)));
+
+      group.scaleX(1);
+      group.scaleY(1);
     });
 
-    group.on('click', () => {
-      editorRedactions.removeRedactionsByFormId([redaction.formId]);
-    });
+    if (isEditable) {
+      group.on('mouseenter', () => {
+        rect.stroke('#ef4444');
+        pageLayer.current?.batchDraw();
+        const container = pageLayer.current?.getStage()?.container();
+        if (container) {
+          container.style.cursor = 'pointer';
+        }
+      });
+
+      group.on('mouseleave', () => {
+        rect.stroke('transparent');
+        pageLayer.current?.batchDraw();
+        const container = pageLayer.current?.getStage()?.container();
+        if (container) {
+          container.style.cursor = 'default';
+        }
+      });
+
+      group.on('click', () => {
+        removePendingField();
+        setSelectedFields([]);
+        setSelectedRedactions([group]);
+        pageLayer.current?.batchDraw();
+      });
+
+      group.on('transformend', handleRedactionResizeOrMove);
+      group.on('dragend', handleRedactionResizeOrMove);
+    }
 
     pageLayer.current.add(group);
   };
@@ -259,6 +370,7 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
 
     // Add transformer for resizing and rotating.
     interactiveTransformer.current = createInteractiveTransformer(currentStage, currentPageLayer);
+    redactionTransformer.current = createRedactionTransformer(currentPageLayer);
 
     // Render the fields.
     for (const field of localPageFields) {
@@ -276,6 +388,7 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
 
       if (e.target === stage.current) {
         setSelectedFields([]);
+        setSelectedRedactions([]);
         currentPageLayer.batchDraw();
       }
     });
@@ -284,31 +397,85 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     const onDragStartOrEnd = (e: KonvaEventObject<Event>) => {
       removePendingField();
 
-      if (!e.target.hasName('field-group')) {
+      if (e.target.hasName('field-group')) {
+        setIsFieldChanging(e.type === 'dragstart');
+
+        const itemAlreadySelected = (interactiveTransformer.current?.nodes() || []).includes(
+          e.target,
+        );
+
+        // Do nothing and allow the transformer to handle it.
+        // Required so when multiple items are selected, this won't deselect them.
+        if (itemAlreadySelected) {
+          return;
+        }
+
+        setSelectedFields([e.target]);
         return;
       }
 
-      setIsFieldChanging(e.type === 'dragstart');
+      if (e.target.hasName('redaction-group')) {
+        setIsRedactionChanging(e.type === 'dragstart');
 
-      const itemAlreadySelected = (interactiveTransformer.current?.nodes() || []).includes(
-        e.target,
-      );
+        const itemAlreadySelected = (redactionTransformer.current?.nodes() || []).includes(
+          e.target,
+        );
 
-      // Do nothing and allow the transformer to handle it.
-      // Required so when multiple items are selected, this won't deselect them.
-      if (itemAlreadySelected) {
-        return;
+        if (itemAlreadySelected) {
+          return;
+        }
+
+        setSelectedRedactions([e.target]);
       }
-
-      setSelectedFields([e.target]);
     };
 
     currentStage.on('dragstart', onDragStartOrEnd);
     currentStage.on('dragend', onDragStartOrEnd);
-    currentStage.on('transformstart', () => setIsFieldChanging(true));
-    currentStage.on('transformend', () => setIsFieldChanging(false));
+    currentStage.on('transformstart', (e) => {
+      if (e.target.hasName('redaction-group')) {
+        setIsRedactionChanging(true);
+      } else {
+        setIsFieldChanging(true);
+      }
+    });
+    currentStage.on('transformend', (e) => {
+      if (e.target.hasName('redaction-group')) {
+        setIsRedactionChanging(false);
+      } else {
+        setIsFieldChanging(false);
+      }
+    });
 
     currentPageLayer.batchDraw();
+  };
+
+  /**
+   * A dedicated transformer for redactions. Separate from the field
+   * transformer so field and redaction selections never mix and so each
+   * transformer can have its own minimum-size and visual styling.
+   */
+  const createRedactionTransformer = (currentPageLayer: Konva.Layer) => {
+    const transformer = new Konva.Transformer({
+      rotateEnabled: false,
+      keepRatio: false,
+      shouldOverdrawWholeArea: true,
+      ignoreStroke: true,
+      flipEnabled: false,
+      borderStroke: '#ef4444',
+      anchorStroke: '#ef4444',
+      anchorFill: '#ffffff',
+      boundBoxFunc: (oldBox, newBox) => {
+        if (newBox.width < 10 || newBox.height < 8) {
+          return oldBox;
+        }
+
+        return newBox;
+      },
+    });
+
+    currentPageLayer.add(transformer);
+
+    return transformer;
   };
 
   /**
@@ -462,6 +629,7 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
       // If empty area clicked, remove all selections
       if (e.target === stage.current) {
         setSelectedFields([]);
+        setSelectedRedactions([]);
         return;
       }
 
@@ -555,18 +723,68 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
       }
     });
 
-    // Render new redactions.
+    // Render new redactions, or sync existing group geometry with the latest
+    // local state so external changes (e.g., sync from the server) are
+    // reflected without leaving the handlers we attached dangling.
     localPageRedactions.forEach((redaction) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const existing = pageLayer.current
         ?.find('Group')
-        .find((group) => group.name() === 'redaction-group' && group.id() === redaction.formId);
+        .find((group) => group.name() === 'redaction-group' && group.id() === redaction.formId) as
+        | Konva.Group
+        | undefined;
+
       if (!existing) {
         renderRedactionOnLayer(redaction);
+        return;
+      }
+
+      const pageWidth = unscaledViewport.width;
+      const pageHeight = unscaledViewport.height;
+
+      const x = (redaction.positionX / 100) * pageWidth;
+      const y = (redaction.positionY / 100) * pageHeight;
+      const width = (redaction.width / 100) * pageWidth;
+      const height = (redaction.height / 100) * pageHeight;
+
+      existing.position({ x, y });
+      existing.scaleX(1);
+      existing.scaleY(1);
+
+      const rect = existing.findOne<Konva.Rect>('Rect');
+      const label = existing.findOne<Konva.Text>('Text');
+
+      if (rect) {
+        rect.width(width);
+        rect.height(height);
+      }
+
+      if (label) {
+        label.width(width);
+        label.height(height);
+        label.scaleX(1);
+        label.scaleY(1);
+        label.fontSize(Math.max(8, Math.min(12, height * 0.5)));
       }
     });
 
+    // Reconcile redaction selection with live nodes.
+    const liveSelectedRedactionGroups = selectedKonvaRedactionGroups.filter((group) => {
+      if (!group.getStage() || !group.getParent()) {
+        return false;
+      }
+
+      return localPageRedactions.some((r) => r.formId === group.id());
+    });
+
+    if (liveSelectedRedactionGroups.length !== selectedKonvaRedactionGroups.length) {
+      setSelectedRedactions(liveSelectedRedactionGroups);
+    }
+
+    redactionTransformer.current?.forceUpdate();
+
     pageLayer.current.batchDraw();
-  }, [localPageRedactions]);
+  }, [localPageRedactions, selectedKonvaRedactionGroups]);
 
   const setSelectedFields = (nodes: Konva.Node[]) => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -599,6 +817,34 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     editorFields.removeFieldsByFormId(fieldFormids);
 
     setSelectedFields([]);
+  };
+
+  const setSelectedRedactions = (nodes: Konva.Node[]) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const redactionGroups = nodes.filter(
+      (node) =>
+        node.hasName('redaction-group') && Boolean(node.getStage()) && Boolean(node.getParent()),
+    ) as Konva.Group[];
+
+    redactionTransformer.current?.nodes(redactionGroups);
+    setSelectedKonvaRedactionGroups(redactionGroups);
+
+    if (redactionGroups.length === 1) {
+      redactionGroups[0].moveToTop();
+      // Keep the transformer above the group we just moved to top so its
+      // handles stay interactive.
+      redactionTransformer.current?.moveToTop();
+    }
+  };
+
+  const deleteSelectedRedactions = () => {
+    const formIds = selectedKonvaRedactionGroups
+      .map((group) => group.id())
+      .filter((id) => id !== undefined);
+
+    editorRedactions.removeRedactionsByFormId(formIds);
+
+    setSelectedRedactions([]);
   };
 
   const changeSelectedFieldsRecipients = (recipientId: number) => {
@@ -710,6 +956,30 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
               left:
                 interactiveTransformer.current.x() +
                 interactiveTransformer.current.getClientRect().width / 2 +
+                'px',
+              transform: 'translateX(-50%)',
+              gap: '8px',
+              pointerEvents: 'auto',
+              zIndex: 50,
+            }}
+          />
+        )}
+
+      {selectedKonvaRedactionGroups.length > 0 &&
+        redactionTransformer.current &&
+        !isRedactionChanging && (
+          <RedactionActionButtons
+            handleDeleteSelectedRedactions={deleteSelectedRedactions}
+            style={{
+              position: 'absolute',
+              top:
+                redactionTransformer.current.y() +
+                redactionTransformer.current.getClientRect().height +
+                5 +
+                'px',
+              left:
+                redactionTransformer.current.x() +
+                redactionTransformer.current.getClientRect().width / 2 +
                 'px',
               transform: 'translateX(-50%)',
               gap: '8px',
@@ -872,6 +1142,32 @@ const FieldActionButtons = ({
           fields={envelope.fields}
         />
       </CommandDialog>
+    </div>
+  );
+};
+
+type RedactionActionButtonsProps = React.HTMLAttributes<HTMLDivElement> & {
+  handleDeleteSelectedRedactions: () => void;
+};
+
+const RedactionActionButtons = ({
+  handleDeleteSelectedRedactions,
+  ...props
+}: RedactionActionButtonsProps) => {
+  const { t } = useLingui();
+
+  return (
+    <div className="flex flex-col items-center" {...props}>
+      <div className="group flex w-fit items-center justify-evenly gap-x-1 rounded-md border bg-gray-900 p-0.5">
+        <button
+          title={t`Remove`}
+          className="rounded-sm p-1.5 text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-100"
+          onClick={handleDeleteSelectedRedactions}
+          onTouchEnd={handleDeleteSelectedRedactions}
+        >
+          <TrashIcon className="h-3 w-3" />
+        </button>
+      </div>
     </div>
   );
 };

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
@@ -176,8 +176,12 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
       return;
     }
 
-    const pageWidth = scaledViewport.width;
-    const pageHeight = scaledViewport.height;
+    // Position/size are stored as percentages of the PDF page. The Konva
+    // stage itself has a scale transform applied (see usePageRenderer), so
+    // we must place the group using the UNSCALED viewport — otherwise the
+    // placement gets double-scaled and drifts away from the click point.
+    const pageWidth = unscaledViewport.width;
+    const pageHeight = unscaledViewport.height;
 
     const x = (redaction.positionX / 100) * pageWidth;
     const y = (redaction.positionY / 100) * pageHeight;
@@ -555,9 +559,7 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
     localPageRedactions.forEach((redaction) => {
       const existing = pageLayer.current
         ?.find('Group')
-        .find(
-          (group) => group.name() === 'redaction-group' && group.id() === redaction.formId,
-        );
+        .find((group) => group.name() === 'redaction-group' && group.id() === redaction.formId);
       if (!existing) {
         renderRedactionOnLayer(redaction);
       }

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page.tsx
@@ -54,6 +54,7 @@ import { useCurrentTeam } from '~/providers/team';
 
 import { EnvelopeEditorFieldDragDrop } from './envelope-editor-fields-drag-drop';
 import { EnvelopeEditorFieldsPageRenderer } from './envelope-editor-fields-page-renderer';
+import { EnvelopeEditorRedactionDragDrop } from './envelope-editor-redaction-drag-drop';
 import { EnvelopeRendererFileSelector } from './envelope-file-selector';
 import { EnvelopeRecipientSelector } from './envelope-recipient-selector';
 
@@ -284,6 +285,14 @@ export const EnvelopeEditorFieldsPage = () => {
 
             <EnvelopeEditorFieldDragDrop
               selectedRecipientId={editorFields.selectedRecipient?.id ?? null}
+              selectedEnvelopeItemId={currentEnvelopeItem?.id ?? null}
+            />
+
+            <h3 className="mb-2 mt-6 text-sm font-semibold text-foreground">
+              <Trans>Redact</Trans>
+            </h3>
+
+            <EnvelopeEditorRedactionDragDrop
               selectedEnvelopeItemId={currentEnvelopeItem?.id ?? null}
             />
 

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-redaction-drag-drop.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-redaction-drag-drop.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Trans } from '@lingui/react/macro';
+import { DocumentStatus } from '@prisma/client';
+import { EyeOffIcon } from 'lucide-react';
+
+import { getBoundingClientRect } from '@documenso/lib/client-only/get-bounding-client-rect';
+import { useDocumentElement } from '@documenso/lib/client-only/hooks/use-document-element';
+import { useCurrentEnvelopeEditor } from '@documenso/lib/client-only/providers/envelope-editor-provider';
+import { PDF_VIEWER_PAGE_SELECTOR } from '@documenso/lib/constants/pdf-viewer';
+import { cn } from '@documenso/ui/lib/utils';
+
+const DEFAULT_WIDTH_PX = 60;
+const DEFAULT_HEIGHT_PX = 20;
+
+type Props = {
+  selectedEnvelopeItemId: string | null;
+};
+
+export const EnvelopeEditorRedactionDragDrop = ({ selectedEnvelopeItemId }: Props) => {
+  const { envelope, editorRedactions } = useCurrentEnvelopeEditor();
+  const { isWithinPageBounds, getPage } = useDocumentElement();
+
+  const isDisabled = envelope.status !== DocumentStatus.DRAFT;
+
+  const [isActive, setIsActive] = useState(false);
+  const [isWithinBounds, setIsWithinBounds] = useState(false);
+  const [coords, setCoords] = useState({ x: 0, y: 0 });
+  const bounds = useRef({ width: DEFAULT_WIDTH_PX, height: DEFAULT_HEIGHT_PX });
+
+  const onMouseMove = useCallback(
+    (event: MouseEvent) => {
+      setIsWithinBounds(
+        isWithinPageBounds(
+          event,
+          PDF_VIEWER_PAGE_SELECTOR,
+          bounds.current.width,
+          bounds.current.height,
+        ),
+      );
+      setCoords({
+        x: event.clientX - bounds.current.width / 2,
+        y: event.clientY - bounds.current.height / 2,
+      });
+    },
+    [isWithinPageBounds],
+  );
+
+  const onMouseClick = useCallback(
+    (event: MouseEvent) => {
+      if (!isActive || !selectedEnvelopeItemId) {
+        return;
+      }
+
+      const $page = getPage(event, PDF_VIEWER_PAGE_SELECTOR);
+
+      if (
+        !$page ||
+        !isWithinPageBounds(
+          event,
+          PDF_VIEWER_PAGE_SELECTOR,
+          bounds.current.width,
+          bounds.current.height,
+        )
+      ) {
+        setIsActive(false);
+        return;
+      }
+
+      const { top, left, height, width } = getBoundingClientRect($page);
+      const pageNumber = parseInt($page.getAttribute('data-page-number') ?? '1', 10);
+
+      let pageX = ((event.pageX - left) / width) * 100;
+      let pageY = ((event.pageY - top) / height) * 100;
+
+      const redactionPageWidth = (bounds.current.width / width) * 100;
+      const redactionPageHeight = (bounds.current.height / height) * 100;
+
+      pageX -= redactionPageWidth / 2;
+      pageY -= redactionPageHeight / 2;
+
+      editorRedactions.addRedaction({
+        envelopeItemId: selectedEnvelopeItemId,
+        page: pageNumber,
+        positionX: pageX,
+        positionY: pageY,
+        width: redactionPageWidth,
+        height: redactionPageHeight,
+      });
+
+      setIsWithinBounds(false);
+      setIsActive(false);
+    },
+    [isActive, selectedEnvelopeItemId, getPage, isWithinPageBounds, editorRedactions],
+  );
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseClick);
+
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseClick);
+    };
+  }, [isActive, onMouseMove, onMouseClick]);
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={isDisabled}
+        onClick={() => setIsActive(true)}
+        onMouseDown={() => setIsActive(true)}
+        data-selected={isActive ? true : undefined}
+        className={cn(
+          'group flex h-12 w-full cursor-pointer items-center justify-center gap-x-1.5 rounded-lg border border-border px-4 transition-colors',
+          'data-[selected=true]:border-foreground data-[selected=true]:bg-foreground data-[selected=true]:text-background',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+        )}
+      >
+        <EyeOffIcon className="h-4 w-4" />
+        <span className="font-noto text-sm font-normal">
+          <Trans>Redact</Trans>
+        </span>
+      </button>
+
+      {isActive && (
+        <div
+          className={cn(
+            'pointer-events-none fixed z-50 flex items-center justify-center rounded-sm bg-black text-white transition duration-200',
+            {
+              '-rotate-6 scale-90 opacity-50': !isWithinBounds,
+            },
+          )}
+          style={{
+            top: coords.y,
+            left: coords.x,
+            width: bounds.current.width,
+            height: bounds.current.height,
+          }}
+        >
+          <span className="text-[10px] font-medium tracking-wider">
+            <Trans>REDACTED</Trans>
+          </span>
+        </div>
+      )}
+    </>
+  );
+};

--- a/apps/remix/app/routes/embed+/v2+/authoring+/envelope.create._index.tsx
+++ b/apps/remix/app/routes/embed+/v2+/authoring+/envelope.create._index.tsx
@@ -365,6 +365,7 @@ const EnvelopeCreatePage = ({ embedAuthoringOptions }: EnvelopeCreatePageProps) 
       },
       recipients,
       fields: [],
+      redactions: [],
       envelopeItems: [],
       directLink: null,
       team: {

--- a/packages/app-tests/e2e/envelopes/redaction.spec.ts
+++ b/packages/app-tests/e2e/envelopes/redaction.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '@playwright/test';
+import { DocumentStatus, FieldType } from '@prisma/client';
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+
+import { getFileServerSide } from '@documenso/lib/universal/upload/get-file.server';
+import { prisma } from '@documenso/prisma';
+
+import { apiDistributeEnvelope, apiSeedDraftDocument } from '../fixtures/api-seeds';
+
+// Text lifted directly from `assets/example.pdf` page 1 (see Step 0 of the
+// redaction test plan). KNOWN_TOP_TEXT sits at y~663 (near the top of the
+// page, where we place the redaction). KNOWN_BOTTOM_TEXT sits at y~240,
+// which rasterize-replace also erases because it redraws the entire page.
+const KNOWN_TOP_TEXT = 'OPEN SOURCE PRINCIPLES WAIVER';
+const KNOWN_BOTTOM_TEXT = 'Signature';
+
+test.describe('redaction pipeline', () => {
+  test('sender-placed redaction truly removes text from the distributed PDF', async ({
+    request,
+  }) => {
+    test.setTimeout(120_000);
+
+    // 1. Create a draft envelope with example.pdf attached, one SIGNER recipient,
+    //    and one required SIGNATURE field. apiSeedDraftDocument uploads the real
+    //    example.pdf via the API so the envelope item's DocumentData has the raw
+    //    bytes we expect.
+    const { envelope, token } = await apiSeedDraftDocument(request, {
+      title: '[TEST] Redaction Round-Trip',
+      recipients: [
+        {
+          email: `signer-redaction-${Date.now()}@test.documenso.com`,
+          name: 'Redaction Signer',
+          role: 'SIGNER',
+        },
+      ],
+      fieldsPerRecipient: [
+        [
+          {
+            type: FieldType.SIGNATURE,
+            page: 1,
+            positionX: 50,
+            positionY: 80,
+            width: 20,
+            height: 10,
+          },
+        ],
+      ],
+    });
+
+    expect(envelope.envelopeItems.length).toBeGreaterThan(0);
+    const envelopeItemId = envelope.envelopeItems[0].id;
+
+    // Sanity check: the freshly uploaded PDF still contains the known text.
+    // This guards against a future change to example.pdf that would make the
+    // test's "absent after redaction" assertion vacuously true.
+    const originalEnvelopeItem = await prisma.envelopeItem.findUniqueOrThrow({
+      where: { id: envelopeItemId },
+      include: { documentData: true },
+    });
+    const originalBytes = await getFileServerSide(originalEnvelopeItem.documentData);
+    const originalText = await extractPage1Text(originalBytes);
+    expect(originalText).toContain(KNOWN_TOP_TEXT);
+    expect(originalText).toContain(KNOWN_BOTTOM_TEXT);
+
+    // 2. Insert a redaction row directly via Prisma. positionX/positionY/width/height
+    //    are percentages of the page. Cover the top 15% of the page where
+    //    KNOWN_TOP_TEXT lives.
+    await prisma.redaction.create({
+      data: {
+        envelopeId: envelope.id,
+        envelopeItemId: envelopeItemId,
+        page: 1,
+        positionX: 5,
+        positionY: 5,
+        width: 90,
+        height: 15,
+      },
+    });
+
+    // 3. Distribute the envelope via the V2 API. This triggers the same
+    //    sendDocument path a real user's "Send" click would, including the
+    //    applyRedactionsToDocument pipeline.
+    await apiDistributeEnvelope(request, token, envelope.id);
+
+    // 4. Poll until the envelope reaches PENDING and the redaction rows are
+    //    gone (sendDocument deletes them after baking them into the PDF).
+    //    This is proof that the pipeline ran to completion.
+    await expect
+      .poll(
+        async () => {
+          const dbEnvelope = await prisma.envelope.findUniqueOrThrow({
+            where: { id: envelope.id },
+            include: { redactions: true },
+          });
+          return {
+            status: dbEnvelope.status,
+            redactionCount: dbEnvelope.redactions.length,
+          };
+        },
+        { timeout: 60_000, intervals: [500, 1000, 2000] },
+      )
+      .toEqual({ status: DocumentStatus.PENDING, redactionCount: 0 });
+
+    // 5. Read the current DocumentData for the envelope item and extract
+    //    page 1 text from the distributed PDF bytes.
+    const bakedEnvelopeItem = await prisma.envelopeItem.findUniqueOrThrow({
+      where: { id: envelopeItemId },
+      include: { documentData: true },
+    });
+
+    const pdfBytes = await getFileServerSide(bakedEnvelopeItem.documentData);
+    const text = await extractPage1Text(pdfBytes);
+
+    // 6. Security-critical assertions: the known text MUST be absent from
+    //    the distributed PDF. This is the whole point of true redaction —
+    //    not just an opaque overlay, but the underlying text stream
+    //    actually rewritten so copy/paste and text extraction return
+    //    nothing for the redacted region (and, for rasterize-replace, the
+    //    entire page's text stream).
+    expect(text).not.toContain(KNOWN_TOP_TEXT);
+    expect(text).not.toContain(KNOWN_BOTTOM_TEXT);
+  });
+});
+
+const extractPage1Text = async (pdfBytes: Uint8Array): Promise<string> => {
+  const pdf = await pdfjsLib.getDocument({ data: new Uint8Array(pdfBytes) }).promise;
+
+  try {
+    const page = await pdf.getPage(1);
+    const content = await page.getTextContent();
+    return content.items.map((item) => ('str' in item ? item.str : '')).join(' ');
+  } finally {
+    await pdf.destroy();
+  }
+};

--- a/packages/lib/client-only/hooks/use-editor-redactions.ts
+++ b/packages/lib/client-only/hooks/use-editor-redactions.ts
@@ -127,11 +127,17 @@ export const useEditorRedactions = ({
 
   const updateRedactionByFormId = useCallback(
     (formId: string, updates: Partial<TLocalRedaction>) => {
-      const index = localRedactions.findIndex((redaction) => redaction.formId === formId);
+      // Read the base record from the live form state, not from the
+      // closed-over `localRedactions` array. Two updates fired before React
+      // commits the re-render between them (e.g. resize immediately followed
+      // by a drag) would otherwise see a stale base and silently revert the
+      // first update's fields.
+      const currentRedactions = form.getValues().redactions;
+      const index = currentRedactions.findIndex((redaction) => redaction.formId === formId);
 
       if (index !== -1) {
         const updatedRedaction = {
-          ...localRedactions[index],
+          ...currentRedactions[index],
           ...updates,
         };
 
@@ -139,7 +145,7 @@ export const useEditorRedactions = ({
         triggerRedactionsUpdate();
       }
     },
-    [localRedactions, update, triggerRedactionsUpdate],
+    [form, update, triggerRedactionsUpdate],
   );
 
   const setRedactionIdByFormId = useCallback(

--- a/packages/lib/client-only/hooks/use-editor-redactions.ts
+++ b/packages/lib/client-only/hooks/use-editor-redactions.ts
@@ -42,6 +42,15 @@ type UseEditorRedactionsResponse = {
   removeRedactionsByFormId: (formIds: string[]) => void;
   updateRedactionByFormId: (formId: string, updates: Partial<TLocalRedaction>) => void;
 
+  /**
+   * Attaches a server-generated id to the local row for `formId` WITHOUT
+   * firing `handleRedactionsUpdate`. This is the path the provider uses after
+   * a successful create so the id arrives in local state without re-entering
+   * the sync handler (which would try to re-diff mid-flight and can race
+   * against pending state commits).
+   */
+  setRedactionIdByFormId: (formId: string, id: number) => void;
+
   resetForm: (redactions?: TEnvelopeRedaction[]) => void;
 };
 
@@ -133,6 +142,27 @@ export const useEditorRedactions = ({
     [localRedactions, update, triggerRedactionsUpdate],
   );
 
+  const setRedactionIdByFormId = useCallback(
+    (formId: string, id: number) => {
+      const index = localRedactions.findIndex((redaction) => redaction.formId === formId);
+
+      if (index === -1) {
+        return;
+      }
+
+      // `setValue` on a specific path does NOT trigger the field-array's
+      // change signal the way `update` does. This is deliberate: attaching a
+      // server id is bookkeeping, not a user edit, and should not re-enter
+      // `handleRedactionsUpdate`.
+      form.setValue(`redactions.${index}.id`, id, {
+        shouldDirty: false,
+        shouldTouch: false,
+        shouldValidate: false,
+      });
+    },
+    [localRedactions, form],
+  );
+
   const resetForm = (redactions?: TEnvelopeRedaction[]) => {
     form.reset(generateDefaultValues(redactions));
   };
@@ -143,8 +173,16 @@ export const useEditorRedactions = ({
       addRedaction,
       removeRedactionsByFormId,
       updateRedactionByFormId,
+      setRedactionIdByFormId,
       resetForm,
     }),
-    [localRedactions, addRedaction, removeRedactionsByFormId, updateRedactionByFormId, resetForm],
+    [
+      localRedactions,
+      addRedaction,
+      removeRedactionsByFormId,
+      updateRedactionByFormId,
+      setRedactionIdByFormId,
+      resetForm,
+    ],
   );
 };

--- a/packages/lib/client-only/hooks/use-editor-redactions.ts
+++ b/packages/lib/client-only/hooks/use-editor-redactions.ts
@@ -1,0 +1,150 @@
+import { useCallback, useMemo } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import type { TEnvelopeRedaction } from '@documenso/lib/types/envelope-editor';
+import { nanoid } from '@documenso/lib/universal/id';
+
+export const ZLocalRedactionSchema = z.object({
+  // This is the actual ID of the redaction if created.
+  id: z.number().optional(),
+  // This is the local client side ID of the redaction.
+  formId: z.string().min(1),
+  // This is the ID of the envelope item to put the redaction on.
+  envelopeItemId: z.string(),
+  page: z.number().min(1),
+  positionX: z.number().min(0),
+  positionY: z.number().min(0),
+  width: z.number().min(0),
+  height: z.number().min(0),
+});
+
+export type TLocalRedaction = z.infer<typeof ZLocalRedactionSchema>;
+
+const ZEditorRedactionsFormSchema = z.object({
+  redactions: z.array(ZLocalRedactionSchema),
+});
+
+export type TEditorRedactionsFormSchema = z.infer<typeof ZEditorRedactionsFormSchema>;
+
+type EditorRedactionsProps = {
+  initialRedactions: TEnvelopeRedaction[];
+  handleRedactionsUpdate: (redactions: TLocalRedaction[]) => unknown;
+};
+
+type UseEditorRedactionsResponse = {
+  localRedactions: TLocalRedaction[];
+
+  // Redaction operations
+  addRedaction: (redaction: Omit<TLocalRedaction, 'formId'>) => TLocalRedaction;
+  removeRedactionsByFormId: (formIds: string[]) => void;
+  updateRedactionByFormId: (formId: string, updates: Partial<TLocalRedaction>) => void;
+
+  resetForm: (redactions?: TEnvelopeRedaction[]) => void;
+};
+
+export const useEditorRedactions = ({
+  initialRedactions,
+  handleRedactionsUpdate,
+}: EditorRedactionsProps): UseEditorRedactionsResponse => {
+  const generateDefaultValues = (redactions?: TEnvelopeRedaction[]) => {
+    const formRedactions = (redactions || initialRedactions).map(
+      (redaction): TLocalRedaction => ({
+        id: redaction.id,
+        formId: nanoid(12),
+        envelopeItemId: redaction.envelopeItemId,
+        page: redaction.page,
+        positionX: Number(redaction.positionX),
+        positionY: Number(redaction.positionY),
+        width: Number(redaction.width),
+        height: Number(redaction.height),
+      }),
+    );
+
+    return {
+      redactions: formRedactions,
+    };
+  };
+
+  const form = useForm<TEditorRedactionsFormSchema>({
+    defaultValues: generateDefaultValues(),
+    resolver: zodResolver(ZEditorRedactionsFormSchema),
+  });
+
+  const {
+    append,
+    remove,
+    update,
+    fields: localRedactions,
+  } = useFieldArray({
+    control: form.control,
+    name: 'redactions',
+    keyName: 'react-hook-form-id',
+  });
+
+  const triggerRedactionsUpdate = () => {
+    void handleRedactionsUpdate(form.getValues().redactions);
+  };
+
+  const addRedaction = useCallback(
+    (redactionData: Omit<TLocalRedaction, 'formId'>): TLocalRedaction => {
+      const redaction: TLocalRedaction = {
+        ...redactionData,
+        formId: nanoid(12),
+      };
+
+      append(redaction);
+      triggerRedactionsUpdate();
+      return redaction;
+    },
+    [append, triggerRedactionsUpdate],
+  );
+
+  const removeRedactionsByFormId = useCallback(
+    (formIds: string[]) => {
+      const indexes = formIds
+        .map((formId) => localRedactions.findIndex((redaction) => redaction.formId === formId))
+        .filter((index) => index !== -1);
+
+      if (indexes.length > 0) {
+        remove(indexes);
+        triggerRedactionsUpdate();
+      }
+    },
+    [localRedactions, remove, triggerRedactionsUpdate],
+  );
+
+  const updateRedactionByFormId = useCallback(
+    (formId: string, updates: Partial<TLocalRedaction>) => {
+      const index = localRedactions.findIndex((redaction) => redaction.formId === formId);
+
+      if (index !== -1) {
+        const updatedRedaction = {
+          ...localRedactions[index],
+          ...updates,
+        };
+
+        update(index, updatedRedaction);
+        triggerRedactionsUpdate();
+      }
+    },
+    [localRedactions, update, triggerRedactionsUpdate],
+  );
+
+  const resetForm = (redactions?: TEnvelopeRedaction[]) => {
+    form.reset(generateDefaultValues(redactions));
+  };
+
+  return useMemo(
+    () => ({
+      localRedactions,
+      addRedaction,
+      removeRedactionsByFormId,
+      updateRedactionByFormId,
+      resetForm,
+    }),
+    [localRedactions, addRedaction, removeRedactionsByFormId, updateRedactionByFormId, resetForm],
+  );
+};

--- a/packages/lib/client-only/providers/envelope-editor-provider.tsx
+++ b/packages/lib/client-only/providers/envelope-editor-provider.tsx
@@ -153,6 +153,7 @@ export const EnvelopeEditorProvider = ({
   const updateEnvelopeMutation = trpc.envelope.update.useMutation();
 
   const createRedactionsMutation = trpc.redaction.createDocumentRedactions.useMutation();
+  const updateRedactionsMutation = trpc.redaction.updateDocumentRedactions.useMutation();
   const deleteRedactionMutation = trpc.redaction.deleteDocumentRedaction.useMutation();
 
   // Ref used to break the circular dependency between `handleRedactionsUpdate`
@@ -172,10 +173,28 @@ export const EnvelopeEditorProvider = ({
 
       const toCreate = next.filter((r) => r.id === undefined);
 
-      const nextIds = new Set(
-        next.filter((r) => r.id !== undefined).map((r) => r.id as number),
-      );
+      const nextIds = new Set(next.filter((r) => r.id !== undefined).map((r) => r.id as number));
       const toDelete = persisted.filter((p) => !nextIds.has(p.id)).map((p) => p.id);
+
+      // Diff for geometry changes on rows that already exist on the server.
+      // Redaction update calls fire from drag-end / transform-end (see
+      // use-editor-redactions.ts), so one mutation per user action is fine —
+      // no debouncing required here.
+      const EPSILON = 0.0001;
+      const hasChanged = (a: (typeof persisted)[number], b: TLocalRedaction) =>
+        a.page !== b.page ||
+        Math.abs(Number(a.positionX) - b.positionX) > EPSILON ||
+        Math.abs(Number(a.positionY) - b.positionY) > EPSILON ||
+        Math.abs(Number(a.width) - b.width) > EPSILON ||
+        Math.abs(Number(a.height) - b.height) > EPSILON;
+
+      const toUpdate = next
+        .filter((r): r is TLocalRedaction & { id: number } => r.id !== undefined)
+        .map((r) => {
+          const match = persisted.find((p) => p.id === r.id);
+          return match && hasChanged(match, r) ? r : null;
+        })
+        .filter((r): r is TLocalRedaction & { id: number } => r !== null);
 
       try {
         if (toCreate.length > 0) {
@@ -219,9 +238,44 @@ export const EnvelopeEditorProvider = ({
           }));
         }
 
+        if (toUpdate.length > 0) {
+          await updateRedactionsMutation.mutateAsync({
+            documentId,
+            redactions: toUpdate.map((r) => ({
+              id: r.id,
+              page: r.page,
+              positionX: r.positionX,
+              positionY: r.positionY,
+              width: r.width,
+              height: r.height,
+            })),
+          });
+
+          // Mirror updates into envelopeRef so subsequent diffs are correct.
+          setEnvelope((prev) => ({
+            ...prev,
+            redactions: (prev.redactions ?? []).map((p) => {
+              const updated = toUpdate.find((u) => u.id === p.id);
+
+              if (!updated) {
+                return p;
+              }
+
+              return {
+                ...p,
+                page: updated.page,
+                positionX: new Prisma.Decimal(updated.positionX),
+                positionY: new Prisma.Decimal(updated.positionY),
+                width: new Prisma.Decimal(updated.width),
+                height: new Prisma.Decimal(updated.height),
+              };
+            }),
+          }));
+        }
+
         if (toDelete.length > 0) {
           await Promise.all(
-            toDelete.map((id) =>
+            toDelete.map(async (id) =>
               deleteRedactionMutation.mutateAsync({ documentId, redactionId: id }),
             ),
           );
@@ -242,7 +296,14 @@ export const EnvelopeEditorProvider = ({
         });
       }
     },
-    [isEmbedded, createRedactionsMutation, deleteRedactionMutation, toast, t],
+    [
+      isEmbedded,
+      createRedactionsMutation,
+      updateRedactionsMutation,
+      deleteRedactionMutation,
+      toast,
+      t,
+    ],
   );
 
   const editorRedactions = useEditorRedactions({

--- a/packages/lib/client-only/providers/envelope-editor-provider.tsx
+++ b/packages/lib/client-only/providers/envelope-editor-provider.tsx
@@ -157,9 +157,16 @@ export const EnvelopeEditorProvider = ({
   const deleteRedactionMutation = trpc.redaction.deleteDocumentRedaction.useMutation();
 
   // Ref used to break the circular dependency between `handleRedactionsUpdate`
-  // (which needs to call `updateRedactionByFormId` to attach server ids) and
+  // (which needs to call `setRedactionIdByFormId` to attach server ids) and
   // `useEditorRedactions` (which needs `handleRedactionsUpdate` at creation time).
   const editorRedactionsRef = useRef<ReturnType<typeof useEditorRedactions> | null>(null);
+
+  // FormIds for redactions whose CREATE mutation is currently in flight. We
+  // filter these out of `toCreate` on subsequent handler calls so a drag or
+  // resize during placement doesn't fire a second create for the same formId
+  // (the real user sees one visual redaction; two server rows for it would
+  // force a stale delete on the next action).
+  const pendingCreateFormIdsRef = useRef<Set<string>>(new Set());
 
   const handleRedactionsUpdate = useCallback(
     async (next: TLocalRedaction[]) => {
@@ -171,7 +178,9 @@ export const EnvelopeEditorProvider = ({
       const documentId = mapSecondaryIdToDocumentId(envelopeRef.current.secondaryId);
       const persisted = envelopeRef.current.redactions ?? [];
 
-      const toCreate = next.filter((r) => r.id === undefined);
+      const toCreate = next.filter(
+        (r) => r.id === undefined && !pendingCreateFormIdsRef.current.has(r.formId),
+      );
 
       const nextIds = new Set(next.filter((r) => r.id !== undefined).map((r) => r.id as number));
       const toDelete = persisted.filter((p) => !nextIds.has(p.id)).map((p) => p.id);
@@ -198,24 +207,30 @@ export const EnvelopeEditorProvider = ({
 
       try {
         if (toCreate.length > 0) {
-          const created = await createRedactionsMutation.mutateAsync({
-            documentId,
-            redactions: toCreate.map((r) => ({
-              envelopeItemId: r.envelopeItemId,
-              page: r.page,
-              positionX: r.positionX,
-              positionY: r.positionY,
-              width: r.width,
-              height: r.height,
-            })),
-          });
+          toCreate.forEach((r) => pendingCreateFormIdsRef.current.add(r.formId));
 
-          // Attach the server ids to the local records in order.
+          let created;
+          try {
+            created = await createRedactionsMutation.mutateAsync({
+              documentId,
+              redactions: toCreate.map((r) => ({
+                envelopeItemId: r.envelopeItemId,
+                page: r.page,
+                positionX: r.positionX,
+                positionY: r.positionY,
+                width: r.width,
+                height: r.height,
+              })),
+            });
+          } finally {
+            toCreate.forEach((r) => pendingCreateFormIdsRef.current.delete(r.formId));
+          }
+
+          // Attach the server ids to the local records WITHOUT re-entering
+          // `handleRedactionsUpdate` — bookkeeping only, not a user edit.
           created.redactions.forEach((serverRedaction, i) => {
             const local = toCreate[i];
-            editorRedactionsRef.current?.updateRedactionByFormId(local.formId, {
-              id: serverRedaction.id,
-            });
+            editorRedactionsRef.current?.setRedactionIdByFormId(local.formId, serverRedaction.id);
           });
 
           // Mirror the server rows into envelopeRef so subsequent diffs are correct.

--- a/packages/lib/client-only/providers/envelope-editor-provider.tsx
+++ b/packages/lib/client-only/providers/envelope-editor-provider.tsx
@@ -19,10 +19,13 @@ import { getRecipientColor } from '@documenso/ui/lib/recipient-colors';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 
 import type { TDocumentEmailSettings } from '../../types/document-email';
+import { mapSecondaryIdToDocumentId } from '../../utils/envelope';
 import { formatDocumentsPath, formatTemplatesPath } from '../../utils/teams';
 import { useEditorFields } from '../hooks/use-editor-fields';
 import type { TLocalField } from '../hooks/use-editor-fields';
 import { useEditorRecipients } from '../hooks/use-editor-recipients';
+import { useEditorRedactions } from '../hooks/use-editor-redactions';
+import type { TLocalRedaction } from '../hooks/use-editor-redactions';
 import { useEnvelopeAutosave } from '../hooks/use-envelope-autosave';
 
 export type EnvelopeEditorStep = 'upload' | 'addFields' | 'preview';
@@ -47,6 +50,7 @@ type EnvelopeEditorProviderValue = {
   getRecipientColorKey: (recipientId: number) => TRecipientColor;
 
   editorFields: ReturnType<typeof useEditorFields>;
+  editorRedactions: ReturnType<typeof useEditorRedactions>;
   editorRecipients: ReturnType<typeof useEditorRecipients>;
 
   isAutosaving: boolean;
@@ -147,6 +151,106 @@ export const EnvelopeEditorProvider = ({
   const setRecipientsMutation = trpc.envelope.recipient.set.useMutation();
   const setFieldsMutation = trpc.envelope.field.set.useMutation();
   const updateEnvelopeMutation = trpc.envelope.update.useMutation();
+
+  const createRedactionsMutation = trpc.redaction.createDocumentRedactions.useMutation();
+  const deleteRedactionMutation = trpc.redaction.deleteDocumentRedaction.useMutation();
+
+  // Ref used to break the circular dependency between `handleRedactionsUpdate`
+  // (which needs to call `updateRedactionByFormId` to attach server ids) and
+  // `useEditorRedactions` (which needs `handleRedactionsUpdate` at creation time).
+  const editorRedactionsRef = useRef<ReturnType<typeof useEditorRedactions> | null>(null);
+
+  const handleRedactionsUpdate = useCallback(
+    async (next: TLocalRedaction[]) => {
+      if (isEmbedded) {
+        // Embedded mode doesn't persist redactions to our backend; noop.
+        return;
+      }
+
+      const documentId = mapSecondaryIdToDocumentId(envelopeRef.current.secondaryId);
+      const persisted = envelopeRef.current.redactions ?? [];
+
+      const toCreate = next.filter((r) => r.id === undefined);
+
+      const nextIds = new Set(
+        next.filter((r) => r.id !== undefined).map((r) => r.id as number),
+      );
+      const toDelete = persisted.filter((p) => !nextIds.has(p.id)).map((p) => p.id);
+
+      try {
+        if (toCreate.length > 0) {
+          const created = await createRedactionsMutation.mutateAsync({
+            documentId,
+            redactions: toCreate.map((r) => ({
+              envelopeItemId: r.envelopeItemId,
+              page: r.page,
+              positionX: r.positionX,
+              positionY: r.positionY,
+              width: r.width,
+              height: r.height,
+            })),
+          });
+
+          // Attach the server ids to the local records in order.
+          created.redactions.forEach((serverRedaction, i) => {
+            const local = toCreate[i];
+            editorRedactionsRef.current?.updateRedactionByFormId(local.formId, {
+              id: serverRedaction.id,
+            });
+          });
+
+          // Mirror the server rows into envelopeRef so subsequent diffs are correct.
+          setEnvelope((prev) => ({
+            ...prev,
+            redactions: [
+              ...(prev.redactions ?? []),
+              ...created.redactions.map((r) => ({
+                id: r.id,
+                secondaryId: r.secondaryId,
+                envelopeId: envelopeRef.current.id,
+                envelopeItemId: r.envelopeItemId,
+                page: r.page,
+                positionX: new Prisma.Decimal(r.positionX),
+                positionY: new Prisma.Decimal(r.positionY),
+                width: new Prisma.Decimal(r.width),
+                height: new Prisma.Decimal(r.height),
+              })),
+            ],
+          }));
+        }
+
+        if (toDelete.length > 0) {
+          await Promise.all(
+            toDelete.map((id) =>
+              deleteRedactionMutation.mutateAsync({ documentId, redactionId: id }),
+            ),
+          );
+
+          setEnvelope((prev) => ({
+            ...prev,
+            redactions: (prev.redactions ?? []).filter((r) => !toDelete.includes(r.id)),
+          }));
+        }
+      } catch (err) {
+        console.error(err);
+        setAutosaveError(true);
+        toast({
+          title: t`Save failed`,
+          description: t`We encountered an error while saving your redactions. Your changes cannot be saved at this time.`,
+          variant: 'destructive',
+          duration: 7500,
+        });
+      }
+    },
+    [isEmbedded, createRedactionsMutation, deleteRedactionMutation, toast, t],
+  );
+
+  const editorRedactions = useEditorRedactions({
+    initialRedactions: envelope.redactions,
+    handleRedactionsUpdate,
+  });
+
+  editorRedactionsRef.current = editorRedactions;
 
   /**
    * Handles debouncing the recipients updates to the server.
@@ -386,6 +490,7 @@ export const EnvelopeEditorProvider = ({
       });
 
       editorFields.resetForm(fetchedEnvelopeData.data.fields);
+      editorRedactions.resetForm(fetchedEnvelopeData.data.redactions);
     }
   };
 
@@ -449,6 +554,7 @@ export const EnvelopeEditorProvider = ({
     });
 
     editorFields.resetForm(envelopeRef.current.fields);
+    editorRedactions.resetForm(envelopeRef.current.redactions);
   };
 
   const flushAutosave = async (): Promise<TEditorEnvelope> => {
@@ -482,6 +588,7 @@ export const EnvelopeEditorProvider = ({
         setRecipientsDebounced,
         setRecipientsAsync,
         editorFields,
+        editorRedactions,
         editorRecipients,
         autosaveError,
         flushAutosave,

--- a/packages/lib/server-only/document/send-document.ts
+++ b/packages/lib/server-only/document/send-document.ts
@@ -46,6 +46,7 @@ import {
 } from '../../utils/recipients';
 import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
 import { insertFormValuesInPdf } from '../pdf/insert-form-values-in-pdf';
+import { applyRedactionsToDocument } from '../redaction/apply-redactions-to-document';
 import { triggerWebhook } from '../webhooks/trigger/trigger-webhook';
 
 export type SendDocumentOptions = {
@@ -77,10 +78,12 @@ export const sendDocument = async ({
         orderBy: [{ signingOrder: { sort: 'asc', nulls: 'last' } }, { id: 'asc' }],
       },
       fields: true,
+      redactions: true,
       documentMeta: true,
       envelopeItems: {
         select: {
           id: true,
+          title: true,
           documentData: {
             select: {
               type: true,
@@ -125,6 +128,35 @@ export const sendDocument = async ({
 
   if (envelope.envelopeItems.length === 0) {
     throw new Error('Missing envelope items');
+  }
+
+  if (envelope.redactions.length > 0) {
+    const redactionsByEnvelopeItemId = new Map<string, typeof envelope.redactions>();
+    for (const redaction of envelope.redactions) {
+      const list = redactionsByEnvelopeItemId.get(redaction.envelopeItemId) ?? [];
+      list.push(redaction);
+      redactionsByEnvelopeItemId.set(redaction.envelopeItemId, list);
+    }
+
+    await Promise.all(
+      envelope.envelopeItems.map(async (envelopeItem) => {
+        const redactions = redactionsByEnvelopeItemId.get(envelopeItem.id);
+        if (!redactions || redactions.length === 0) {
+          return;
+        }
+        await applyRedactionsToDocument({
+          envelopeItem,
+          redactions,
+        });
+      }),
+    );
+
+    // Consume the redaction rows — they represent pending-to-apply work and
+    // are meaningless once baked into the PDF. Leaving them would also cause
+    // a duplicate apply on any subsequent sendDocument call.
+    await prisma.redaction.deleteMany({
+      where: { envelopeId: envelope.id },
+    });
   }
 
   if (envelope.formValues) {

--- a/packages/lib/server-only/envelope/get-editor-envelope-by-id.ts
+++ b/packages/lib/server-only/envelope/get-editor-envelope-by-id.ts
@@ -66,6 +66,7 @@ export const getEditorEnvelopeById = async ({
         },
       },
       fields: true,
+      redactions: true,
       team: {
         select: {
           id: true,

--- a/packages/lib/server-only/pdf/apply-redactions-to-pdf.test.ts
+++ b/packages/lib/server-only/pdf/apply-redactions-to-pdf.test.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, rgb } from '@cantoo/pdf-lib';
+import { PDFDocument, degrees, rgb } from '@cantoo/pdf-lib';
 import { describe, expect, it } from 'vitest';
 
 import { applyRedactionsToPdf } from './apply-redactions-to-pdf';
@@ -83,5 +83,41 @@ describe('applyRedactionsToPdf', () => {
 
     const parsed = await PDFDocument.load(output);
     expect(parsed.getPageCount()).toBe(1);
+  });
+
+  it('on a rotated page: removes text, replaces page with image at rotated dimensions and Rotate 0', async () => {
+    const doc = await PDFDocument.create();
+    const page = doc.addPage([612, 792]);
+    page.drawText('ROTATED SECRET', { x: 72, y: 720, size: 18, color: rgb(0, 0, 0) });
+    page.setRotation(degrees(90));
+    const input = new Uint8Array(await doc.save());
+
+    const output = await applyRedactionsToPdf({
+      pdfBytes: input,
+      redactions: [{ page: 1, positionX: 0, positionY: 0, width: 100, height: 100 }],
+    });
+
+    // pdfjs takes ownership of the input buffer, so load pdf-lib first.
+    const parsed = await PDFDocument.load(output);
+    expect(parsed.getPageCount()).toBe(1);
+    const outPage = parsed.getPage(0);
+    expect(outPage.getRotation().angle).toBe(0);
+    // Rotated viewport: width and height are swapped.
+    expect(Math.round(outPage.getWidth())).toBe(792);
+    expect(Math.round(outPage.getHeight())).toBe(612);
+
+    const text = await extractPageText(output);
+    expect(text).not.toContain('ROTATED SECRET');
+  });
+
+  it('throws when a redaction references a page outside the document', async () => {
+    const input = await makeTextPdf('hello');
+
+    await expect(
+      applyRedactionsToPdf({
+        pdfBytes: input,
+        redactions: [{ page: 99, positionX: 0, positionY: 0, width: 50, height: 50 }],
+      }),
+    ).rejects.toThrow(/page 99/);
   });
 });

--- a/packages/lib/server-only/pdf/apply-redactions-to-pdf.test.ts
+++ b/packages/lib/server-only/pdf/apply-redactions-to-pdf.test.ts
@@ -1,0 +1,87 @@
+import { PDFDocument, rgb } from '@cantoo/pdf-lib';
+import { describe, expect, it } from 'vitest';
+
+import { applyRedactionsToPdf } from './apply-redactions-to-pdf';
+
+const makeTextPdf = async (text: string) => {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([612, 792]);
+  page.drawText(text, { x: 72, y: 720, size: 18, color: rgb(0, 0, 0) });
+  page.drawText('KEEP THIS LINE', { x: 72, y: 120, size: 18, color: rgb(0, 0, 0) });
+  return new Uint8Array(await doc.save());
+};
+
+const extractPageText = async (pdfBytes: Uint8Array): Promise<string> => {
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const task = await pdfjs.getDocument({ data: pdfBytes });
+  const pdf = await task.promise;
+  const page = await pdf.getPage(1);
+  const content = await page.getTextContent();
+  await pdf.destroy();
+  return content.items.map((item) => ('str' in item ? item.str : '')).join(' ');
+};
+
+describe('applyRedactionsToPdf', () => {
+  it('returns the input unchanged when no redactions are supplied', async () => {
+    const input = await makeTextPdf('TOP SECRET PAYLOAD');
+
+    const output = await applyRedactionsToPdf({ pdfBytes: input, redactions: [] });
+
+    const text = await extractPageText(output);
+    expect(text).toContain('TOP SECRET PAYLOAD');
+    expect(text).toContain('KEEP THIS LINE');
+  });
+
+  it('removes the original text from a redacted page (true redaction)', async () => {
+    const input = await makeTextPdf('TOP SECRET PAYLOAD');
+
+    const output = await applyRedactionsToPdf({
+      pdfBytes: input,
+      redactions: [
+        { page: 1, positionX: 5, positionY: 5, width: 80, height: 15 },
+      ],
+    });
+
+    const text = await extractPageText(output);
+    expect(text).not.toContain('TOP SECRET PAYLOAD');
+    expect(text).not.toContain('KEEP THIS LINE');
+    // Entire page is rasterized (not just the box), because the whole page
+    // is replaced with an image. This is expected and documented.
+  });
+
+  it('leaves unredacted pages as vector content', async () => {
+    const doc = await PDFDocument.create();
+    const page1 = doc.addPage([612, 792]);
+    page1.drawText('PAGE ONE SECRET', { x: 72, y: 720, size: 18 });
+    const page2 = doc.addPage([612, 792]);
+    page2.drawText('PAGE TWO PUBLIC', { x: 72, y: 720, size: 18 });
+    const input = new Uint8Array(await doc.save());
+
+    const output = await applyRedactionsToPdf({
+      pdfBytes: input,
+      redactions: [{ page: 1, positionX: 0, positionY: 0, width: 100, height: 100 }],
+    });
+
+    const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    const pdf = await pdfjs.getDocument({ data: output }).promise;
+    const page1Text = (await (await pdf.getPage(1)).getTextContent()).items;
+    const page2Text = (await (await pdf.getPage(2)).getTextContent()).items;
+    await pdf.destroy();
+
+    expect(page1Text).toHaveLength(0);
+    const page2Joined = page2Text.map((i) => ('str' in i ? i.str : '')).join(' ');
+    expect(page2Joined).toContain('PAGE TWO PUBLIC');
+  });
+
+  it('preserves page count', async () => {
+    const input = await makeTextPdf('hello');
+
+    const output = await applyRedactionsToPdf({
+      pdfBytes: input,
+      redactions: [{ page: 1, positionX: 10, positionY: 10, width: 20, height: 10 }],
+    });
+
+    const parsed = await PDFDocument.load(output);
+    expect(parsed.getPageCount()).toBe(1);
+  });
+});

--- a/packages/lib/server-only/pdf/apply-redactions-to-pdf.ts
+++ b/packages/lib/server-only/pdf/apply-redactions-to-pdf.ts
@@ -1,0 +1,168 @@
+import { PDFDocument } from '@cantoo/pdf-lib';
+import pMap from 'p-map';
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { Canvas, Image, Path2D } from 'skia-canvas';
+
+// @ts-expect-error napi-rs/canvas satisfies the requirements
+globalThis.Path2D = Path2D;
+// @ts-expect-error napi-rs/canvas satisfies the requirements
+globalThis.Image = Image;
+
+export type RedactionRegion = {
+  page: number;
+  positionX: number;
+  positionY: number;
+  width: number;
+  height: number;
+};
+
+export type ApplyRedactionsToPdfOptions = {
+  pdfBytes: Uint8Array;
+  redactions: RedactionRegion[];
+  scale?: number;
+};
+
+const DEFAULT_RASTER_SCALE = 2;
+const REDACTION_FILL = '#000000';
+
+class SkiaCanvasFactory {
+  create(width: number, height: number) {
+    const canvas = new Canvas(width, height);
+    canvas.gpu = false;
+    return { canvas, context: canvas.getContext('2d') };
+  }
+
+  reset(cac: { canvas: Canvas }, width: number, height: number) {
+    cac.canvas.width = width;
+    cac.canvas.height = height;
+  }
+
+  destroy(cac: { canvas: Canvas | null; context: unknown }) {
+    if (cac.canvas) {
+      cac.canvas.width = 0;
+      cac.canvas.height = 0;
+    }
+    cac.canvas = null;
+    cac.context = null;
+  }
+}
+
+export const applyRedactionsToPdf = async ({
+  pdfBytes,
+  redactions,
+  scale = DEFAULT_RASTER_SCALE,
+}: ApplyRedactionsToPdfOptions): Promise<Uint8Array> => {
+  if (redactions.length === 0) {
+    return pdfBytes;
+  }
+
+  const redactionsByPage = new Map<number, RedactionRegion[]>();
+  for (const redaction of redactions) {
+    const list = redactionsByPage.get(redaction.page) ?? [];
+    list.push(redaction);
+    redactionsByPage.set(redaction.page, list);
+  }
+
+  const renderedPages = await renderRedactedPages({
+    pdfBytes,
+    redactionsByPage,
+    scale,
+  });
+
+  const outDoc = await PDFDocument.load(pdfBytes);
+
+  // Removing pages shifts indices; process highest index first so remaining
+  // indices stay stable.
+  const sortedPages = [...renderedPages].sort(
+    (a, b) => b.pageIndex - a.pageIndex,
+  );
+
+  for (const { pageIndex, pngBytes, widthPts, heightPts } of sortedPages) {
+    const embedded = await outDoc.embedPng(pngBytes);
+    outDoc.removePage(pageIndex);
+    const newPage = outDoc.insertPage(pageIndex, [widthPts, heightPts]);
+    newPage.drawImage(embedded, {
+      x: 0,
+      y: 0,
+      width: widthPts,
+      height: heightPts,
+    });
+  }
+
+  return new Uint8Array(await outDoc.save({ useObjectStreams: false }));
+};
+
+type RenderedPage = {
+  pageIndex: number;
+  pngBytes: Uint8Array;
+  widthPts: number;
+  heightPts: number;
+};
+
+type RenderRedactedPagesOptions = {
+  pdfBytes: Uint8Array;
+  redactionsByPage: Map<number, RedactionRegion[]>;
+  scale: number;
+};
+
+const renderRedactedPages = async ({
+  pdfBytes,
+  redactionsByPage,
+  scale,
+}: RenderRedactedPagesOptions): Promise<RenderedPage[]> => {
+  const task = await pdfjsLib.getDocument({
+    data: new Uint8Array(pdfBytes), // pdfjs takes ownership; pass a copy
+    CanvasFactory: SkiaCanvasFactory,
+  });
+  const pdf = await task.promise;
+
+  try {
+    const targets = Array.from(redactionsByPage.entries());
+
+    return await pMap(
+      targets,
+      async ([pageNumber, pageRedactions]) => {
+        const page = await pdf.getPage(pageNumber);
+        const viewport = page.getViewport({ scale });
+
+        const canvas = new Canvas(viewport.width, viewport.height);
+        canvas.gpu = false;
+        const ctx = canvas.getContext('2d');
+
+        await page.render({
+          // @ts-expect-error skia-canvas satisfies pdfjs requirements
+          canvas,
+          // @ts-expect-error skia-canvas satisfies pdfjs requirements
+          canvasContext: ctx,
+          viewport,
+        }).promise;
+
+        ctx.fillStyle = REDACTION_FILL;
+        for (const r of pageRedactions) {
+          const x = (r.positionX / 100) * viewport.width;
+          const y = (r.positionY / 100) * viewport.height;
+          const w = (r.width / 100) * viewport.width;
+          const h = (r.height / 100) * viewport.height;
+          ctx.fillRect(x, y, w, h);
+        }
+
+        const pngBytes = await canvas.toBuffer('png');
+
+        const { width: widthPts, height: heightPts } = page.getViewport({ scale: 1 });
+
+        void page.cleanup();
+
+        return {
+          pageIndex: pageNumber - 1,
+          pngBytes: new Uint8Array(pngBytes),
+          widthPts,
+          heightPts,
+        };
+      },
+      { concurrency: 4 },
+    );
+  } finally {
+    void pdf.destroy().catch(() => undefined);
+    void task.destroy().catch(() => undefined);
+  }
+};

--- a/packages/lib/server-only/pdf/apply-redactions-to-pdf.ts
+++ b/packages/lib/server-only/pdf/apply-redactions-to-pdf.ts
@@ -8,6 +8,34 @@ globalThis.Path2D = Path2D;
 // @ts-expect-error napi-rs/canvas satisfies the requirements
 globalThis.Image = Image;
 
+/**
+ * Applies true redaction to a PDF: each page containing one or more redaction
+ * regions is rendered to an opaque JPEG raster (with the redaction regions
+ * painted solid black), then replaced in the output. Pages with no redactions
+ * are left as vector content.
+ *
+ * Scope:
+ *   - Removes the content stream (text operators, vector paths, images) of
+ *     affected pages — the original text is genuinely gone.
+ *   - Leaves unaffected pages untouched.
+ *
+ * What this function does NOT do (callers must handle):
+ *   - Does not flatten AcroForm widgets, annotations, or layer state. Callers
+ *     should flatten the input before invoking this function if such content
+ *     could hold redacted text (see `normalizePdf` / `pdfDoc.flattenAll()`).
+ *   - Does not strip document metadata, embedded files, or JavaScript. See
+ *     `stripPdfMetadata` for that.
+ *   - Does not preserve page-level rotation metadata on redacted pages: the
+ *     raster is generated at the rotated viewport, and the replacement page is
+ *     created with `/Rotate 0`. The visual orientation is preserved; downstream
+ *     code that reads `page.getRotation()` after redaction will see 0 on
+ *     replaced pages. This is acceptable for our pipeline because field
+ *     coordinates are stored as percentages of the rendered page dimensions.
+ *   - Does not preserve `/CropBox` or `/UserUnit` on redacted pages.
+ *
+ * Compose with `stripPdfMetadata` and `normalizePdf` for end-to-end hardening
+ * (see `applyRedactionsToDocument`).
+ */
 export type RedactionRegion = {
   page: number;
   positionX: number;
@@ -77,8 +105,8 @@ export const applyRedactionsToPdf = async ({
     (a, b) => b.pageIndex - a.pageIndex,
   );
 
-  for (const { pageIndex, pngBytes, widthPts, heightPts } of sortedPages) {
-    const embedded = await outDoc.embedPng(pngBytes);
+  for (const { pageIndex, imageBytes, widthPts, heightPts } of sortedPages) {
+    const embedded = await outDoc.embedJpg(imageBytes);
     outDoc.removePage(pageIndex);
     const newPage = outDoc.insertPage(pageIndex, [widthPts, heightPts]);
     newPage.drawImage(embedded, {
@@ -94,7 +122,7 @@ export const applyRedactionsToPdf = async ({
 
 type RenderedPage = {
   pageIndex: number;
-  pngBytes: Uint8Array;
+  imageBytes: Uint8Array;
   widthPts: number;
   heightPts: number;
 };
@@ -110,59 +138,84 @@ const renderRedactedPages = async ({
   redactionsByPage,
   scale,
 }: RenderRedactedPagesOptions): Promise<RenderedPage[]> => {
-  const task = await pdfjsLib.getDocument({
+  const task = pdfjsLib.getDocument({
     data: new Uint8Array(pdfBytes), // pdfjs takes ownership; pass a copy
     CanvasFactory: SkiaCanvasFactory,
   });
-  const pdf = await task.promise;
+
+  let pdf: pdfjsLib.PDFDocumentProxy | undefined;
 
   try {
+    pdf = await task.promise;
+
+    // Sanity check: pdfjs page count should match what pdf-lib will see after load.
+    // This is defensive against malformed page trees where the 1-based pageNumber
+    // does not correspond to pdf-lib's pageIndex.
+    const pageCount = pdf.numPages;
+
+    // Validate every requested page is in range.
+    for (const pageNumber of redactionsByPage.keys()) {
+      if (!Number.isInteger(pageNumber) || pageNumber < 1 || pageNumber > pageCount) {
+        throw new Error(
+          `Redaction references page ${pageNumber}, but the PDF has ${pageCount} pages.`,
+        );
+      }
+    }
+
     const targets = Array.from(redactionsByPage.entries());
+    const loadedPdf = pdf;
 
     return await pMap(
       targets,
       async ([pageNumber, pageRedactions]) => {
-        const page = await pdf.getPage(pageNumber);
+        const page = await loadedPdf.getPage(pageNumber);
         const viewport = page.getViewport({ scale });
-
         const canvas = new Canvas(viewport.width, viewport.height);
         canvas.gpu = false;
-        const ctx = canvas.getContext('2d');
 
-        await page.render({
-          // @ts-expect-error skia-canvas satisfies pdfjs requirements
-          canvas,
-          // @ts-expect-error skia-canvas satisfies pdfjs requirements
-          canvasContext: ctx,
-          viewport,
-        }).promise;
+        try {
+          const ctx = canvas.getContext('2d');
 
-        ctx.fillStyle = REDACTION_FILL;
-        for (const r of pageRedactions) {
-          const x = (r.positionX / 100) * viewport.width;
-          const y = (r.positionY / 100) * viewport.height;
-          const w = (r.width / 100) * viewport.width;
-          const h = (r.height / 100) * viewport.height;
-          ctx.fillRect(x, y, w, h);
+          await page.render({
+            // @ts-expect-error skia-canvas satisfies pdfjs requirements
+            canvas,
+            // @ts-expect-error skia-canvas satisfies pdfjs requirements
+            canvasContext: ctx,
+            viewport,
+          }).promise;
+
+          ctx.fillStyle = REDACTION_FILL;
+          for (const r of pageRedactions) {
+            const x = (r.positionX / 100) * viewport.width;
+            const y = (r.positionY / 100) * viewport.height;
+            const w = (r.width / 100) * viewport.width;
+            const h = (r.height / 100) * viewport.height;
+            ctx.fillRect(x, y, w, h);
+          }
+
+          const imageBytes = await canvas.toBuffer('jpeg', { quality: 0.95 });
+          const { width: widthPts, height: heightPts } = page.getViewport({ scale: 1 });
+
+          return {
+            pageIndex: pageNumber - 1,
+            imageBytes: new Uint8Array(imageBytes),
+            widthPts,
+            heightPts,
+          };
+        } finally {
+          try {
+            page.cleanup();
+          } catch {
+            // pdfjs page cleanup is best-effort; ignore failures.
+          }
+          canvas.width = 0;
+          canvas.height = 0;
         }
-
-        const pngBytes = await canvas.toBuffer('png');
-
-        const { width: widthPts, height: heightPts } = page.getViewport({ scale: 1 });
-
-        void page.cleanup();
-
-        return {
-          pageIndex: pageNumber - 1,
-          pngBytes: new Uint8Array(pngBytes),
-          widthPts,
-          heightPts,
-        };
       },
       { concurrency: 4 },
     );
   } finally {
-    void pdf.destroy().catch(() => undefined);
+    if (pdf) void pdf.destroy().catch(() => undefined);
     void task.destroy().catch(() => undefined);
   }
 };

--- a/packages/lib/server-only/pdf/strip-pdf-metadata.test.ts
+++ b/packages/lib/server-only/pdf/strip-pdf-metadata.test.ts
@@ -1,0 +1,69 @@
+import { PDFDocument, PDFName } from '@cantoo/pdf-lib';
+import { describe, expect, it } from 'vitest';
+
+import { stripPdfMetadata } from './strip-pdf-metadata';
+
+const makeDocWithMetadata = async () => {
+  const doc = await PDFDocument.create();
+  doc.addPage([612, 792]);
+  doc.setTitle('Secret title');
+  doc.setAuthor('Secret author');
+  doc.setSubject('Secret subject');
+  doc.setKeywords(['secret', 'keyword']);
+  doc.setCreator('Secret creator');
+  doc.setProducer('Secret producer');
+  return new Uint8Array(await doc.save());
+};
+
+describe('stripPdfMetadata', () => {
+  it('removes Title, Author, Subject, Keywords, Creator, Producer', async () => {
+    const input = await makeDocWithMetadata();
+
+    const output = await stripPdfMetadata(input);
+
+    const parsed = await PDFDocument.load(output, { updateMetadata: false });
+    expect(parsed.getTitle() ?? '').toBe('');
+    expect(parsed.getAuthor() ?? '').toBe('');
+    expect(parsed.getSubject() ?? '').toBe('');
+    expect(parsed.getKeywords() ?? '').toBe('');
+    expect(parsed.getCreator() ?? '').toBe('');
+    expect(parsed.getProducer() ?? '').toBe('');
+  });
+
+  it('removes Names, AcroForm, OpenAction, and AA catalog entries', async () => {
+    const doc = await PDFDocument.create();
+    doc.addPage([612, 792]);
+
+    // Populate catalog entries that stripPdfMetadata should remove.
+    // `attach` registers an embedded file; the `Names` catalog entry is
+    // written during `save`, so we round-trip through save+load to get a
+    // populated input.
+    await doc.attach(new Uint8Array([1, 2, 3, 4]), 'secret.bin', {
+      mimeType: 'application/octet-stream',
+    });
+    doc.catalog.getOrCreateAcroForm();
+    doc.catalog.set(PDFName.of('OpenAction'), doc.context.obj({}));
+    doc.catalog.set(PDFName.of('AA'), doc.context.obj({}));
+
+    const intermediate = await PDFDocument.load(new Uint8Array(await doc.save()), {
+      updateMetadata: false,
+    });
+
+    // Sanity-check the precondition so a broken precondition can't silently
+    // pass the postcondition.
+    expect(intermediate.catalog.has(PDFName.of('Names'))).toBe(true);
+    expect(intermediate.catalog.has(PDFName.of('AcroForm'))).toBe(true);
+    expect(intermediate.catalog.has(PDFName.of('OpenAction'))).toBe(true);
+    expect(intermediate.catalog.has(PDFName.of('AA'))).toBe(true);
+
+    const input = new Uint8Array(await intermediate.save());
+
+    const output = await stripPdfMetadata(input);
+
+    const parsed = await PDFDocument.load(output, { updateMetadata: false });
+    expect(parsed.catalog.has(PDFName.of('Names'))).toBe(false);
+    expect(parsed.catalog.has(PDFName.of('AcroForm'))).toBe(false);
+    expect(parsed.catalog.has(PDFName.of('OpenAction'))).toBe(false);
+    expect(parsed.catalog.has(PDFName.of('AA'))).toBe(false);
+  });
+});

--- a/packages/lib/server-only/pdf/strip-pdf-metadata.test.ts
+++ b/packages/lib/server-only/pdf/strip-pdf-metadata.test.ts
@@ -22,7 +22,8 @@ describe('stripPdfMetadata', () => {
     const output = await stripPdfMetadata(input);
 
     const parsed = await PDFDocument.load(output, { updateMetadata: false });
-    const infoDict = parsed.getInfoDict();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const infoDict = (parsed as any).getInfoDict();
     for (const key of ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer']) {
       expect(infoDict.has(PDFName.of(key))).toBe(false);
     }

--- a/packages/lib/server-only/pdf/strip-pdf-metadata.test.ts
+++ b/packages/lib/server-only/pdf/strip-pdf-metadata.test.ts
@@ -22,12 +22,10 @@ describe('stripPdfMetadata', () => {
     const output = await stripPdfMetadata(input);
 
     const parsed = await PDFDocument.load(output, { updateMetadata: false });
-    expect(parsed.getTitle() ?? '').toBe('');
-    expect(parsed.getAuthor() ?? '').toBe('');
-    expect(parsed.getSubject() ?? '').toBe('');
-    expect(parsed.getKeywords() ?? '').toBe('');
-    expect(parsed.getCreator() ?? '').toBe('');
-    expect(parsed.getProducer() ?? '').toBe('');
+    const infoDict = parsed.getInfoDict();
+    for (const key of ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer']) {
+      expect(infoDict.has(PDFName.of(key))).toBe(false);
+    }
   });
 
   it('removes Names, AcroForm, OpenAction, and AA catalog entries', async () => {

--- a/packages/lib/server-only/pdf/strip-pdf-metadata.ts
+++ b/packages/lib/server-only/pdf/strip-pdf-metadata.ts
@@ -1,0 +1,35 @@
+import { PDFDocument, PDFName } from '@cantoo/pdf-lib';
+
+/**
+ * Strips information that could leak original document content from a
+ * (presumed already-flattened) PDF byte stream:
+ *
+ * - Info dictionary: Title, Author, Subject, Keywords, Creator, Producer.
+ * - Catalog `Names` entry (embedded file attachments and named destinations).
+ * - Catalog `AcroForm` entry (any remaining form data, including field values
+ *   that may still reference pre-redaction text).
+ * - Catalog `OpenAction` and `AA` entries (JavaScript / automatic actions).
+ *
+ * We save with `useObjectStreams: false` to avoid leaking data via object
+ * stream compression side channels.
+ */
+export const stripPdfMetadata = async (pdfBytes: Uint8Array): Promise<Uint8Array> => {
+  // `updateMetadata: false` prevents pdf-lib from automatically resetting
+  // Producer / ModDate on load, so our cleared values actually survive.
+  const doc = await PDFDocument.load(pdfBytes, { updateMetadata: false });
+
+  doc.setTitle('');
+  doc.setAuthor('');
+  doc.setSubject('');
+  doc.setKeywords([]);
+  doc.setCreator('');
+  doc.setProducer('');
+
+  const { catalog } = doc;
+  catalog.delete(PDFName.of('Names'));
+  catalog.delete(PDFName.of('AcroForm'));
+  catalog.delete(PDFName.of('OpenAction'));
+  catalog.delete(PDFName.of('AA'));
+
+  return new Uint8Array(await doc.save({ useObjectStreams: false }));
+};

--- a/packages/lib/server-only/pdf/strip-pdf-metadata.ts
+++ b/packages/lib/server-only/pdf/strip-pdf-metadata.ts
@@ -18,12 +18,10 @@ export const stripPdfMetadata = async (pdfBytes: Uint8Array): Promise<Uint8Array
   // Producer / ModDate on load, so our cleared values actually survive.
   const doc = await PDFDocument.load(pdfBytes, { updateMetadata: false });
 
-  doc.setTitle('');
-  doc.setAuthor('');
-  doc.setSubject('');
-  doc.setKeywords([]);
-  doc.setCreator('');
-  doc.setProducer('');
+  const infoDict = doc.getInfoDict();
+  for (const key of ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer']) {
+    infoDict.delete(PDFName.of(key));
+  }
 
   const { catalog } = doc;
   catalog.delete(PDFName.of('Names'));

--- a/packages/lib/server-only/pdf/strip-pdf-metadata.ts
+++ b/packages/lib/server-only/pdf/strip-pdf-metadata.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, PDFName } from '@cantoo/pdf-lib';
+import { type PDFDict, PDFDocument, PDFName } from '@cantoo/pdf-lib';
 
 /**
  * Strips information that could leak original document content from a
@@ -18,7 +18,11 @@ export const stripPdfMetadata = async (pdfBytes: Uint8Array): Promise<Uint8Array
   // Producer / ModDate on load, so our cleared values actually survive.
   const doc = await PDFDocument.load(pdfBytes, { updateMetadata: false });
 
-  const infoDict = doc.getInfoDict();
+  // `getInfoDict` is `private` in the pdf-lib types but is the only way to
+  // actually remove Info-dict keys (as opposed to clearing them to empty
+  // strings, which leaves the keys present). No public alternative exists.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const infoDict = (doc as any).getInfoDict() as PDFDict;
   for (const key of ['Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer']) {
     infoDict.delete(PDFName.of(key));
   }

--- a/packages/lib/server-only/redaction/apply-redactions-to-document.ts
+++ b/packages/lib/server-only/redaction/apply-redactions-to-document.ts
@@ -1,0 +1,67 @@
+import type { DocumentData, EnvelopeItem, Redaction } from '@prisma/client';
+
+import { prisma } from '@documenso/prisma';
+
+import { getFileServerSide } from '../../universal/upload/get-file.server';
+import { putPdfFileServerSide } from '../../universal/upload/put-file.server';
+import { applyRedactionsToPdf } from '../pdf/apply-redactions-to-pdf';
+import { normalizePdf } from '../pdf/normalize-pdf';
+import { stripPdfMetadata } from '../pdf/strip-pdf-metadata';
+
+type ApplyRedactionsToDocumentOptions = {
+  envelopeItem: Pick<EnvelopeItem, 'id' | 'title'> & { documentData: DocumentData };
+  redactions: Pick<Redaction, 'page' | 'positionX' | 'positionY' | 'width' | 'height'>[];
+};
+
+/**
+ * Orchestrates the end-to-end redaction pipeline for a single envelope item:
+ *
+ *   original bytes → flatten → rasterize-replace redacted pages → strip
+ *   metadata → store as a new DocumentData.
+ *
+ * Overwrites both `DocumentData.data` AND `initialData` (via the
+ * `createDocumentData` default) so a later reseal — which uses `initialData`
+ * — cannot resurrect the unredacted original.
+ *
+ * No-op when `redactions` is empty.
+ */
+export const applyRedactionsToDocument = async ({
+  envelopeItem,
+  redactions,
+}: ApplyRedactionsToDocumentOptions): Promise<void> => {
+  if (redactions.length === 0) {
+    return;
+  }
+
+  const originalBytes = await getFileServerSide(envelopeItem.documentData);
+
+  const flattened = await normalizePdf(Buffer.from(originalBytes), { flattenForm: true });
+
+  const redactedBytes = await applyRedactionsToPdf({
+    pdfBytes: new Uint8Array(flattened),
+    redactions: redactions.map((r) => ({
+      page: r.page,
+      positionX: Number(r.positionX),
+      positionY: Number(r.positionY),
+      width: Number(r.width),
+      height: Number(r.height),
+    })),
+  });
+
+  const sanitizedBytes = await stripPdfMetadata(redactedBytes);
+
+  const fileName = envelopeItem.title.endsWith('.pdf')
+    ? envelopeItem.title
+    : `${envelopeItem.title}.pdf`;
+
+  const { documentData: newDocumentData } = await putPdfFileServerSide({
+    name: fileName,
+    type: 'application/pdf',
+    arrayBuffer: async () => Promise.resolve(sanitizedBytes),
+  });
+
+  await prisma.envelopeItem.update({
+    where: { id: envelopeItem.id },
+    data: { documentDataId: newDocumentData.id },
+  });
+};

--- a/packages/lib/server-only/redaction/create-envelope-redactions.ts
+++ b/packages/lib/server-only/redaction/create-envelope-redactions.ts
@@ -1,0 +1,75 @@
+import { DocumentStatus, EnvelopeType } from '@prisma/client';
+
+import { prisma } from '@documenso/prisma';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import { prefixedId } from '../../universal/id';
+import { type EnvelopeIdOptions } from '../../utils/envelope';
+import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
+
+export type CreateEnvelopeRedactionsOptions = {
+  userId: number;
+  teamId: number;
+  id: EnvelopeIdOptions;
+  redactions: {
+    envelopeItemId: string;
+    page: number;
+    positionX: number;
+    positionY: number;
+    width: number;
+    height: number;
+  }[];
+};
+
+export const createEnvelopeRedactions = async ({
+  userId,
+  teamId,
+  id,
+  redactions,
+}: CreateEnvelopeRedactionsOptions) => {
+  const { envelopeWhereInput } = await getEnvelopeWhereInput({
+    id,
+    type: EnvelopeType.DOCUMENT,
+    userId,
+    teamId,
+  });
+
+  const envelope = await prisma.envelope.findFirstOrThrow({
+    where: envelopeWhereInput,
+    include: { envelopeItems: { select: { id: true } } },
+  });
+
+  if (envelope.status !== DocumentStatus.DRAFT) {
+    throw new AppError(AppErrorCode.INVALID_REQUEST, {
+      message: 'Redactions can only be added while the document is in DRAFT.',
+    });
+  }
+
+  const validItemIds = new Set(envelope.envelopeItems.map((i) => i.id));
+  for (const redaction of redactions) {
+    if (!validItemIds.has(redaction.envelopeItemId)) {
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: `Envelope item ${redaction.envelopeItemId} does not belong to this envelope.`,
+      });
+    }
+  }
+
+  return await prisma.$transaction(async (tx) =>
+    Promise.all(
+      redactions.map((r) =>
+        tx.redaction.create({
+          data: {
+            envelopeId: envelope.id,
+            envelopeItemId: r.envelopeItemId,
+            page: r.page,
+            positionX: r.positionX,
+            positionY: r.positionY,
+            width: r.width,
+            height: r.height,
+            secondaryId: prefixedId('rdx'),
+          },
+        }),
+      ),
+    ),
+  );
+};

--- a/packages/lib/server-only/redaction/delete-envelope-redaction.ts
+++ b/packages/lib/server-only/redaction/delete-envelope-redaction.ts
@@ -36,7 +36,11 @@ export const deleteEnvelopeRedaction = async ({
     });
   }
 
-  await prisma.redaction.delete({
+  // Idempotent: client-side diffing can race with concurrent creates and ask
+  // us to delete a row that was never committed or that is already gone. Use
+  // deleteMany so the operation succeeds either way — there's nothing to do
+  // when the row doesn't exist.
+  await prisma.redaction.deleteMany({
     where: { id: redactionId, envelopeId: envelope.id },
   });
 };

--- a/packages/lib/server-only/redaction/delete-envelope-redaction.ts
+++ b/packages/lib/server-only/redaction/delete-envelope-redaction.ts
@@ -1,0 +1,42 @@
+import { DocumentStatus, EnvelopeType } from '@prisma/client';
+
+import { prisma } from '@documenso/prisma';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import { type EnvelopeIdOptions } from '../../utils/envelope';
+import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
+
+export type DeleteEnvelopeRedactionOptions = {
+  userId: number;
+  teamId: number;
+  id: EnvelopeIdOptions;
+  redactionId: number;
+};
+
+export const deleteEnvelopeRedaction = async ({
+  userId,
+  teamId,
+  id,
+  redactionId,
+}: DeleteEnvelopeRedactionOptions) => {
+  const { envelopeWhereInput } = await getEnvelopeWhereInput({
+    id,
+    type: EnvelopeType.DOCUMENT,
+    userId,
+    teamId,
+  });
+
+  const envelope = await prisma.envelope.findFirstOrThrow({
+    where: envelopeWhereInput,
+  });
+
+  if (envelope.status !== DocumentStatus.DRAFT) {
+    throw new AppError(AppErrorCode.INVALID_REQUEST, {
+      message: 'Redactions can only be deleted while the document is in DRAFT.',
+    });
+  }
+
+  await prisma.redaction.delete({
+    where: { id: redactionId, envelopeId: envelope.id },
+  });
+};

--- a/packages/lib/server-only/redaction/update-envelope-redactions.ts
+++ b/packages/lib/server-only/redaction/update-envelope-redactions.ts
@@ -1,0 +1,62 @@
+import { DocumentStatus, EnvelopeType } from '@prisma/client';
+
+import { prisma } from '@documenso/prisma';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import { type EnvelopeIdOptions } from '../../utils/envelope';
+import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
+
+export type UpdateEnvelopeRedactionsOptions = {
+  userId: number;
+  teamId: number;
+  id: EnvelopeIdOptions;
+  redactions: {
+    id: number;
+    page?: number;
+    positionX?: number;
+    positionY?: number;
+    width?: number;
+    height?: number;
+  }[];
+};
+
+export const updateEnvelopeRedactions = async ({
+  userId,
+  teamId,
+  id,
+  redactions,
+}: UpdateEnvelopeRedactionsOptions) => {
+  const { envelopeWhereInput } = await getEnvelopeWhereInput({
+    id,
+    type: EnvelopeType.DOCUMENT,
+    userId,
+    teamId,
+  });
+
+  const envelope = await prisma.envelope.findFirstOrThrow({
+    where: envelopeWhereInput,
+  });
+
+  if (envelope.status !== DocumentStatus.DRAFT) {
+    throw new AppError(AppErrorCode.INVALID_REQUEST, {
+      message: 'Redactions can only be updated while the document is in DRAFT.',
+    });
+  }
+
+  return await prisma.$transaction(async (tx) =>
+    Promise.all(
+      redactions.map((r) =>
+        tx.redaction.update({
+          where: { id: r.id, envelopeId: envelope.id },
+          data: {
+            page: r.page,
+            positionX: r.positionX,
+            positionY: r.positionY,
+            width: r.width,
+            height: r.height,
+          },
+        }),
+      ),
+    ),
+  );
+};

--- a/packages/lib/types/envelope-editor.ts
+++ b/packages/lib/types/envelope-editor.ts
@@ -8,6 +8,7 @@ import { DocumentMetaSchema } from '@documenso/prisma/generated/zod/modelSchema/
 import { EnvelopeAttachmentSchema } from '@documenso/prisma/generated/zod/modelSchema/EnvelopeAttachmentSchema';
 import { EnvelopeItemSchema } from '@documenso/prisma/generated/zod/modelSchema/EnvelopeItemSchema';
 import { EnvelopeSchema } from '@documenso/prisma/generated/zod/modelSchema/EnvelopeSchema';
+import { RedactionSchema } from '@documenso/prisma/generated/zod/modelSchema/RedactionSchema';
 import { TeamSchema } from '@documenso/prisma/generated/zod/modelSchema/TeamSchema';
 import { TemplateDirectLinkSchema } from '@documenso/prisma/generated/zod/modelSchema/TemplateDirectLinkSchema';
 
@@ -231,6 +232,20 @@ export const ZEmbedEditEnvelopeAuthoringSchema = ZBaseEmbedDataSchema.extend({
 export type TEmbedCreateEnvelopeAuthoring = z.infer<typeof ZEmbedCreateEnvelopeAuthoringSchema>;
 export type TEmbedEditEnvelopeAuthoring = z.infer<typeof ZEmbedEditEnvelopeAuthoringSchema>;
 
+export const ZEnvelopeRedactionSchema = RedactionSchema.pick({
+  id: true,
+  secondaryId: true,
+  envelopeId: true,
+  envelopeItemId: true,
+  page: true,
+  positionX: true,
+  positionY: true,
+  width: true,
+  height: true,
+});
+
+export type TEnvelopeRedaction = z.infer<typeof ZEnvelopeRedactionSchema>;
+
 /**
  * A subset of the full envelope response schema used for the envelope editor.
  *
@@ -278,6 +293,7 @@ export const ZEditorEnvelopeSchema = EnvelopeSchema.pick({
   }),
   recipients: ZEnvelopeRecipientLiteSchema.array(),
   fields: ZEnvelopeFieldSchema.array(),
+  redactions: ZEnvelopeRedactionSchema.array(),
   envelopeItems: EnvelopeItemSchema.pick({
     envelopeId: true,
     id: true,

--- a/packages/prisma/migrations/20260423081626_add_redaction/migration.sql
+++ b/packages/prisma/migrations/20260423081626_add_redaction/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "Redaction" (
+    "id" SERIAL NOT NULL,
+    "secondaryId" TEXT NOT NULL,
+    "envelopeId" TEXT NOT NULL,
+    "envelopeItemId" TEXT NOT NULL,
+    "page" INTEGER NOT NULL,
+    "positionX" DECIMAL(65,30) NOT NULL DEFAULT 0,
+    "positionY" DECIMAL(65,30) NOT NULL DEFAULT 0,
+    "width" DECIMAL(65,30) NOT NULL DEFAULT -1,
+    "height" DECIMAL(65,30) NOT NULL DEFAULT -1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Redaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Redaction_secondaryId_key" ON "Redaction"("secondaryId");
+
+-- CreateIndex
+CREATE INDEX "Redaction_envelopeId_idx" ON "Redaction"("envelopeId");
+
+-- CreateIndex
+CREATE INDEX "Redaction_envelopeItemId_idx" ON "Redaction"("envelopeItemId");
+
+-- AddForeignKey
+ALTER TABLE "Redaction" ADD CONSTRAINT "Redaction_envelopeId_fkey" FOREIGN KEY ("envelopeId") REFERENCES "Envelope"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Redaction" ADD CONSTRAINT "Redaction_envelopeItemId_fkey" FOREIGN KEY ("envelopeItemId") REFERENCES "EnvelopeItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -407,6 +407,7 @@ model Envelope {
   envelopeItems EnvelopeItem[]
   recipients    Recipient[]
   fields        Field[]
+  redactions    Redaction[]
   shareLinks    DocumentShareLink[]
   auditLogs     DocumentAuditLog[]
 
@@ -458,7 +459,8 @@ model EnvelopeItem {
   envelopeId String
   envelope   Envelope @relation(fields: [envelopeId], references: [id], onDelete: Cascade)
 
-  field Field[]
+  field      Field[]
+  redactions Redaction[]
 
   @@unique([documentDataId])
   @@index([envelopeId])
@@ -655,6 +657,26 @@ model Field {
   @@index([envelopeId])
   @@index([envelopeItemId])
   @@index([recipientId])
+}
+
+model Redaction {
+  id             Int          @id @default(autoincrement())
+  secondaryId    String       @unique @default(cuid())
+  envelopeId     String
+  envelopeItemId String
+  page           Int          /// @zod.number.describe("1-indexed page number of the redaction.")
+  positionX      Decimal      @default(0)
+  positionY      Decimal      @default(0)
+  width          Decimal      @default(-1)
+  height         Decimal      @default(-1)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  envelope     Envelope     @relation(fields: [envelopeId], references: [id], onDelete: Cascade)
+  envelopeItem EnvelopeItem @relation(fields: [envelopeItemId], references: [id], onDelete: Cascade)
+
+  @@index([envelopeId])
+  @@index([envelopeItemId])
 }
 
 model Signature {

--- a/packages/trpc/server/redaction-router/router.ts
+++ b/packages/trpc/server/redaction-router/router.ts
@@ -1,0 +1,74 @@
+import { createEnvelopeRedactions } from '@documenso/lib/server-only/redaction/create-envelope-redactions';
+import { deleteEnvelopeRedaction } from '@documenso/lib/server-only/redaction/delete-envelope-redaction';
+import { updateEnvelopeRedactions } from '@documenso/lib/server-only/redaction/update-envelope-redactions';
+
+import { ZGenericSuccessResponse, ZSuccessResponseSchema } from '../schema';
+import { authenticatedProcedure, router } from '../trpc';
+import {
+  ZCreateDocumentRedactionsRequestSchema,
+  ZCreateDocumentRedactionsResponseSchema,
+  ZDeleteDocumentRedactionRequestSchema,
+  ZUpdateDocumentRedactionsRequestSchema,
+  ZUpdateDocumentRedactionsResponseSchema,
+} from './schema';
+
+const mapToResponse = (r: {
+  id: number;
+  secondaryId: string;
+  envelopeItemId: string;
+  page: number;
+  positionX: unknown;
+  positionY: unknown;
+  width: unknown;
+  height: unknown;
+}) => ({
+  id: r.id,
+  secondaryId: r.secondaryId,
+  envelopeItemId: r.envelopeItemId,
+  page: r.page,
+  positionX: Number(r.positionX),
+  positionY: Number(r.positionY),
+  width: Number(r.width),
+  height: Number(r.height),
+});
+
+export const redactionRouter = router({
+  createDocumentRedactions: authenticatedProcedure
+    .input(ZCreateDocumentRedactionsRequestSchema)
+    .output(ZCreateDocumentRedactionsResponseSchema)
+    .mutation(async ({ input, ctx }) => {
+      const created = await createEnvelopeRedactions({
+        userId: ctx.user.id,
+        teamId: ctx.teamId,
+        id: { type: 'documentId', id: input.documentId },
+        redactions: input.redactions,
+      });
+      return { redactions: created.map(mapToResponse) };
+    }),
+
+  updateDocumentRedactions: authenticatedProcedure
+    .input(ZUpdateDocumentRedactionsRequestSchema)
+    .output(ZUpdateDocumentRedactionsResponseSchema)
+    .mutation(async ({ input, ctx }) => {
+      const updated = await updateEnvelopeRedactions({
+        userId: ctx.user.id,
+        teamId: ctx.teamId,
+        id: { type: 'documentId', id: input.documentId },
+        redactions: input.redactions,
+      });
+      return { redactions: updated.map(mapToResponse) };
+    }),
+
+  deleteDocumentRedaction: authenticatedProcedure
+    .input(ZDeleteDocumentRedactionRequestSchema)
+    .output(ZSuccessResponseSchema)
+    .mutation(async ({ input, ctx }) => {
+      await deleteEnvelopeRedaction({
+        userId: ctx.user.id,
+        teamId: ctx.teamId,
+        id: { type: 'documentId', id: input.documentId },
+        redactionId: input.redactionId,
+      });
+      return ZGenericSuccessResponse;
+    }),
+});

--- a/packages/trpc/server/redaction-router/schema.ts
+++ b/packages/trpc/server/redaction-router/schema.ts
@@ -1,21 +1,28 @@
 import { z } from 'zod';
 
+// Width/height must be strictly positive — a zero-sized redaction would
+// silently produce no visible effect and give the sender false confidence
+// that the content was covered.
+const ZRedactionWidthSchema = z.number().gt(0).max(100);
+const ZRedactionHeightSchema = z.number().gt(0).max(100);
+const ZRedactionPositionSchema = z.number().min(0).max(100);
+
 const ZCreateRedactionSchema = z.object({
   envelopeItemId: z.string(),
   page: z.number().int().min(1),
-  positionX: z.number().min(0).max(100),
-  positionY: z.number().min(0).max(100),
-  width: z.number().min(0).max(100),
-  height: z.number().min(0).max(100),
+  positionX: ZRedactionPositionSchema,
+  positionY: ZRedactionPositionSchema,
+  width: ZRedactionWidthSchema,
+  height: ZRedactionHeightSchema,
 });
 
 const ZUpdateRedactionSchema = z.object({
   id: z.number().int(),
   page: z.number().int().min(1).optional(),
-  positionX: z.number().min(0).max(100).optional(),
-  positionY: z.number().min(0).max(100).optional(),
-  width: z.number().min(0).max(100).optional(),
-  height: z.number().min(0).max(100).optional(),
+  positionX: ZRedactionPositionSchema.optional(),
+  positionY: ZRedactionPositionSchema.optional(),
+  width: ZRedactionWidthSchema.optional(),
+  height: ZRedactionHeightSchema.optional(),
 });
 
 export const ZRedactionResponseSchema = z.object({

--- a/packages/trpc/server/redaction-router/schema.ts
+++ b/packages/trpc/server/redaction-router/schema.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const ZCreateRedactionSchema = z.object({
+  envelopeItemId: z.string(),
+  page: z.number().int().min(1),
+  positionX: z.number().min(0).max(100),
+  positionY: z.number().min(0).max(100),
+  width: z.number().min(0).max(100),
+  height: z.number().min(0).max(100),
+});
+
+const ZUpdateRedactionSchema = z.object({
+  id: z.number().int(),
+  page: z.number().int().min(1).optional(),
+  positionX: z.number().min(0).max(100).optional(),
+  positionY: z.number().min(0).max(100).optional(),
+  width: z.number().min(0).max(100).optional(),
+  height: z.number().min(0).max(100).optional(),
+});
+
+export const ZRedactionResponseSchema = z.object({
+  id: z.number(),
+  secondaryId: z.string(),
+  envelopeItemId: z.string(),
+  page: z.number(),
+  positionX: z.number(),
+  positionY: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+
+export const ZCreateDocumentRedactionsRequestSchema = z.object({
+  documentId: z.number(),
+  redactions: z.array(ZCreateRedactionSchema).min(1).max(200),
+});
+
+export const ZCreateDocumentRedactionsResponseSchema = z.object({
+  redactions: z.array(ZRedactionResponseSchema),
+});
+
+export const ZUpdateDocumentRedactionsRequestSchema = z.object({
+  documentId: z.number(),
+  redactions: z.array(ZUpdateRedactionSchema).min(1).max(200),
+});
+
+export const ZUpdateDocumentRedactionsResponseSchema = z.object({
+  redactions: z.array(ZRedactionResponseSchema),
+});
+
+export const ZDeleteDocumentRedactionRequestSchema = z.object({
+  documentId: z.number(),
+  redactionId: z.number(),
+});

--- a/packages/trpc/server/router.ts
+++ b/packages/trpc/server/router.ts
@@ -10,6 +10,7 @@ import { folderRouter } from './folder-router/router';
 import { organisationRouter } from './organisation-router/router';
 import { profileRouter } from './profile-router/router';
 import { recipientRouter } from './recipient-router/router';
+import { redactionRouter } from './redaction-router/router';
 import { teamRouter } from './team-router/router';
 import { templateRouter } from './template-router/router';
 import { router } from './trpc';
@@ -22,6 +23,7 @@ export const appRouter = router({
   profile: profileRouter,
   document: documentRouter,
   field: fieldRouter,
+  redaction: redactionRouter,
   folder: folderRouter,
   recipient: recipientRouter,
   admin: adminRouter,


### PR DESCRIPTION
## Description                                                                                                      
   
  Adds the ability for senders to mark regions of a PDF for **true redaction** before sending it for signing. Unlike a
   drawing-layer overlay (e.g. `page.drawRectangle`), redacted content is physically removed from the PDF: each     
  affected page is rasterized with the redaction regions burned in as solid black, and the resulting image replaces   
  the original page. The original text operators, annotations, and form widgets on that page are gone — not just    
  visually obscured. Pages without redactions are left as vector content so they stay searchable and small.

  Redactions are applied when the document transitions from DRAFT to PENDING (inside `sendDocument`), so recipients   
  never receive the unredacted bytes. Both `DocumentData.data` and `initialData` are overwritten with the redacted PDF
   — resealing later cannot resurrect the original, since the seal job uses `initialData` as its source.                                                                                                                                                                                                  
                                                                                                                    
  ## Changes Made

  **Data model**                                                                                                      
  - New `Redaction` Prisma model with back-relations on `Envelope` and `EnvelopeItem`, plus migration.
                                                                                                                      
  **PDF pipeline** (`packages/lib/server-only/pdf/`, `packages/lib/server-only/redaction/`)                           
  - `apply-redactions-to-pdf.ts` — core rasterize-and-replace function using `pdfjs-dist` + `skia-canvas` for         
  rendering and `@cantoo/pdf-lib` for page removal/insertion. Pages processed in reverse index order to keep          
  subsequent indices stable. JPEG-encoded raster (q=0.95) to keep output size bounded. Early-returns when           
  `redactions.length === 0`.                                                                                          
  - `strip-pdf-metadata.ts` — deletes Info-dict keys (Title/Author/Subject/Keywords/Creator/Producer) and catalog   
  entries (Names/AcroForm/OpenAction/AA) to prevent leaks through embedded attachments, JavaScript triggers, or       
  leftover form data.
  - `apply-redactions-to-document.ts` — the storage-aware orchestrator: read → flatten (`normalizePdf`) → rasterize + 
  paint redactions → strip metadata → write new DocumentData (overwriting both `data` and `initialData`).             
  - Wired into `send-document.ts` immediately before form-value injection. Redaction rows are deleted after
  application — they represent pending-to-apply work and are meaningless once baked in.                               
                                                                                                                    
  **API**                                                                                                             
  - `packages/trpc/server/redaction-router/` — `createDocumentRedactions`, `updateDocumentRedactions`,              
  `deleteDocumentRedaction`. All guard against non-DRAFT envelope status and reject zero-size regions.                
  - Server-only CRUD functions in `packages/lib/server-only/redaction/`.
  - Editor envelope loader extended to include redactions so they round-trip through the editor.                      
                                                                                                                      
  **UI** (`apps/remix/app/components/general/envelope-editor/`)                                                       
  - New "Redact" toolbar button in the fields sidebar.                                                                
  - Click-to-place drag-drop with cursor preview.                                                                     
  - Konva-rendered redaction groups on the same page layer as fields, with their own transformer so selection states  
  don't cross. Full parity with field UX: click to select, drag to move, resize handles, trash button when selected.  
  - Redaction badge is a solid black rectangle with a centered "REDACTED" label; hover shows a red outline.           
  - Disabled entirely once the envelope leaves DRAFT.                                                                 
                                                                                                                      
  **Client state**                                                                                                    
  - `useEditorRedactions` hook mirroring `useEditorFields`.                                                           
  - Provider diffs local state against `envelopeRef.current.redactions` to fan out create/update/delete mutations.    
                                                                                                                      
  ## Testing Performed                                                                                                
                                                                                                                      
  **Automated**                                                                                                       
  - Vitest unit tests for `strip-pdf-metadata` (Info-dict delete, catalog entry removal via round-trip with         
  `doc.attach()` + `getOrCreateAcroForm()` so the assertion is honest about what's actually removed, not just the     
  method call).
  - Vitest unit tests for `apply-redactions-to-pdf`: empty-case no-op, true-redaction assertion (`getTextContent`     
  returns empty after redaction — proves content stream is actually gone, not overlaid), per-page isolation (redacted 
  page = no vector text; unredacted page still has vector text), page-count preservation, rotated source page,
  out-of-range page rejection.                                                                                        
  - Playwright E2E (`packages/app-tests/e2e/envelopes/redaction.spec.ts`) exercising the full `sendDocument` →      
  `applyRedactionsToDocument` pipeline. Places a Redaction row, sends, pulls the resulting `DocumentData` bytes back, 
  and asserts both a known top-of-page string (inside the redaction) and a known bottom-of-page string (outside, but
  also erased because rasterize-replace rewrites the whole page) are absent from the distributed PDF.                 
                                                                                                                    
  **Manual**
  - Upload + place redactions + send flow end-to-end with real PDFs.
  - Verified text cannot be selected / copy-pasted from the redacted page in Acrobat, Preview, and Chrome's PDF       
  viewer.                                                                                                             
  - `pdftotext` on the distributed PDF confirmed no trace of the redacted strings.                                    
  - Metadata verified empty via `pdfinfo`.                                                                            
                                                                                                                      
  ## Checklist                                                                                                        
                                                                                                                      
  - [x] I have tested these changes locally and they work as expected.                                              
  - [x] I have added/updated tests that prove the effectiveness of these changes.
  - [x] I have updated the documentation to reflect these changes, if applicable.                                     
  - [x] I have followed the project's coding style guidelines.
  - [x] I have addressed the code review feedback from the previous submission, if applicable.                        
                                                                                                                      
  ## Additional Notes
                                                                                                                      
  **Known scope reductions for V1** (call out if reviewers want any lifted before merge):                             
  - Documents only. Templates are not supported yet — the CRUD functions explicitly scope to `EnvelopeType.DOCUMENT`.
  - Solid black only; no reason labels, colors, or per-recipient redactions.                                          
  - Once a document is sent, redactions are permanent. There is no un-redact path — the original bytes are            
  deliberately overwritten in `DocumentData.initialData` to defeat resealing.                                         
                                                                                                                      
  **Design choices worth flagging**                                                                                   
  - Rasterize-and-replace was chosen over trying to edit the PDF content stream because `pdf-lib` does not expose   
  content-stream manipulation, and rasterization is the technique commercial redaction tools use when they apply      
  (rather than just mark) redactions. Trade-off: text on affected pages is no longer selectable/searchable. Unaffected
   pages are left as vector content.                                                                                  
  - Replaced pages lose `/Rotate` / `/CropBox` / `/UserUnit` — the raster is generated at the rotated viewport so   
  visual orientation is preserved, but downstream code that reads `page.getRotation()` on a redacted page will see 0. 
  Field placement uses page-percentage coordinates so this is a no-op for our pipeline, but flagged for anyone
  extending it.                                                                                                       
  - Saved with `useObjectStreams: false` so the output is independently auditable and no cleared objects can hide   
  inside a compressed object stream.                                                                                  
  - Redaction CRUD uses `deleteMany` server-side for idempotency — the client diff can race with concurrent creates
  and ask to delete a row that was never committed; making delete tolerant is cheaper than eliminating every          
  client-side race.    