### PR TITLE
chore: migrate Inngest SDK from v3 to v4 (automated codemod)

### DIFF
--- a/packages/lib/jobs/client/inngest.ts
+++ b/packages/lib/jobs/client/inngest.ts
@@ -42,12 +42,12 @@ export class InngestJobProvider extends BaseJobProvider {
 
     const fn = this._client.createFunction(
       {
-        id: job.id,
+      id: job.id,
         name: job.name,
         optimizeParallelism: job.optimizeParallelism ?? false,
-      },
-      triggerConfig,
-      async (ctx) => {
+      triggers: [triggerConfig],
+    },
+    async (ctx) => {
         const io = this.convertInngestIoToJobRunIo(ctx);
 
         // We need to cast to any so we can deal with parsing later.


### PR DESCRIPTION
## What this does
This PR migrates the Inngest TypeScript SDK from v3 to v4 using an 
automated codemod tool I built called migrate-inngest-v4.

## Changes
- Moves `triggerConfig` from the second argument of `createFunction()` 
  into the options object as `triggers: [triggerConfig]` — required by v4

## How it was generated
This change was automatically applied by running:
npx migrate-inngest-v4 .

The tool is available at: https://github.com/web3smallie/migrate-inngest-v4

## References
- Inngest v3 → v4 migration guide: https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4
- Documenso is currently on inngest@^3.54.0 (see package.json line 65)