### PR TITLE
feat: notify organisation owner when an invite is declined

### DIFF
--- a/apps/remix/app/routes/_unauthenticated+/organisation.decline.$token.tsx
+++ b/apps/remix/app/routes/_unauthenticated+/organisation.decline.$token.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/react/macro';
 import { OrganisationMemberInviteStatus } from '@prisma/client';
 import { Link } from 'react-router';
 
+import { jobs } from '@documenso/lib/jobs/client';
 import { prisma } from '@documenso/prisma';
 import { Button } from '@documenso/ui/primitives/button';
 
@@ -44,6 +45,13 @@ export async function loader({ params }: Route.LoaderArgs) {
         status: OrganisationMemberInviteStatus.DECLINED,
       },
     });
+    await jobs.triggerJob({
+      name: 'send.organisation-member-declined.email',
+      payload: {
+        organisationId: organisationMemberInvite.organisationId,
+        memberEmail: organisationMemberInvite.email,
+      },
+    });
   }
 
   return {
@@ -63,7 +71,7 @@ export default function DeclineInvitationPage({ loaderData }: Route.ComponentPro
             <Trans>Invalid token</Trans>
           </h1>
 
-          <p className="text-muted-foreground mb-4 mt-2 text-sm">
+          <p className="mb-4 mt-2 text-sm text-muted-foreground">
             <Trans>This token is invalid or has expired. No action is needed.</Trans>
           </p>
 
@@ -83,7 +91,7 @@ export default function DeclineInvitationPage({ loaderData }: Route.ComponentPro
         <Trans>Invitation declined</Trans>
       </h1>
 
-      <p className="text-muted-foreground mb-4 mt-2 text-sm">
+      <p className="mb-4 mt-2 text-sm text-muted-foreground">
         <Trans>
           You have declined the invitation from <strong>{data.organisationName}</strong> to join
           their organisation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "apps/docs/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "apps/docs/node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -5218,9 +5232,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5236,9 +5247,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5256,9 +5264,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5274,9 +5279,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,20 +350,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "apps/docs/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/docs/node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -5232,6 +5218,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5247,6 +5236,9 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5264,6 +5256,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5279,6 +5274,9 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/packages/email/templates/organisation-declined.tsx
+++ b/packages/email/templates/organisation-declined.tsx
@@ -1,0 +1,78 @@
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
+import { Trans } from '@lingui/react/macro';
+
+import { Body, Container, Head, Hr, Html, Img, Preview, Section, Text } from '../components';
+import { useBranding } from '../providers/branding';
+import { TemplateFooter } from '../template-components/template-footer';
+import TemplateImage from '../template-components/template-image';
+
+export type OrganisationDeclinedEmailProps = {
+  assetBaseUrl: string;
+  baseUrl: string;
+  memberEmail: string;
+  organisationName: string;
+  organisationUrl: string;
+};
+
+export const OrganisationDeclinedEmailTemplate = ({
+  assetBaseUrl = 'http://localhost:3002',
+  baseUrl = 'https://documenso.com',
+  memberEmail = 'johndoe@documenso.com',
+  organisationName = 'Organisation Name',
+  organisationUrl = 'demo',
+}: OrganisationDeclinedEmailProps) => {
+  const { _ } = useLingui();
+  const branding = useBranding();
+
+  const previewText = msg`A member has declined your organisation invitation on Documenso`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{_(previewText)}</Preview>
+
+      <Body className="mx-auto my-auto font-sans">
+        <Section className="bg-white text-slate-500">
+          <Container className="mx-auto mb-2 mt-8 max-w-xl rounded-lg border border-solid border-slate-200 p-2 backdrop-blur-sm">
+            {branding.brandingEnabled && branding.brandingLogo ? (
+              <Img src={branding.brandingLogo} alt="Branding Logo" className="mb-4 h-6 p-2" />
+            ) : (
+              <TemplateImage
+                assetBaseUrl={assetBaseUrl}
+                className="mb-4 h-6 p-2"
+                staticAsset="logo.png"
+              />
+            )}
+
+            <Section>
+              <TemplateImage
+                className="mx-auto"
+                assetBaseUrl={assetBaseUrl}
+                staticAsset="add-user.png"
+              />
+            </Section>
+
+            <Section className="p-2 text-slate-500">
+              <Text className="text-center text-lg font-medium text-black">
+                <Trans>An invitation was declined {organisationName}</Trans>
+              </Text>
+
+              <div className="mx-auto my-2 w-fit rounded-lg bg-gray-50 px-4 py-2 text-base font-medium text-slate-600">
+                {memberEmail}
+              </div>
+            </Section>
+          </Container>
+
+          <Hr className="mx-auto mt-12 max-w-xl" />
+
+          <Container className="mx-auto max-w-xl">
+            <TemplateFooter isDocument={false} />
+          </Container>
+        </Section>
+      </Body>
+    </Html>
+  );
+};
+
+export default OrganisationDeclinedEmailTemplate;

--- a/packages/lib/jobs/client.ts
+++ b/packages/lib/jobs/client.ts
@@ -2,6 +2,7 @@ import { JobClient } from './client/client';
 import { SEND_CONFIRMATION_EMAIL_JOB_DEFINITION } from './definitions/emails/send-confirmation-email';
 import { SEND_DOCUMENT_CANCELLED_EMAILS_JOB_DEFINITION } from './definitions/emails/send-document-cancelled-emails';
 import { SEND_DOCUMENT_CREATED_FROM_DIRECT_TEMPLATE_EMAIL_JOB_DEFINITION } from './definitions/emails/send-document-created-from-direct-template-email';
+import { SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-declined-email';
 import { SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-joined-email';
 import { SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-left-email';
 import { SEND_OWNER_RECIPIENT_EXPIRED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-owner-recipient-expired-email';
@@ -31,6 +32,7 @@ export const jobsClient = new JobClient([
   SEND_CONFIRMATION_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION,
+  SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION,
   SEND_TEAM_DELETED_EMAIL_JOB_DEFINITION,
   SEAL_DOCUMENT_JOB_DEFINITION,
   SEAL_DOCUMENT_SWEEP_JOB_DEFINITION,

--- a/packages/lib/jobs/definitions/emails/send-organisation-member-declined-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-member-declined-email.handler.ts
@@ -1,0 +1,99 @@
+import { createElement } from 'react';
+
+import { msg } from '@lingui/core/macro';
+
+import { mailer } from '@documenso/email/mailer';
+import OrganisationDeclinedEmailTemplate from '@documenso/email/templates/organisation-declined';
+import { prisma } from '@documenso/prisma';
+
+import { getI18nInstance } from '../../../client-only/providers/i18n-server';
+import { NEXT_PUBLIC_WEBAPP_URL } from '../../../constants/app';
+import { ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP } from '../../../constants/organisations';
+import { getEmailContext } from '../../../server-only/email/get-email-context';
+import { renderEmailWithI18N } from '../../../utils/render-email-with-i18n';
+import type { JobRunIO } from '../../client/_internal/job';
+import type { TSendOrganisationMemberDeclinedEmailJobDefinition } from './send-organisation-member-declined-email';
+
+export const run = async ({
+  payload,
+  io,
+}: {
+  payload: TSendOrganisationMemberDeclinedEmailJobDefinition;
+  io: JobRunIO;
+}) => {
+  const organisation = await prisma.organisation.findFirstOrThrow({
+    where: {
+      id: payload.organisationId,
+    },
+    include: {
+      members: {
+        where: {
+          organisationGroupMembers: {
+            some: {
+              group: {
+                organisationRole: {
+                  in: ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP['MANAGE_ORGANISATION'],
+                },
+              },
+            },
+          },
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const { branding, emailLanguage, senderEmail } = await getEmailContext({
+    emailType: 'INTERNAL',
+    source: {
+      type: 'organisation',
+      organisationId: organisation.id,
+    },
+  });
+
+  for (const member of organisation.members) {
+    await io.runTask(
+      `send-organisation-member-declined-email--${payload.memberEmail}_${member.id}`,
+      async () => {
+        const emailContent = createElement(OrganisationDeclinedEmailTemplate, {
+          assetBaseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+          baseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+          memberEmail: payload.memberEmail,
+          organisationName: organisation.name,
+          organisationUrl: organisation.url || '',
+        });
+
+        // !: Replace with the actual language of the recipient later
+        const [html, text] = await Promise.all([
+          renderEmailWithI18N(emailContent, {
+            lang: emailLanguage,
+            branding,
+          }),
+          renderEmailWithI18N(emailContent, {
+            lang: emailLanguage,
+            branding,
+            plainText: true,
+          }),
+        ]);
+
+        const i18n = await getI18nInstance(emailLanguage);
+
+        await mailer.sendMail({
+          to: member.user.email,
+          from: senderEmail,
+          subject: i18n._(msg`An organisation invitation was declined`),
+          html,
+          text,
+        });
+      },
+    );
+  }
+};

--- a/packages/lib/jobs/definitions/emails/send-organisation-member-declined-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-member-declined-email.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import type { JobDefinition } from '../../client/_internal/job';
+
+const SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_ID =
+  'send.organisation-member-declined.email';
+
+const SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA = z.object({
+  organisationId: z.string(),
+  memberEmail: z.string().email(),
+});
+
+export type TSendOrganisationMemberDeclinedEmailJobDefinition = z.infer<
+  typeof SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA
+>;
+
+export const SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION = {
+  id: SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  name: 'Send Organisation Member Declined Email',
+  version: '1.0.0',
+  trigger: {
+    name: SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_ID,
+    schema: SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA,
+  },
+  handler: async ({ payload, io }) => {
+    const handler = await import('./send-organisation-member-declined-email.handler');
+    await handler.run({ payload, io });
+  },
+} as const satisfies JobDefinition<
+  typeof SEND_ORGANISATION_MEMBER_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  TSendOrganisationMemberDeclinedEmailJobDefinition
+>;


### PR DESCRIPTION
## Summary
Currently, when an invited member declines an invitation to join an organisation, the organisation owner/admin is not notified. This PR implements a background email notification to ensure owners stay informed about their invitation status.

## Changes
- Created a new React Email template: `OrganisationDeclinedEmailTemplate`.
- Defined a new background job: `send.organisation-member-declined.email`.
- Implemented a job handler to identify organisation admins and send the notification email.
- Updated the invitation decline route to trigger the background job upon a successful status update.

## How to Verify
1. Log in as an organisation owner and invite a new member.
2. Access the invitation link and click the "Decline" button.
3. Verify that the invitation status in the database is updated to `DECLINED`.
4. Check the organisation owner's email inbox (e.g., via Inbucket) to confirm receipt of the "Invitation Declined" notification.

## Screenshots
<img width="1365" height="603" alt="image" src="https://github.com/user-attachments/assets/e5c8c0ec-aeac-4b6b-a207-1e7b164349ab" />

Fixes #2755
