### PR TITLE
fix: prevent stored XSS in app banner by removing unsafe HTML rendering

### DIFF
--- a/apps/remix/app/components/general/app-banner.tsx
+++ b/apps/remix/app/components/general/app-banner.tsx
@@ -16,7 +16,7 @@ export const AppBanner = ({ banner }: AppBannerProps) => {
         style={{ color: banner.data.textColor }}
       >
         <div className="flex items-center">
-          <span dangerouslySetInnerHTML={{ __html: banner.data.content }} />
+          <span>{banner.data.content}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixes a stored XSS vulnerability in the app banner component caused by unsafe HTML rendering.

## Related Issue

N/A

## Changes Made

- Removed usage of `dangerouslySetInnerHTML`
- Replaced it with safe text rendering using `{banner.data.content}`
- Eliminated risk of arbitrary HTML/JavaScript execution from banner content

## Testing Performed

- Verified that banner content still renders correctly as text
- Confirmed that HTML tags are no longer interpreted or executed
- Ensured no runtime errors after the change

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

This change prioritizes security by removing support for raw HTML rendering in banner content, preventing potential stored XSS attacks without introducing additional dependencies.