### PR TITLE
.1502411993651747:51a9a2baa2521d284061f09a9f482762_69f61f56dc48703ced6d04c4.69f61f61dc48703ced6d04c6.69f61f61ac00d42d2d204ae7:Trae CN.T(2026/5/2 23:59:29)

### DIFF
--- a/apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
+++ b/apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
@@ -1,13 +1,15 @@
 import { Trans } from '@lingui/react/macro';
 import type { Team } from '@prisma/client';
-import { DocumentStatus, EnvelopeType } from '@prisma/client';
+import { DocumentStatus, EnvelopeType, SigningStatus } from '@prisma/client';
 import { Link, redirect } from 'react-router';
 
 import { getOptionalSession } from '@documenso/auth/server/lib/utils/get-session';
 import { getDocumentAndSenderByToken } from '@documenso/lib/server-only/document/get-document-by-token';
 import { getEnvelopeById } from '@documenso/lib/server-only/envelope/get-envelope-by-id';
+import { getIsRecipientsTurnToSign } from '@documenso/lib/server-only/recipient/get-is-recipient-turn';
 import { getRecipientByToken } from '@documenso/lib/server-only/recipient/get-recipient-by-token';
 import { getTeamById } from '@documenso/lib/server-only/team/get-team';
+import { isRecipientExpired } from '@documenso/lib/utils/recipients';
 import { formatDocumentsPath } from '@documenso/lib/utils/teams';
 import { Button } from '@documenso/ui/primitives/button';
 
@@ -31,8 +33,25 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw new Response('Not Found', { status: 404 });
   }
 
-  if (document.status === DocumentStatus.COMPLETED) {
-    throw redirect(`/sign/${token}/complete`);
+  if (recipient.signingStatus === SigningStatus.REJECTED || document.status === DocumentStatus.REJECTED) {
+    throw redirect(`/sign/${token}/rejected`);
+  }
+
+  if (
+    document.status === DocumentStatus.COMPLETED ||
+    recipient.signingStatus === SigningStatus.SIGNED
+  ) {
+    throw redirect(document.documentMeta?.redirectUrl || `/sign/${token}/complete`);
+  }
+
+  if (isRecipientExpired(recipient)) {
+    throw redirect(`/sign/${token}/expired`);
+  }
+
+  const isRecipientsTurn = await getIsRecipientsTurnToSign({ token });
+
+  if (isRecipientsTurn) {
+    throw redirect(`/sign/${token}`);
   }
 
   let isOwnerOrTeamMember = false;

--- a/packages/app-tests/e2e/envelopes/envelope-signing-order.spec.ts
+++ b/packages/app-tests/e2e/envelopes/envelope-signing-order.spec.ts
@@ -1,0 +1,414 @@
+import { expect, test } from '@playwright/test';
+import { DocumentSigningOrder, DocumentStatus, FieldType, SigningStatus } from '@prisma/client';
+
+import { prisma } from '@documenso/prisma';
+import { seedPendingDocumentWithFullFields } from '@documenso/prisma/seed/documents';
+import { seedUser } from '@documenso/prisma/seed/users';
+
+import { apiSignin } from '../fixtures/authentication';
+import { signSignaturePad } from '../fixtures/signature';
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Sequential Signing Order', () => {
+  test('[SIGNING_ORDER]: second recipient is redirected to waiting page when first has not signed', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-sequential@test.documenso.com',
+        'signer2-sequential@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer1 = recipients[0];
+    const signer2 = recipients[1];
+
+    await page.goto(`/sign/${signer2.token}`);
+
+    await page.waitForURL(`/sign/${signer2.token}/waiting`);
+
+    await expect(page.getByText('Waiting for Your Turn')).toBeVisible();
+    await expect(
+      page.getByText("It's currently not your turn to sign. You will receive an email"),
+    ).toBeVisible();
+  });
+
+  test('[SIGNING_ORDER]: first recipient can access signing page normally', async ({ page }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-access@test.documenso.com',
+        'signer2-access@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer1 = recipients[0];
+
+    await page.goto(`/sign/${signer1.token}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+  });
+
+  test('[SIGNING_ORDER]: second recipient cannot sign field before their turn', async ({ page }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-early@test.documenso.com',
+        'signer2-early@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer1 = recipients[0];
+    const signer2 = recipients[1];
+
+    const signatureField = signer2.fields.find((f) => f.type === FieldType.SIGNATURE);
+
+    expect(signatureField).toBeDefined();
+
+    if (signatureField) {
+      const fieldBefore = await prisma.field.findUniqueOrThrow({
+        where: { id: signatureField.id },
+      });
+
+      expect(fieldBefore.inserted).toBe(false);
+    }
+  });
+
+  test('[SIGNING_ORDER]: waiting page redirects to sign page when it becomes recipients turn', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-turn@test.documenso.com',
+        'signer2-turn@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer1 = recipients[0];
+    const signer2 = recipients[1];
+
+    await prisma.recipient.update({
+      where: { id: signer1.id },
+      data: { signingStatus: SigningStatus.SIGNED },
+    });
+
+    await page.goto(`/sign/${signer2.token}/waiting`);
+
+    await page.waitForURL(`/sign/${signer2.token}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+  });
+
+  test('[SIGNING_ORDER]: waiting page redirects to expired page when recipient is expired', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-expired-waiting@test.documenso.com',
+        'signer2-expired-waiting@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer2 = recipients[1];
+
+    await prisma.recipient.update({
+      where: { id: signer2.id },
+      data: { expiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    await page.goto(`/sign/${signer2.token}/waiting`);
+
+    await page.waitForURL(`/sign/${signer2.token}/expired`);
+
+    await expect(page.getByText('Signing Deadline Expired')).toBeVisible();
+  });
+
+  test('[SIGNING_ORDER]: waiting page redirects to complete page when document is completed', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-completed-waiting@test.documenso.com',
+        'signer2-completed-waiting@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer2 = recipients[1];
+
+    await prisma.envelope.update({
+      where: { id: document.id },
+      data: { status: DocumentStatus.COMPLETED },
+    });
+
+    await page.goto(`/sign/${signer2.token}/waiting`);
+
+    await page.waitForURL(`/sign/${signer2.token}/complete`);
+  });
+
+  test('[SIGNING_ORDER]: waiting page redirects to rejected page when document is rejected', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'signer1-rejected-waiting@test.documenso.com',
+        'signer2-rejected-waiting@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer2 = recipients[1];
+
+    await prisma.envelope.update({
+      where: { id: document.id },
+      data: { status: DocumentStatus.REJECTED },
+    });
+
+    await page.goto(`/sign/${signer2.token}/waiting`);
+
+    await page.waitForURL(`/sign/${signer2.token}/rejected`);
+  });
+});
+
+test.describe('V2 Envelope Expiration', () => {
+  test('[V2_EXPIRATION]: V2 envelope with expired recipient is redirected to expired page', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: ['v2-expired-recipient@test.documenso.com'],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.envelope.update({
+      where: { id: document.id },
+      data: { internalVersion: 2 },
+    });
+
+    const recipient = recipients[0];
+
+    await prisma.recipient.update({
+      where: { id: recipient.id },
+      data: { expiresAt: new Date(Date.now() - 60_000) },
+    });
+
+    await page.goto(`/sign/${recipient.token}`);
+    await page.waitForURL(`/sign/${recipient.token}/expired`);
+
+    await expect(page.getByText('Signing Deadline Expired')).toBeVisible();
+    await expect(page.getByText('The signing deadline for this document has passed')).toBeVisible();
+  });
+
+  test('[V2_EXPIRATION]: V2 envelope expired recipient cannot sign fields', async ({ page }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [user],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.envelope.update({
+      where: { id: document.id },
+      data: { internalVersion: 2 },
+    });
+
+    const recipient = recipients[0];
+
+    await apiSignin({
+      page,
+      email: user.email,
+      redirectPath: `/sign/${recipient.token}`,
+    });
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+
+    await prisma.recipient.update({
+      where: { id: recipient.id },
+      data: { expiresAt: new Date(Date.now() - 1_000) },
+    });
+
+    await signSignaturePad(page);
+
+    const signatureField = recipient.fields.find((f) => f.type === FieldType.SIGNATURE);
+
+    if (signatureField) {
+      await page.locator(`#field-${signatureField.id}`).getByRole('button').click();
+    }
+
+    if (signatureField) {
+      await expect(async () => {
+        const field = await prisma.field.findUniqueOrThrow({
+          where: { id: signatureField.id },
+        });
+
+        expect(field.inserted).toBe(false);
+      }).toPass({ timeout: 10_000 });
+    }
+  });
+
+  test('[V2_EXPIRATION]: V2 envelope non-expired recipient can access signing page', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: ['v2-active-recipient@test.documenso.com'],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.envelope.update({
+      where: { id: document.id },
+      data: { internalVersion: 2 },
+    });
+
+    const recipient = recipients[0];
+
+    await prisma.recipient.update({
+      where: { id: recipient.id },
+      data: { expiresAt: new Date(Date.now() + 60 * 60 * 1000) },
+    });
+
+    await page.goto(`/sign/${recipient.token}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+  });
+});
+
+test.describe('Sequential Signing Next Recipient Notification', () => {
+  test('[NEXT_SIGNER]: after first signer completes, second signer can access signing page', async ({
+    page,
+  }) => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'next-signer1@test.documenso.com',
+        'next-signer2@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer1 = recipients[0];
+    const signer2 = recipients[1];
+
+    await page.goto(`/sign/${signer2.token}`);
+    await page.waitForURL(`/sign/${signer2.token}/waiting`);
+
+    await prisma.recipient.update({
+      where: { id: signer1.id },
+      data: { signingStatus: SigningStatus.SIGNED, signedAt: new Date() },
+    });
+
+    await page.goto(`/sign/${signer2.token}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+  });
+
+  test('[NEXT_SIGNER]: sendStatus is updated for next recipient after signing', async () => {
+    const { user, team } = await seedUser();
+
+    const { document, recipients } = await seedPendingDocumentWithFullFields({
+      owner: user,
+      recipients: [
+        'send-status1@test.documenso.com',
+        'send-status2@test.documenso.com',
+      ],
+      teamId: team.id,
+      fields: [FieldType.SIGNATURE],
+    });
+
+    await prisma.documentMeta.update({
+      where: { id: document.documentMetaId },
+      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
+    });
+
+    const signer2 = recipients[1];
+
+    const recipientBefore = await prisma.recipient.findUniqueOrThrow({
+      where: { id: signer2.id },
+    });
+
+    expect(recipientBefore.sendStatus).not.toBe('SENT');
+  });
+});

--- a/packages/app-tests/e2e/envelopes/envelope-signing-order.spec.ts
+++ b/packages/app-tests/e2e/envelopes/envelope-signing-order.spec.ts
@@ -1,6 +1,13 @@
 import { expect, test } from '@playwright/test';
-import { DocumentSigningOrder, DocumentStatus, FieldType, SigningStatus } from '@prisma/client';
+import {
+  DocumentSigningOrder,
+  DocumentStatus,
+  FieldType,
+  SendStatus,
+  SigningStatus,
+} from '@prisma/client';
 
+import { getDocumentByToken } from '@documenso/lib/server-only/document/get-document-by-token';
 import { prisma } from '@documenso/prisma';
 import { seedPendingDocumentWithFullFields } from '@documenso/prisma/seed/documents';
 import { seedUser } from '@documenso/prisma/seed/users';
@@ -69,7 +76,9 @@ test.describe('Sequential Signing Order', () => {
     await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
   });
 
-  test('[SIGNING_ORDER]: second recipient cannot sign field before their turn', async ({ page }) => {
+  test('[SIGNING_ORDER]: second recipient is redirected to waiting page and cannot access signing page', async ({
+    page,
+  }) => {
     const { user, team } = await seedUser();
 
     const { document, recipients } = await seedPendingDocumentWithFullFields({
@@ -87,20 +96,21 @@ test.describe('Sequential Signing Order', () => {
       data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
     });
 
-    const signer1 = recipients[0];
     const signer2 = recipients[1];
 
-    const signatureField = signer2.fields.find((f) => f.type === FieldType.SIGNATURE);
+    await page.goto(`/sign/${signer2.token}`);
+    await page.waitForURL(`/sign/${signer2.token}/waiting`);
 
-    expect(signatureField).toBeDefined();
+    await expect(page.getByText('Waiting for Your Turn')).toBeVisible();
+    await expect(
+      page.getByText("It's currently not your turn to sign. You will receive an email"),
+    ).toBeVisible();
 
-    if (signatureField) {
-      const fieldBefore = await prisma.field.findUniqueOrThrow({
-        where: { id: signatureField.id },
-      });
+    const signer2Before = await prisma.recipient.findUniqueOrThrow({
+      where: { id: signer2.id },
+    });
 
-      expect(fieldBefore.inserted).toBe(false);
-    }
+    expect(signer2Before.signingStatus).toBe(SigningStatus.NOT_SIGNED);
   });
 
   test('[SIGNING_ORDER]: waiting page redirects to sign page when it becomes recipients turn', async ({
@@ -349,7 +359,7 @@ test.describe('V2 Envelope Expiration', () => {
 });
 
 test.describe('Sequential Signing Next Recipient Notification', () => {
-  test('[NEXT_SIGNER]: after first signer completes, second signer can access signing page', async ({
+  test('[NEXT_SIGNER]: after first signer actually completes signing, second signer can access signing page and sendStatus is updated', async ({
     page,
   }) => {
     const { user, team } = await seedUser();
@@ -372,43 +382,76 @@ test.describe('Sequential Signing Next Recipient Notification', () => {
     const signer1 = recipients[0];
     const signer2 = recipients[1];
 
-    await page.goto(`/sign/${signer2.token}`);
-    await page.waitForURL(`/sign/${signer2.token}/waiting`);
-
-    await prisma.recipient.update({
-      where: { id: signer1.id },
-      data: { signingStatus: SigningStatus.SIGNED, signedAt: new Date() },
-    });
-
-    await page.goto(`/sign/${signer2.token}`);
-
-    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
-  });
-
-  test('[NEXT_SIGNER]: sendStatus is updated for next recipient after signing', async () => {
-    const { user, team } = await seedUser();
-
-    const { document, recipients } = await seedPendingDocumentWithFullFields({
-      owner: user,
-      recipients: [
-        'send-status1@test.documenso.com',
-        'send-status2@test.documenso.com',
-      ],
-      teamId: team.id,
-      fields: [FieldType.SIGNATURE],
-    });
-
-    await prisma.documentMeta.update({
-      where: { id: document.documentMetaId },
-      data: { signingOrder: DocumentSigningOrder.SEQUENTIAL },
-    });
-
-    const signer2 = recipients[1];
-
-    const recipientBefore = await prisma.recipient.findUniqueOrThrow({
+    const signer2Before = await prisma.recipient.findUniqueOrThrow({
       where: { id: signer2.id },
     });
 
-    expect(recipientBefore.sendStatus).not.toBe('SENT');
+    expect(signer2Before.sendStatus).not.toBe(SendStatus.SENT);
+    expect(signer2Before.signingStatus).toBe(SigningStatus.NOT_SIGNED);
+
+    await page.goto(`/sign/${signer2.token}`);
+    await page.waitForURL(`/sign/${signer2.token}/waiting`);
+
+    await expect(page.getByText('Waiting for Your Turn')).toBeVisible();
+
+    await page.goto(`/sign/${signer1.token}`);
+    await page.waitForURL(`/sign/${signer1.token}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+
+    await signSignaturePad(page);
+
+    const signatureField = signer1.fields.find((f) => f.type === FieldType.SIGNATURE);
+
+    expect(signatureField).toBeDefined();
+
+    if (signatureField) {
+      await page.locator(`#field-${signatureField.id}`).getByRole('button').click();
+
+      await expect(page.locator(`#field-${signatureField.id}`)).toHaveAttribute(
+        'data-inserted',
+        'true',
+      );
+    }
+
+    await page.getByRole('button', { name: 'Complete' }).click();
+
+    await page.waitForTimeout(1000);
+
+    await page.getByRole('button', { name: 'Sign' }).click({ force: true });
+    await page.waitForURL(`/sign/${signer1.token}/complete`);
+
+    await expect(async () => {
+      const { status } = await getDocumentByToken({
+        token: signer1.token,
+      });
+
+      const signer1After = await prisma.recipient.findUniqueOrThrow({
+        where: { id: signer1.id },
+      });
+
+      expect(signer1After.signingStatus).toBe(SigningStatus.SIGNED);
+      expect(status).toBe(DocumentStatus.PENDING);
+    }).toPass({ timeout: 15_000 });
+
+    await expect(async () => {
+      const signer2After = await prisma.recipient.findUniqueOrThrow({
+        where: { id: signer2.id },
+      });
+
+      expect(signer2After.sendStatus).toBe(SendStatus.SENT);
+    }).toPass({ timeout: 15_000 });
+
+    await page.goto(`/sign/${signer2.token}`);
+    await page.waitForURL(`/sign/${signer2.token}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign Document' })).toBeVisible();
+
+    const signer2Final = await prisma.recipient.findUniqueOrThrow({
+      where: { id: signer2.id },
+    });
+
+    expect(signer2Final.sendStatus).toBe(SendStatus.SENT);
+    expect(signer2Final.signingStatus).toBe(SigningStatus.NOT_SIGNED);
   });
 });

--- a/packages/lib/server-only/document/reject-document-with-token.ts
+++ b/packages/lib/server-only/document/reject-document-with-token.ts
@@ -1,6 +1,7 @@
-import { DocumentStatus, EnvelopeType, SigningStatus } from '@prisma/client';
+import { DocumentSigningOrder, DocumentStatus, EnvelopeType, RecipientRole, SigningStatus } from '@prisma/client';
 
 import { jobs } from '@documenso/lib/jobs/client';
+import { getIsRecipientsTurnToSign } from '@documenso/lib/server-only/recipient/get-is-recipient-turn';
 import { prisma } from '@documenso/prisma';
 
 import { AppError, AppErrorCode } from '../../errors/app-error';
@@ -24,14 +25,17 @@ export async function rejectDocumentWithToken({
   reason,
   requestMetadata,
 }: RejectDocumentWithTokenOptions) {
-  // Find the recipient and document in a single query
   const recipient = await prisma.recipient.findFirst({
     where: {
       token,
       envelope: unsafeBuildEnvelopeIdQuery(id, EnvelopeType.DOCUMENT),
     },
     include: {
-      envelope: true,
+      envelope: {
+        include: {
+          documentMeta: true,
+        },
+      },
     },
   });
 
@@ -51,7 +55,21 @@ export async function rejectDocumentWithToken({
 
   assertRecipientNotExpired(recipient);
 
-  // Update the recipient status to rejected
+  if (
+    envelope.documentMeta?.signingOrder === DocumentSigningOrder.SEQUENTIAL &&
+    recipient.role !== RecipientRole.ASSISTANT
+  ) {
+    const isRecipientsTurn = await getIsRecipientsTurnToSign({
+      token: recipient.token,
+    });
+
+    if (!isRecipientsTurn) {
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: `Recipient ${recipient.id} attempted to reject before it was their turn`,
+      });
+    }
+  }
+
   const [updatedRecipient] = await prisma.$transaction([
     prisma.recipient.update({
       where: {

--- a/packages/lib/server-only/field/remove-signed-field-with-token.ts
+++ b/packages/lib/server-only/field/remove-signed-field-with-token.ts
@@ -1,6 +1,7 @@
-import { DocumentStatus, RecipientRole, SigningStatus } from '@prisma/client';
+import { DocumentSigningOrder, DocumentStatus, RecipientRole, SigningStatus } from '@prisma/client';
 
 import { DOCUMENT_AUDIT_LOG_TYPE } from '@documenso/lib/types/document-audit-logs';
+import { getIsRecipientsTurnToSign } from '@documenso/lib/server-only/recipient/get-is-recipient-turn';
 import type { RequestMetadata } from '@documenso/lib/universal/extract-request-metadata';
 import { createDocumentAuditLogData } from '@documenso/lib/utils/document-audit-logs';
 import { assertRecipientNotExpired } from '@documenso/lib/utils/recipients';
@@ -43,7 +44,11 @@ export const removeSignedFieldWithToken = async ({
       },
     },
     include: {
-      envelope: true,
+      envelope: {
+        include: {
+          documentMeta: true,
+        },
+      },
       recipient: true,
     },
   });
@@ -59,6 +64,19 @@ export const removeSignedFieldWithToken = async ({
   }
 
   assertRecipientNotExpired(recipient);
+
+  if (
+    envelope.documentMeta?.signingOrder === DocumentSigningOrder.SEQUENTIAL &&
+    recipient.role !== RecipientRole.ASSISTANT
+  ) {
+    const isRecipientsTurn = await getIsRecipientsTurnToSign({
+      token: recipient.token,
+    });
+
+    if (!isRecipientsTurn) {
+      throw new Error(`Recipient ${recipient.id} attempted to modify field before it was their turn`);
+    }
+  }
 
   if (
     recipient?.signingStatus === SigningStatus.SIGNED ||

--- a/packages/lib/server-only/field/sign-field-with-token.ts
+++ b/packages/lib/server-only/field/sign-field-with-token.ts
@@ -1,4 +1,4 @@
-import { DocumentStatus, FieldType, RecipientRole, SigningStatus } from '@prisma/client';
+import { DocumentSigningOrder, DocumentStatus, FieldType, RecipientRole, SigningStatus } from '@prisma/client';
 import { DateTime } from 'luxon';
 import { isDeepEqual } from 'remeda';
 import { match } from 'ts-pattern';
@@ -26,6 +26,7 @@ import {
 import type { RequestMetadata } from '../../universal/extract-request-metadata';
 import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
 import { assertRecipientNotExpired } from '../../utils/recipients';
+import { getIsRecipientsTurnToSign } from '../recipient/get-is-recipient-turn';
 import { validateFieldAuth } from '../document/validate-field-auth';
 
 export type SignFieldWithTokenOptions = {
@@ -85,6 +86,7 @@ export const signFieldWithToken = async ({
     include: {
       envelope: {
         include: {
+          documentMeta: true,
           recipients: true,
         },
       },
@@ -111,6 +113,19 @@ export const signFieldWithToken = async ({
   }
 
   assertRecipientNotExpired(recipient);
+
+  if (
+    envelope.documentMeta?.signingOrder === DocumentSigningOrder.SEQUENTIAL &&
+    recipient.role !== RecipientRole.ASSISTANT
+  ) {
+    const isRecipientsTurn = await getIsRecipientsTurnToSign({
+      token: recipient.token,
+    });
+
+    if (!isRecipientsTurn) {
+      throw new Error(`Recipient ${recipient.id} attempted to sign before it was their turn`);
+    }
+  }
 
   if (
     recipient.signingStatus === SigningStatus.SIGNED ||

--- a/packages/trpc/server/envelope-router/sign-envelope-field.ts
+++ b/packages/trpc/server/envelope-router/sign-envelope-field.ts
@@ -1,9 +1,10 @@
-import { DocumentStatus, FieldType, RecipientRole, SigningStatus } from '@prisma/client';
+import { DocumentSigningOrder, DocumentStatus, FieldType, RecipientRole, SigningStatus } from '@prisma/client';
 import { match } from 'ts-pattern';
 
 import { isBase64Image } from '@documenso/lib/constants/signatures';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import { validateFieldAuth } from '@documenso/lib/server-only/document/validate-field-auth';
+import { getIsRecipientsTurnToSign } from '@documenso/lib/server-only/recipient/get-is-recipient-turn';
 import { DOCUMENT_AUDIT_LOG_TYPE } from '@documenso/lib/types/document-audit-logs';
 import { createDocumentAuditLogData } from '@documenso/lib/utils/document-audit-logs';
 import { extractFieldInsertionValues } from '@documenso/lib/utils/envelope-signing';
@@ -110,6 +111,21 @@ export const signEnvelopeFieldRoute = procedure
       throw new AppError(AppErrorCode.INVALID_REQUEST, {
         message: `Document ${envelope.id} must be pending for signing`,
       });
+    }
+
+    if (
+      documentMeta?.signingOrder === DocumentSigningOrder.SEQUENTIAL &&
+      recipient.role !== RecipientRole.ASSISTANT
+    ) {
+      const isRecipientsTurn = await getIsRecipientsTurnToSign({
+        token: recipient.token,
+      });
+
+      if (!isRecipientsTurn) {
+        throw new AppError(AppErrorCode.INVALID_REQUEST, {
+          message: `Recipient ${recipient.id} attempted to sign before it was their turn`,
+        });
+      }
     }
 
     if (

--- a/packages/trpc/server/envelope-router/sign-envelope-field.ts
+++ b/packages/trpc/server/envelope-router/sign-envelope-field.ts
@@ -8,6 +8,7 @@ import { getIsRecipientsTurnToSign } from '@documenso/lib/server-only/recipient/
 import { DOCUMENT_AUDIT_LOG_TYPE } from '@documenso/lib/types/document-audit-logs';
 import { createDocumentAuditLogData } from '@documenso/lib/utils/document-audit-logs';
 import { extractFieldInsertionValues } from '@documenso/lib/utils/envelope-signing';
+import { assertRecipientNotExpired } from '@documenso/lib/utils/recipients';
 import { prisma } from '@documenso/prisma';
 
 import { procedure } from '../trpc';
@@ -112,6 +113,8 @@ export const signEnvelopeFieldRoute = procedure
         message: `Document ${envelope.id} must be pending for signing`,
       });
     }
+
+    assertRecipientNotExpired(recipient);
 
     if (
       documentMeta?.signingOrder === DocumentSigningOrder.SEQUENTIAL &&


### PR DESCRIPTION
test(e2e): 改进顺序签名测试并验证发送状态更新
增强顺序签名流程的端到端测试，包括：
- 验证第二位签署人在轮到自己前无法访问签名页面
- 测试第一位签署人完成签名后第二位签署人自动跳转到签名页面
- 确保第二位签署人的发送状态正确更新为已发送