### PR TITLE
fix: improve signature rendering quality with high-resolution caching

### DIFF
--- a/packages/lib/universal/field-renderer/render-signature-field.ts
+++ b/packages/lib/universal/field-renderer/render-signature-field.ts
@@ -41,6 +41,18 @@ const getImageDimensions = (img: HTMLImageElement, fieldWidth: number, fieldHeig
 };
 
 /**
+ * The pixel ratio used when caching the signature image as an offscreen bitmap.
+ *
+ * Konva's default redraw composites the source image with low-quality scaling
+ * which makes signatures look blurry, especially when the source PNG is much
+ * larger than the field. Caching at a high pixel ratio rasterises the shape
+ * once into a sharp bitmap that is then reused on every redraw.
+ *
+ * Multiplied by `devicePixelRatio` to keep the cache crisp on retina displays.
+ */
+const SIGNATURE_IMAGE_CACHE_PIXEL_RATIO = 2;
+
+/**
  * Build a Konva.Image for a base64 signature, sized to fit within the given
  * field dimensions. Works in both browser and Node.js (via skia-canvas).
  */
@@ -64,6 +76,13 @@ const createSignatureImage = (
       image.setAttrs({
         image: img,
         ...getImageDimensions(img, fieldWidth, fieldHeight),
+      });
+
+      // Cache the image as a high-resolution bitmap so it stays sharp on
+      // redraws and zoom changes instead of being re-scaled from the source PNG
+      // every time.
+      image.cache({
+        pixelRatio: SIGNATURE_IMAGE_CACHE_PIXEL_RATIO * (window.devicePixelRatio || 1),
       });
     };
 


### PR DESCRIPTION
## Description

Increase the resolution of the signatures since they are somewhat blurry for different resolutions.

Note this is only an issue on the browser side Konva signature renderer, the signatures inserted into documents are fine.

### Before on external monitor

<img width="236" height="267" alt="image" src="https://github.com/user-attachments/assets/1596c149-99a1-478a-b07b-c5efdc9428b9" />

### After on external monitor 

<img width="236" height="267" alt="image" src="https://github.com/user-attachments/assets/e19d0d6f-8d99-4d6c-a9c6-9c8418f3e480" />

### Before on Mac screen

<img width="486" height="496" alt="image" src="https://github.com/user-attachments/assets/54451da6-cbc4-44b5-8e76-ac25c1c00512" />

### After on Mac screen

<img width="486" height="496" alt="image" src="https://github.com/user-attachments/assets/a7087bd4-26c7-41e9-92ab-459db4373de0" />


