### PR TITLE
feat: add envelope ids to certs

### DIFF
--- a/packages/lib/server-only/pdf/generate-certificate-pdf.ts
+++ b/packages/lib/server-only/pdf/generate-certificate-pdf.ts
@@ -142,6 +142,7 @@ export const generateCertificatePdf = async (options: GenerateCertificatePdfOpti
       };
     }),
     envelopeOwner,
+    envelopeId: envelope.id,
     qrToken: envelope.qrToken,
     hidePoweredBy: organisationClaim.flags.hidePoweredBy ?? false,
     pageWidth,

--- a/packages/lib/server-only/pdf/render-audit-logs.ts
+++ b/packages/lib/server-only/pdf/render-audit-logs.ts
@@ -57,7 +57,7 @@ const textXs = 8;
 const fontMedium = '500';
 
 const pageTopMargin = 60;
-const pageBottomMargin = 15;
+const pageBottomMargin = 27;
 const contentMaxWidth = 768;
 const rowPadding = 10;
 const titleFontSize = 18;
@@ -595,7 +595,7 @@ export async function renderAuditLogs({
 
   const groupedRows = groupRowsIntoPages({
     auditLogs,
-    maxHeight: pageHeight,
+    maxHeight: pageHeight - pageBottomMargin,
     contentWidth,
     i18n,
     overviewCard,
@@ -621,6 +621,16 @@ export async function renderAuditLogs({
   for (const [index, pageGroup] of pageGroups.entries()) {
     stage.destroyChildren();
     const page = new Konva.Layer();
+
+    const footerText = new Konva.Text({
+      x: margin,
+      y: pageHeight - textXs - 10,
+      text: `${i18n._(msg`Envelope ID`)}: ${envelope.id}`,
+      fontFamily: 'Inter',
+      fontSize: textXs,
+      fill: textMutedForegroundLight,
+    });
+    page.add(footerText);
 
     page.add(pageGroup);
 
@@ -656,6 +666,16 @@ export async function renderAuditLogs({
       x: pageWidth - brandingRect.width - margin,
       y: pageTopMargin,
     } satisfies Partial<Konva.GroupConfig>);
+
+    const overflowFooterText = new Konva.Text({
+      x: margin,
+      y: pageHeight - textXs - 10,
+      text: `${i18n._(msg`Envelope ID`)}: ${envelope.id}`,
+      fontFamily: 'Inter',
+      fontSize: textXs,
+      fill: textMutedForegroundLight,
+    });
+    page.add(overflowFooterText);
 
     page.add(brandingGroup);
     stage.add(page);

--- a/packages/lib/server-only/pdf/render-certificate.ts
+++ b/packages/lib/server-only/pdf/render-certificate.ts
@@ -49,6 +49,7 @@ export type CertificateRecipient = {
 
 type GenerateCertificateOptions = {
   recipients: CertificateRecipient[];
+  envelopeId: string;
   qrToken: string | null;
   hidePoweredBy: boolean;
   i18n: I18n;
@@ -88,7 +89,7 @@ const columnWidthPercentages = [30, 30, 40];
 const rowPadding = 12;
 const tableHeaderHeight = 38;
 const pageTopMargin = 72;
-const pageBottomMargin = 12;
+const pageBottomMargin = 24;
 const contentMaxWidth = 768;
 
 const titleFontSize = 18;
@@ -717,6 +718,7 @@ const renderTables = (options: RenderTablesOptions) => {
 
 export async function renderCertificate({
   recipients,
+  envelopeId,
   qrToken,
   hidePoweredBy,
   i18n,
@@ -802,6 +804,16 @@ export async function renderCertificate({
       }
     }
 
+    const footerText = new Konva.Text({
+      x: margin,
+      y: pageHeight - textXs - 10,
+      text: `${i18n._(msg`Envelope ID`)}: ${envelopeId}`,
+      fontFamily: 'Inter',
+      fontSize: textXs,
+      fill: textMutedForegroundLight,
+    });
+    page.add(footerText);
+
     page.add(group);
     stage.add(page);
 
@@ -819,6 +831,16 @@ export async function renderCertificate({
       x: pageWidth - brandingRect.width - margin,
       y: pageTopMargin / 2, // Less padding since there's nothing else on this page.
     } satisfies Partial<Konva.GroupConfig>);
+
+    const overflowFooterText = new Konva.Text({
+      x: margin,
+      y: pageHeight - textXs - 10,
+      text: `${i18n._(msg`Envelope ID`)}: ${envelopeId}`,
+      fontFamily: 'Inter',
+      fontSize: textXs,
+      fill: textMutedForegroundLight,
+    });
+    page.add(overflowFooterText);
 
     page.add(brandingGroup);
     stage.add(page);


### PR DESCRIPTION
## Description

Add envelope IDs to every certificate and audit log page to the bottom left of the page

Notes: Tried other positions (such as under the title, top right, bottom right), but bottom left seems to feel the most out unobtrusive location. 

<img width="419" height="1206" alt="image" src="https://github.com/user-attachments/assets/9df7937a-a7cb-4617-b9ae-984d4eb69d3e" />

## Closeup

<img width="804" height="296" alt="image" src="https://github.com/user-attachments/assets/efcd5aec-e565-42db-ad40-d134e9c2cadf" />

