### PR TITLE
fix: send notification email to org owner when invite is declined

### DIFF
--- a/packages/email/templates/organisation-invite-declined.tsx
+++ b/packages/email/templates/organisation-invite-declined.tsx
@@ -1,0 +1,82 @@
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
+import { Trans } from '@lingui/react/macro';
+
+import { Body, Container, Head, Hr, Html, Img, Preview, Section, Text } from '../components';
+import { useBranding } from '../providers/branding';
+import { TemplateFooter } from '../template-components/template-footer';
+import TemplateImage from '../template-components/template-image';
+
+export type OrganisationInviteDeclinedEmailProps = {
+  assetBaseUrl: string;
+  baseUrl: string;
+  inviteeName: string;
+  inviteeEmail: string;
+  organisationName: string;
+  organisationUrl: string;
+};
+
+export const OrganisationInviteDeclinedEmailTemplate = ({
+  assetBaseUrl = 'http://localhost:3002',
+  baseUrl = 'https://documenso.com',
+  inviteeName = 'John Doe',
+  inviteeEmail = 'johndoe@documenso.com',
+  organisationName = 'Organisation Name',
+  organisationUrl = 'demo',
+}: OrganisationInviteDeclinedEmailProps) => {
+  const { _ } = useLingui();
+  const branding = useBranding();
+
+  const previewText = msg`An organisation invitation was declined on Documenso`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{_(previewText)}</Preview>
+
+      <Body className="mx-auto my-auto font-sans">
+        <Section className="bg-white text-slate-500">
+          <Container className="mx-auto mb-2 mt-8 max-w-xl rounded-lg border border-solid border-slate-200 p-2 backdrop-blur-sm">
+            {branding.brandingEnabled && branding.brandingLogo ? (
+              <Img src={branding.brandingLogo} alt="Branding Logo" className="mb-4 h-6 p-2" />
+            ) : (
+              <TemplateImage
+                assetBaseUrl={assetBaseUrl}
+                className="mb-4 h-6 p-2"
+                staticAsset="logo.png"
+              />
+            )}
+
+            <Section>
+              <TemplateImage
+                className="mx-auto"
+                assetBaseUrl={assetBaseUrl}
+                staticAsset="delete-user.png"
+              />
+            </Section>
+
+            <Section className="p-2 text-slate-500">
+              <Text className="text-center text-lg font-medium text-black">
+                <Trans>
+                  An invitation to join your organisation {organisationName} was declined
+                </Trans>
+              </Text>
+
+              <div className="mx-auto my-2 w-fit rounded-lg bg-gray-50 px-4 py-2 text-base font-medium text-slate-600">
+                {inviteeName || inviteeEmail}
+              </div>
+            </Section>
+          </Container>
+
+          <Hr className="mx-auto mt-12 max-w-xl" />
+
+          <Container className="mx-auto max-w-xl">
+            <TemplateFooter isDocument={false} />
+          </Container>
+        </Section>
+      </Body>
+    </Html>
+  );
+};
+
+export default OrganisationInviteDeclinedEmailTemplate;

--- a/packages/lib/jobs/client.ts
+++ b/packages/lib/jobs/client.ts
@@ -5,6 +5,7 @@ import { SEND_DOCUMENT_CANCELLED_EMAILS_JOB_DEFINITION } from './definitions/ema
 import { SEND_DOCUMENT_COMPLETED_EMAILS_JOB_DEFINITION } from './definitions/emails/send-document-completed-emails';
 import { SEND_DOCUMENT_CREATED_FROM_DIRECT_TEMPLATE_EMAIL_JOB_DEFINITION } from './definitions/emails/send-document-created-from-direct-template-email';
 import { SEND_ORGANISATION_LIMIT_EXCEEDED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-limit-exceeded-email';
+import { SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-invite-declined-email';
 import { SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-joined-email';
 import { SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-left-email';
 import { SEND_OWNER_RECIPIENT_EXPIRED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-owner-recipient-expired-email';
@@ -36,6 +37,7 @@ export const jobsClient = new JobClient([
   SEND_SIGNING_EMAIL_JOB_DEFINITION,
   SEND_CONFIRMATION_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION,
+  SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_LIMIT_EXCEEDED_EMAIL_JOB_DEFINITION,
   SEND_TEAM_DELETED_EMAIL_JOB_DEFINITION,

--- a/packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
@@ -1,0 +1,115 @@
+import { createElement } from 'react';
+
+import { msg } from '@lingui/core/macro';
+
+import { mailer } from '@documenso/email/mailer';
+import OrganisationInviteDeclinedEmailTemplate from '@documenso/email/templates/organisation-invite-declined';
+import { prisma } from '@documenso/prisma';
+
+import { getI18nInstance } from '../../../client-only/providers/i18n-server';
+import { NEXT_PUBLIC_WEBAPP_URL } from '../../../constants/app';
+import { ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP } from '../../../constants/organisations';
+import { getEmailContext } from '../../../server-only/email/get-email-context';
+import { renderEmailWithI18N } from '../../../utils/render-email-with-i18n';
+import type { JobRunIO } from '../../client/_internal/job';
+import type { TSendOrganisationMemberInviteDeclinedEmailJobDefinition } from './send-organisation-member-invite-declined-email';
+
+export const run = async ({
+  payload,
+  io,
+}: {
+  payload: TSendOrganisationMemberInviteDeclinedEmailJobDefinition;
+  io: JobRunIO;
+}) => {
+  const organisation = await prisma.organisation.findFirstOrThrow({
+    where: {
+      id: payload.organisationId,
+    },
+    include: {
+      members: {
+        where: {
+          organisationGroupMembers: {
+            some: {
+              group: {
+                organisationRole: {
+                  in: ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP['MANAGE_ORGANISATION'],
+                },
+              },
+            },
+          },
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const inviteeUser = await prisma.user.findFirst({
+    where: {
+      email: {
+        equals: payload.inviteeEmail,
+        mode: 'insensitive',
+      },
+    },
+    select: {
+      name: true,
+      email: true,
+    },
+  });
+
+  const inviteeName = inviteeUser?.name || '';
+  const inviteeEmail = inviteeUser?.email ?? payload.inviteeEmail;
+
+  const { branding, emailLanguage, senderEmail } = await getEmailContext({
+    emailType: 'INTERNAL',
+    source: {
+      type: 'organisation',
+      organisationId: organisation.id,
+    },
+  });
+
+  for (const member of organisation.members) {
+    await io.runTask(
+      `send-organisation-member-invite-declined-email--${payload.inviteId}_${member.id}`,
+      async () => {
+        const emailContent = createElement(OrganisationInviteDeclinedEmailTemplate, {
+          assetBaseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+          baseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+          inviteeName,
+          inviteeEmail,
+          organisationName: organisation.name,
+          organisationUrl: organisation.url,
+        });
+
+        const [html, text] = await Promise.all([
+          renderEmailWithI18N(emailContent, {
+            lang: emailLanguage,
+            branding,
+          }),
+          renderEmailWithI18N(emailContent, {
+            lang: emailLanguage,
+            branding,
+            plainText: true,
+          }),
+        ]);
+
+        const i18n = await getI18nInstance(emailLanguage);
+
+        await mailer.sendMail({
+          to: member.user.email,
+          from: senderEmail,
+          subject: i18n._(msg`An organisation invitation was declined`),
+          html,
+          text,
+        });
+      },
+    );
+  }
+};

--- a/packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+import type { JobDefinition } from '../../client/_internal/job';
+
+const SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID =
+  'send.organisation-member-invite-declined.email';
+
+const SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA = z.object({
+  organisationId: z.string(),
+  inviteId: z.string(),
+  inviteeEmail: z.string(),
+});
+
+export type TSendOrganisationMemberInviteDeclinedEmailJobDefinition = z.infer<
+  typeof SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA
+>;
+
+export const SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION = {
+  id: SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  name: 'Send Organisation Member Invite Declined Email',
+  version: '1.0.0',
+  trigger: {
+    name: SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+    schema: SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA,
+  },
+  handler: async ({ payload, io }) => {
+    const handler = await import('./send-organisation-member-invite-declined-email.handler');
+
+    await handler.run({ payload, io });
+  },
+} as const satisfies JobDefinition<
+  typeof SEND_ORGANISATION_MEMBER_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  TSendOrganisationMemberInviteDeclinedEmailJobDefinition
+>;

--- a/packages/lib/translations/de/web.po
+++ b/packages/lib/translations/de/web.po
@@ -1836,6 +1836,18 @@ msgstr "Ein Fehler ist aufgetreten, während dein Profil aktualisiert wurde."
 msgid "An error occurred while uploading your document."
 msgstr "Ein Fehler ist aufgetreten, während dein Dokument hochgeladen wurde."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut."

--- a/packages/lib/translations/en/web.po
+++ b/packages/lib/translations/en/web.po
@@ -1827,6 +1827,18 @@ msgstr "An error occurred while updating your profile."
 msgid "An error occurred while uploading your document."
 msgstr "An error occurred while uploading your document."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr "An invitation to join your organisation {organisationName} was declined"
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr "An organisation invitation was declined"
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr "An organisation invitation was declined on Documenso"
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "An error occurred. Please try again later."

--- a/packages/lib/translations/es/web.po
+++ b/packages/lib/translations/es/web.po
@@ -1836,6 +1836,18 @@ msgstr "Ocurrió un error al actualizar tu perfil."
 msgid "An error occurred while uploading your document."
 msgstr "Ocurrió un error al subir tu documento."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "Ocurrió un error. Por favor intenta de nuevo más tarde."

--- a/packages/lib/translations/fr/web.po
+++ b/packages/lib/translations/fr/web.po
@@ -1836,6 +1836,18 @@ msgstr "Une erreur est survenue lors de la mise à jour de votre profil."
 msgid "An error occurred while uploading your document."
 msgstr "Une erreur est survenue lors de l'importation de votre document."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "Une erreur s'est produite. Veuillez réessayer plus tard."

--- a/packages/lib/translations/it/web.po
+++ b/packages/lib/translations/it/web.po
@@ -1836,6 +1836,18 @@ msgstr "Si è verificato un errore durante l'aggiornamento del tuo profilo."
 msgid "An error occurred while uploading your document."
 msgstr "Si è verificato un errore durante il caricamento del tuo documento."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "Si è verificato un errore. Per favore riprova più tardi."

--- a/packages/lib/translations/ja/web.po
+++ b/packages/lib/translations/ja/web.po
@@ -1836,6 +1836,18 @@ msgstr "プロフィールの更新中にエラーが発生しました。"
 msgid "An error occurred while uploading your document."
 msgstr "文書のアップロード中にエラーが発生しました。"
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "エラーが発生しました。後でもう一度お試しください。"

--- a/packages/lib/translations/ko/web.po
+++ b/packages/lib/translations/ko/web.po
@@ -1836,6 +1836,18 @@ msgstr "프로필을 업데이트하는 중 오류가 발생했습니다."
 msgid "An error occurred while uploading your document."
 msgstr "문서를 업로드하는 중 오류가 발생했습니다."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "오류가 발생했습니다. 잠시 후 다시 시도해 주세요."

--- a/packages/lib/translations/nl/web.po
+++ b/packages/lib/translations/nl/web.po
@@ -1836,6 +1836,18 @@ msgstr "Er is een fout opgetreden bij het bijwerken van je profiel."
 msgid "An error occurred while uploading your document."
 msgstr "Er is een fout opgetreden bij het uploaden van je document."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "Er is een fout opgetreden. Probeer het later opnieuw."

--- a/packages/lib/translations/pl/web.po
+++ b/packages/lib/translations/pl/web.po
@@ -1840,6 +1840,18 @@ msgstr "Wystąpił błąd podczas przesyłania dokumentu."
 msgid "An error occurred. Please try again later."
 msgstr "Wystąpił błąd. Spróbuj ponownie później."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/routes/_unauthenticated+/organisation.sso.confirmation.$token.tsx
 msgid "An organisation wants to create an account for you. Please review the details below."
 msgstr "Organizacja chce utworzyć konto dla Ciebie. Sprawdź szczegóły poniżej."

--- a/packages/lib/translations/pt-BR/web.po
+++ b/packages/lib/translations/pt-BR/web.po
@@ -1827,6 +1827,18 @@ msgstr "Ocorreu um erro ao atualizar seu perfil."
 msgid "An error occurred while uploading your document."
 msgstr "Ocorreu um erro ao fazer upload do seu documento."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "Ocorreu um erro. Por favor, tente novamente mais tarde."

--- a/packages/lib/translations/sq/web.po
+++ b/packages/lib/translations/sq/web.po
@@ -1219,6 +1219,18 @@ msgstr "Ndodhi një gabim gjatë përditësimit të profilit tuaj."
 msgid "An error occurred while uploading your document."
 msgstr "Ndodhi një gabim gjatë ngarkimit të dokumentit tuaj."
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/general/generic-error-layout.tsx
 msgid "An unexpected error occurred."
 msgstr "Ndodhi një gabim i papritur."

--- a/packages/lib/translations/zh/web.po
+++ b/packages/lib/translations/zh/web.po
@@ -1836,6 +1836,18 @@ msgstr "更新你的资料时发生错误。"
 msgid "An error occurred while uploading your document."
 msgstr "上传文档时发生错误。"
 
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An invitation to join your organisation {organisationName} was declined"
+msgstr ""
+
+#: packages/lib/jobs/definitions/emails/send-organisation-member-invite-declined-email.handler.ts
+msgid "An organisation invitation was declined"
+msgstr ""
+
+#: packages/email/templates/organisation-invite-declined.tsx
+msgid "An organisation invitation was declined on Documenso"
+msgstr ""
+
 #: apps/remix/app/components/forms/support-ticket-form.tsx
 msgid "An error occurred. Please try again later."
 msgstr "发生错误。请稍后重试。"

--- a/packages/trpc/server/organisation-router/decline-organisation-member-invite.ts
+++ b/packages/trpc/server/organisation-router/decline-organisation-member-invite.ts
@@ -1,4 +1,5 @@
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { jobs } from '@documenso/lib/jobs/client';
 import { prisma } from '@documenso/prisma';
 import { OrganisationMemberInviteStatus } from '@prisma/client';
 
@@ -24,6 +25,16 @@ export const declineOrganisationMemberInviteRoute = maybeAuthenticatedProcedure
       throw new AppError(AppErrorCode.NOT_FOUND);
     }
 
+    if (organisationMemberInvite.status === OrganisationMemberInviteStatus.DECLINED) {
+      return;
+    }
+
+    if (organisationMemberInvite.status !== OrganisationMemberInviteStatus.PENDING) {
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: 'Only pending invitations can be declined',
+      });
+    }
+
     await prisma.organisationMemberInvite.update({
       where: {
         id: organisationMemberInvite.id,
@@ -33,5 +44,12 @@ export const declineOrganisationMemberInviteRoute = maybeAuthenticatedProcedure
       },
     });
 
-    // TODO: notify the team owner
+    await jobs.triggerJob({
+      name: 'send.organisation-member-invite-declined.email',
+      payload: {
+        organisationId: organisationMemberInvite.organisationId,
+        inviteId: organisationMemberInvite.id,
+        inviteeEmail: organisationMemberInvite.email,
+      },
+    });
   });


### PR DESCRIPTION
## Problem
When an organization invite is declined by the invitee, the org owner receives no notification email about the decline, leaving them unaware of the status.

## Change
Add a notification email to the org owner when an invite is declined, following the same pattern used for other invite lifecycle events (accepted/expired).

Fixes #2755.

Made with [Cursor](https://cursor.com)