### PR TITLE
feat: track and display last used timestamp for API tokens

### DIFF
--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.tokens.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.tokens.tsx
@@ -90,6 +90,14 @@ export default function ApiTokensPage() {
                           Created on {i18n.date(token.createdAt, DateTime.DATETIME_FULL)}
                         </Trans>
                       </p>
+                      {token.lastUsedAt && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          <Trans>
+                            Last used on {i18n.date(token.lastUsedAt, DateTime.DATETIME_FULL)}
+                          </Trans>
+                        </p>
+                      )}
+
                       {token.expires ? (
                         <p className="mt-1 text-xs text-muted-foreground">
                           <Trans>

--- a/packages/lib/server-only/public-api/get-api-token-by-token.ts
+++ b/packages/lib/server-only/public-api/get-api-token-by-token.ts
@@ -66,6 +66,16 @@ export const getApiTokenByToken = async ({ token }: { token: string }) => {
       statusCode: 401,
     });
   }
+  prisma.apiToken
+    .update({
+      where: {
+        id: apiToken.id,
+      },
+      data: {
+        lastUsedAt: new Date(),
+      },
+    })
+    .catch(() => {});
 
   return {
     ...apiToken,

--- a/packages/lib/server-only/public-api/get-api-tokens.ts
+++ b/packages/lib/server-only/public-api/get-api-tokens.ts
@@ -21,6 +21,7 @@ export const getApiTokens = async ({ userId, teamId }: GetApiTokensOptions) => {
       id: true,
       name: true,
       createdAt: true,
+      lastUsedAt: true,
       expires: true,
     },
     orderBy: {

--- a/packages/prisma/migrations/20260502140739_add_api_token_last_used_at/migration.sql
+++ b/packages/prisma/migrations/20260502140739_add_api_token_last_used_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ApiToken" ADD COLUMN     "lastUsedAt" TIMESTAMP(3);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -226,6 +226,7 @@ model ApiToken {
   algorithm ApiTokenAlgorithm @default(SHA512)
   expires   DateTime?
   createdAt DateTime          @default(now())
+  lastUsedAt DateTime?
   userId    Int?
   user      User?             @relation(fields: [userId], references: [id], onDelete: Cascade)
   teamId    Int

--- a/packages/trpc/server/api-token-router/get-api-tokens.types.ts
+++ b/packages/trpc/server/api-token-router/get-api-tokens.types.ts
@@ -9,7 +9,10 @@ export const ZGetApiTokensResponseSchema = z.array(
     id: true,
     name: true,
     createdAt: true,
+    lastUsedAt: true,
     expires: true,
+  }).extend({
+    lastUsedAt: z.coerce.date().nullable(),
   }),
 );
 


### PR DESCRIPTION
## Description
Hello! This PR implements the `lastUsedAt` field for API tokens to help users track token hygiene and security, as requested in #2756.

## Changes
- **Schema**: Added a nullable `lastUsedAt` DateTime field to the `ApiToken` model.
- **Backend Logic**: Updated `getApiTokenByToken` to perform a non-blocking background write to `lastUsedAt` upon successful token validation. This ensures no additional latency is added to API requests.
- **Data Layer**: Updated the library fetching logic and tRPC Zod schemas to include the new field.
- **UI**: Displayed the "Last used on..." timestamp in the API Tokens list within Team Settings, alongside the creation and expiration dates.

## Why?
This provides admins with a clear signal on whether a token is actively being used or is safe to rotate/delete, aligning with industry standards like GitHub and Stripe.

## Testing
- Verified that the timestamp updates correctly in the background when a token is used via the Public API.
- Verified that the UI displays the date accurately once updated.
- Verified that new tokens (with null timestamps) are handled gracefully by the UI and Zod schemas.

##screenshots
<img width="1030" height="624" alt="image" src="https://github.com/user-attachments/assets/84e89044-a7a4-41f8-a82c-6e204f905aa9" />

Fixes #2756
