### PR TITLE
fix: sanitize cmdk values to prevent DOMException with double quotes

### DIFF
--- a/apps/remix/app/components/general/envelope-editor/envelope-recipient-selector.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-recipient-selector.tsx
@@ -4,7 +4,14 @@ import { canRecipientFieldsBeModified } from '@documenso/lib/utils/recipients';
 import { getRecipientColorStyles } from '@documenso/ui/lib/recipient-colors';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '@documenso/ui/primitives/command';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@documenso/ui/primitives/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@documenso/ui/primitives/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@documenso/ui/primitives/tooltip';
 import type { I18n } from '@lingui/core';
@@ -143,80 +150,89 @@ export const EnvelopeRecipientSelectorCommand = ({
   );
 
   return (
-    <Command value={selectedRecipient ? selectedRecipient.id.toString() : undefined} className={className}>
+    <Command className={className}>
       <CommandInput placeholder={placeholder} />
 
-      <CommandEmpty>
-        <span className="inline-block px-4 text-muted-foreground">
-          <Trans>No recipient matching this description was found.</Trans>
-        </span>
-      </CommandEmpty>
+      <CommandList>
+        <CommandEmpty>
+          <span className="inline-block px-4 text-muted-foreground">
+            <Trans>No recipient matching this description was found.</Trans>
+          </span>
+        </CommandEmpty>
 
-      {recipientsByRoleToDisplay().map(([role, roleRecipients], roleIndex) => (
-        <CommandGroup key={roleIndex}>
-          <div className="mt-2 mb-1 ml-2 font-medium text-muted-foreground text-xs">
-            {t(RECIPIENT_ROLES_DESCRIPTION[role].roleNamePlural)}
-          </div>
-
-          {roleRecipients.length === 0 && (
-            <div key={`${role}-empty`} className="px-4 pt-2.5 pb-4 text-center text-muted-foreground/80 text-xs">
-              <Trans>No recipients with this role</Trans>
+        {recipientsByRoleToDisplay().map(([role, roleRecipients], roleIndex) => (
+          <CommandGroup key={roleIndex}>
+            <div className="mt-2 mb-1 ml-2 font-medium text-muted-foreground text-xs">
+              {t(RECIPIENT_ROLES_DESCRIPTION[role].roleNamePlural)}
             </div>
-          )}
 
-          {roleRecipients.map((recipient) => (
-            <CommandItem
-              key={recipient.id}
-              className={cn(
-                'px-2 last:mb-1 [&:not(:first-child)]:mt-1',
-                getRecipientColorStyles(recipients.findIndex((r) => r.id === recipient.id)).comboBoxItem,
-                {
-                  'text-muted-foreground': recipient.sendStatus === SendStatus.SENT,
-                  'cursor-not-allowed': isRecipientDisabled(recipient.id),
-                },
-              )}
-              onSelect={() => {
-                if (!isRecipientDisabled(recipient.id)) {
-                  onSelectedRecipientChange(recipient);
-                }
-              }}
-            >
-              <span
-                className={cn('truncate text-foreground/70', {
-                  'text-foreground/80': recipient.id === selectedRecipient?.id,
-                  'opacity-50': isRecipientDisabled(recipient.id),
-                })}
-              >
-                {getRecipientLabel(recipient)}
-              </span>
-
-              <div className="ml-auto flex items-center justify-center">
-                {!isRecipientDisabled(recipient.id) ? (
-                  <Check
-                    aria-hidden={recipient.id !== selectedRecipient?.id}
-                    className={cn('h-4 w-4 flex-shrink-0', {
-                      'opacity-0': recipient.id !== selectedRecipient?.id,
-                      'opacity-100': recipient.id === selectedRecipient?.id,
-                    })}
-                  />
-                ) : (
-                  <Tooltip>
-                    <TooltipTrigger disabled={false}>
-                      <Info className="z-50 ml-2 h-4 w-4" />
-                    </TooltipTrigger>
-
-                    <TooltipContent className="max-w-xs text-muted-foreground">
-                      <Trans>
-                        This document has already been sent to this recipient. You can no longer edit this recipient.
-                      </Trans>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
+            {roleRecipients.length === 0 && (
+              <div key={`${role}-empty`} className="px-4 pt-2.5 pb-4 text-center text-muted-foreground/80 text-xs">
+                <Trans>No recipients with this role</Trans>
               </div>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      ))}
+            )}
+
+            {roleRecipients.map((recipient) => (
+              <CommandItem
+                key={recipient.id}
+                value={`id-${recipient.id.toString()}`}
+                keywords={[`${recipient.name} ${recipient.email}`]}
+                className={cn(
+                  'px-2 last:mb-1 [&:not(:first-child)]:mt-1',
+                  getRecipientColorStyles(recipients.findIndex((r) => r.id === recipient.id)).comboBoxItem,
+                  {
+                    'text-muted-foreground': recipient.sendStatus === SendStatus.SENT,
+                    'cursor-not-allowed': isRecipientDisabled(recipient.id),
+                  },
+                )}
+                onClick={() => {
+                  if (!isRecipientDisabled(recipient.id)) {
+                    onSelectedRecipientChange(recipient);
+                  }
+                }}
+                onSelect={() => {
+                  if (!isRecipientDisabled(recipient.id)) {
+                    onSelectedRecipientChange(recipient);
+                  }
+                }}
+              >
+                <span
+                  className={cn('truncate text-foreground/70', {
+                    'text-foreground/80': recipient.id === selectedRecipient?.id,
+                    'opacity-50': isRecipientDisabled(recipient.id),
+                  })}
+                >
+                  {getRecipientLabel(recipient)}
+                </span>
+
+                <div className="ml-auto flex items-center justify-center">
+                  {!isRecipientDisabled(recipient.id) ? (
+                    <Check
+                      aria-hidden={recipient.id !== selectedRecipient?.id}
+                      className={cn('h-4 w-4 flex-shrink-0', {
+                        'opacity-0': recipient.id !== selectedRecipient?.id,
+                        'opacity-100': recipient.id === selectedRecipient?.id,
+                      })}
+                    />
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger disabled={false}>
+                        <Info className="z-50 ml-2 h-4 w-4" />
+                      </TooltipTrigger>
+
+                      <TooltipContent className="max-w-xs text-muted-foreground">
+                        <Trans>
+                          This document has already been sent to this recipient. You can no longer edit this recipient.
+                        </Trans>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
     </Command>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,6 +349,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "apps/docs/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "apps/docs/node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -2299,9 +2313,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2319,9 +2330,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2339,9 +2347,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2359,9 +2364,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -5213,9 +5215,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5231,9 +5230,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5251,9 +5247,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5269,9 +5262,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -15631,269 +15621,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cmdk": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-0.2.1.tgz",
-      "integrity": "sha512-U6//9lQ6JvT47+6OF6Gi8BvkxYQ8SCRRSKIJkthIMsFsLZRG0cKvTtuTaefyIKMQb8rvvXy0wGdpTNq/jPtm+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-dialog": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-dialog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.0.tgz",
-      "integrity": "sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-dismissable-layer": "1.0.0",
-        "@radix-ui/react-focus-guards": "1.0.0",
-        "@radix-ui/react-focus-scope": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-portal": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.0",
-        "@radix-ui/react-slot": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.4"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
-      "integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.0",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-escape-keydown": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
-      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.0.tgz",
-      "integrity": "sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.0",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-portal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.0.tgz",
-      "integrity": "sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
-      "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-slot": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
-      "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.0.tgz",
-      "integrity": "sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/cmdk/node_modules/react-remove-scroll": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
-      "integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.3",
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/co-body": {
@@ -30836,7 +30563,7 @@
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^1.2.1",
-        "cmdk": "^0.2.1",
+        "cmdk": "^1.1.1",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.554.0",
         "luxon": "^3.7.2",
@@ -30862,6 +30589,22 @@
         "@types/react-dom": "^18",
         "react": "^18",
         "typescript": "5.6.2"
+      }
+    },
+    "packages/ui/node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     }
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,7 +60,7 @@
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
-    "cmdk": "^0.2.1",
+    "cmdk": "^1.1.1",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.554.0",
     "luxon": "^3.7.2",

--- a/packages/ui/primitives/command.tsx
+++ b/packages/ui/primitives/command.tsx
@@ -9,16 +9,23 @@ import { Dialog, DialogContent } from './dialog';
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive
-    ref={ref}
-    className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
-      className,
-    )}
-    {...props}
-  />
-));
+>(({ className, value, ...props }, ref) => {
+  const sanitizedValue = React.useMemo(() => {
+    return typeof value === 'string' ? value.replace(/"/g, '') : value;
+  }, [value]);
+
+  return (
+    <CommandPrimitive
+      ref={ref}
+      value={sanitizedValue}
+      className={cn(
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
 
 Command.displayName = CommandPrimitive.displayName;
 
@@ -141,16 +148,23 @@ CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className,
-    )}
-    {...props}
-  />
-));
+>(({ className, value, ...props }, ref) => {
+  const sanitizedValue = React.useMemo(() => {
+    return typeof value === 'string' ? value.replace(/"/g, '') : value;
+  }, [value]);
+
+  return (
+    <CommandPrimitive.Item
+      ref={ref}
+      value={sanitizedValue}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
 
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 

--- a/packages/ui/primitives/recipient-selector.tsx
+++ b/packages/ui/primitives/recipient-selector.tsx
@@ -10,7 +10,7 @@ import { sortBy } from 'remeda';
 import { getRecipientColorStyles } from '../lib/recipient-colors';
 import { cn } from '../lib/utils';
 import { Button } from './button';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from './command';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './command';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
 
@@ -106,79 +106,87 @@ export const RecipientSelector = ({
       </PopoverTrigger>
 
       <PopoverContent className="p-0" align={align}>
-        <Command value={selectedRecipient ? selectedRecipient.id.toString() : undefined}>
+        <Command>
           <CommandInput />
 
-          <CommandEmpty>
-            <span className="inline-block px-4 text-muted-foreground">
-              <Trans>No recipient matching this description was found.</Trans>
-            </span>
-          </CommandEmpty>
+          <CommandList>
+            <CommandEmpty>
+              <span className="inline-block px-4 text-muted-foreground">
+                <Trans>No recipient matching this description was found.</Trans>
+              </span>
+            </CommandEmpty>
 
-          {recipientsByRoleToDisplay.map(([role, roleRecipients], roleIndex) => (
-            <CommandGroup key={roleIndex}>
-              <div className="mt-2 mb-1 ml-2 font-medium text-muted-foreground text-xs">
-                {_(RECIPIENT_ROLES_DESCRIPTION[role].roleNamePlural)}
-              </div>
-
-              {roleRecipients.length === 0 && (
-                <div key={`${role}-empty`} className="px-4 pt-2.5 pb-4 text-center text-muted-foreground/80 text-xs">
-                  <Trans>No recipients with this role</Trans>
+            {recipientsByRoleToDisplay.map(([role, roleRecipients], roleIndex) => (
+              <CommandGroup key={roleIndex}>
+                <div className="mt-2 mb-1 ml-2 font-medium text-muted-foreground text-xs">
+                  {_(RECIPIENT_ROLES_DESCRIPTION[role].roleNamePlural)}
                 </div>
-              )}
 
-              {roleRecipients.map((recipient) => (
-                <CommandItem
-                  key={recipient.id}
-                  className={cn(
-                    'px-2 last:mb-1 [&:not(:first-child)]:mt-1',
-                    getRecipientColorStyles(recipients.findIndex((r) => r.id === recipient.id)).comboBoxItem,
-                    {
-                      'text-muted-foreground': recipient.sendStatus === SendStatus.SENT,
-                    },
-                  )}
-                  onSelect={() => {
-                    onSelectedRecipientChange(recipient);
-                    setShowRecipientsSelector(false);
-                  }}
-                  disabled={recipient.signingStatus !== SigningStatus.NOT_SIGNED}
-                >
-                  <span
-                    className={cn('truncate text-foreground/70', {
-                      'text-foreground/80': recipient.id === selectedRecipient?.id,
-                    })}
-                  >
-                    {getRecipientLabel(recipient)}
-                  </span>
-
-                  <div className="ml-auto flex items-center justify-center">
-                    {recipient.sendStatus !== SendStatus.SENT ? (
-                      <Check
-                        aria-hidden={recipient.id !== selectedRecipient?.id}
-                        className={cn('h-4 w-4 flex-shrink-0', {
-                          'opacity-0': recipient.id !== selectedRecipient?.id,
-                          'opacity-100': recipient.id === selectedRecipient?.id,
-                        })}
-                      />
-                    ) : (
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <Info className="ml-2 h-4 w-4" />
-                        </TooltipTrigger>
-
-                        <TooltipContent className="max-w-xs text-muted-foreground">
-                          <Trans>
-                            This document has already been sent to this recipient. You can no longer edit this
-                            recipient.
-                          </Trans>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
+                {roleRecipients.length === 0 && (
+                  <div key={`${role}-empty`} className="px-4 pt-2.5 pb-4 text-center text-muted-foreground/80 text-xs">
+                    <Trans>No recipients with this role</Trans>
                   </div>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          ))}
+                )}
+
+                {roleRecipients.map((recipient) => (
+                  <CommandItem
+                    key={recipient.id}
+                    value={`id-${recipient.id.toString()}`}
+                    keywords={[`${recipient.name} ${recipient.email}`]}
+                    className={cn(
+                      'px-2 last:mb-1 [&:not(:first-child)]:mt-1',
+                      getRecipientColorStyles(recipients.findIndex((r) => r.id === recipient.id)).comboBoxItem,
+                      {
+                        'text-muted-foreground': recipient.sendStatus === SendStatus.SENT,
+                      },
+                    )}
+                    onClick={() => {
+                      onSelectedRecipientChange(recipient);
+                      setShowRecipientsSelector(false);
+                    }}
+                    onSelect={() => {
+                      onSelectedRecipientChange(recipient);
+                      setShowRecipientsSelector(false);
+                    }}
+                    disabled={recipient.signingStatus !== SigningStatus.NOT_SIGNED}
+                  >
+                    <span
+                      className={cn('truncate text-foreground/70', {
+                        'text-foreground/80': recipient.id === selectedRecipient?.id,
+                      })}
+                    >
+                      {getRecipientLabel(recipient)}
+                    </span>
+
+                    <div className="ml-auto flex items-center justify-center">
+                      {recipient.sendStatus !== SendStatus.SENT ? (
+                        <Check
+                          aria-hidden={recipient.id !== selectedRecipient?.id}
+                          className={cn('h-4 w-4 flex-shrink-0', {
+                            'opacity-0': recipient.id !== selectedRecipient?.id,
+                            'opacity-100': recipient.id === selectedRecipient?.id,
+                          })}
+                        />
+                      ) : (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Info className="ml-2 h-4 w-4" />
+                          </TooltipTrigger>
+
+                          <TooltipContent className="max-w-xs text-muted-foreground">
+                            <Trans>
+                              This document has already been sent to this recipient. You can no longer edit this
+                              recipient.
+                            </Trans>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
         </Command>
       </PopoverContent>
     </Popover>

--- a/packages/ui/primitives/template-flow/add-template-fields.tsx
+++ b/packages/ui/primitives/template-flow/add-template-fields.tsx
@@ -12,7 +12,14 @@ import { parseMessageDescriptor } from '@documenso/lib/utils/i18n';
 import { cn } from '@documenso/ui/lib/utils';
 import { Button } from '@documenso/ui/primitives/button';
 import { Card, CardContent } from '@documenso/ui/primitives/card';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '@documenso/ui/primitives/command';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@documenso/ui/primitives/command';
 import {
   DocumentFlowFormContainerActions,
   DocumentFlowFormContainerContent,
@@ -612,66 +619,75 @@ export const AddTemplateFieldsFormPartial = ({
                 </PopoverTrigger>
 
                 <PopoverContent className="p-0" align="start">
-                  <Command value={selectedSigner?.email}>
+                  <Command>
                     <CommandInput />
 
-                    <CommandEmpty>
-                      <span className="inline-block px-4 text-muted-foreground">
-                        <Trans>No recipient matching this description was found.</Trans>
-                      </span>
-                    </CommandEmpty>
+                    <CommandList>
+                      <CommandEmpty>
+                        <span className="inline-block px-4 text-muted-foreground">
+                          <Trans>No recipient matching this description was found.</Trans>
+                        </span>
+                      </CommandEmpty>
 
-                    {/* Note: This is duplicated in `add-fields.tsx` */}
-                    {recipientsByRoleToDisplay.map(([role, roleRecipients], roleIndex) => (
-                      <CommandGroup key={roleIndex}>
-                        <div className="mt-2 mb-1 ml-2 font-medium text-muted-foreground text-xs">
-                          {_(RECIPIENT_ROLES_DESCRIPTION[role].roleNamePlural)}
-                        </div>
-
-                        {roleRecipients.length === 0 && (
-                          <div
-                            key={`${role}-empty`}
-                            className="px-4 pt-2.5 pb-4 text-center text-muted-foreground/80 text-xs"
-                          >
-                            <Trans>No recipients with this role</Trans>
+                      {/* Note: This is duplicated in `add-fields.tsx` */}
+                      {recipientsByRoleToDisplay.map(([role, roleRecipients], roleIndex) => (
+                        <CommandGroup key={roleIndex}>
+                          <div className="mt-2 mb-1 ml-2 font-medium text-muted-foreground text-xs">
+                            {_(RECIPIENT_ROLES_DESCRIPTION[role].roleNamePlural)}
                           </div>
-                        )}
 
-                        {roleRecipients.map((recipient) => (
-                          <CommandItem
-                            key={recipient.id}
-                            className={cn(
-                              'px-2 last:mb-1 [&:not(:first-child)]:mt-1',
-                              getRecipientColorStyles(recipients.findIndex((r) => r.id === recipient.id))?.comboBoxItem,
-                            )}
-                            onSelect={() => {
-                              setSelectedSigner(recipient);
-                              setShowRecipientsSelector(false);
-                            }}
-                          >
-                            <span
-                              className={cn('truncate text-foreground/70', {
-                                'text-foreground/80': recipient === selectedSigner,
-                              })}
+                          {roleRecipients.length === 0 && (
+                            <div
+                              key={`${role}-empty`}
+                              className="px-4 pt-2.5 pb-4 text-center text-muted-foreground/80 text-xs"
                             >
-                              {recipient.name && !isTemplateRecipientEmailPlaceholder(recipient.email) && (
-                                <span title={`${recipient.name} (${recipient.email})`}>
-                                  {recipient.name} ({recipient.email})
-                                </span>
-                              )}
+                              <Trans>No recipients with this role</Trans>
+                            </div>
+                          )}
 
-                              {recipient.name && isTemplateRecipientEmailPlaceholder(recipient.email) && (
-                                <span title={recipient.name}>{recipient.name}</span>
+                          {roleRecipients.map((recipient) => (
+                            <CommandItem
+                              key={recipient.id}
+                              value={`id-${recipient.id.toString()}`}
+                              keywords={[`${recipient.name} ${recipient.email}`]}
+                              className={cn(
+                                'px-2 last:mb-1 [&:not(:first-child)]:mt-1',
+                                getRecipientColorStyles(recipients.findIndex((r) => r.id === recipient.id))
+                                  ?.comboBoxItem,
                               )}
+                              onClick={() => {
+                                setSelectedSigner(recipient);
+                                setShowRecipientsSelector(false);
+                              }}
+                              onSelect={() => {
+                                setSelectedSigner(recipient);
+                                setShowRecipientsSelector(false);
+                              }}
+                            >
+                              <span
+                                className={cn('truncate text-foreground/70', {
+                                  'text-foreground/80': recipient === selectedSigner,
+                                })}
+                              >
+                                {recipient.name && !isTemplateRecipientEmailPlaceholder(recipient.email) && (
+                                  <span title={`${recipient.name} (${recipient.email})`}>
+                                    {recipient.name} ({recipient.email})
+                                  </span>
+                                )}
 
-                              {!recipient.name && !isTemplateRecipientEmailPlaceholder(recipient.email) && (
-                                <span title={recipient.email}>{recipient.email}</span>
-                              )}
-                            </span>
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    ))}
+                                {recipient.name && isTemplateRecipientEmailPlaceholder(recipient.email) && (
+                                  <span title={recipient.name}>{recipient.name}</span>
+                                )}
+
+                                {!recipient.name && !isTemplateRecipientEmailPlaceholder(recipient.email) && (
+                                  <span title={recipient.email}>{recipient.email}</span>
+                                )}
+                              </span>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      ))}
+                    </CommandList>
                   </Command>
                 </PopoverContent>
               </Popover>


### PR DESCRIPTION
## Problem
In `cmdk@0.2.1`, using a string with double quotes (like a recipient's name) as a `value` or text content for a `CommandItem` triggers a `DOMException`. This is because the library uses that value to build a CSS selector internally. In our Remix environment, this exception causes a complete app crash and a **500 Internal Server Error**.

## Solution
Following maintainer feedback, I have implemented a cleaner, centralized solution:
1. **Upgraded `cmdk` to `v1.1.1`**: Updated the dependency in `packages/ui`.
2. **Centralized Sanitization**: Since `cmdk v1.1.1` still exhibits the same CSS selector bug with double quotes, I moved the sanitization logic directly into the `CommandItem` primitive in `packages/ui/primitives/command.tsx`.
Now, any `CommandItem` used throughout the app will automatically strip double quotes from its `value` prop before passing it to the underlying library. This fixes the crash globally while keeping the code in individual components clean and readable.

## Visual Changes
## Before (Crash) 
<img width="1365" height="627" alt="image" src="https://github.com/user-attachments/assets/9f332b54-4e5c-4417-9156-9b72947b5830" />

## After (Fixed) 
<img width="1361" height="631" alt="image" src="https://github.com/user-attachments/assets/d30511a3-770d-42fb-9e27-a3bbf70ee953" />

## Key Changes
- **Dependency Update**: `cmdk` upgraded to `1.1.1`.
- **Core Primitive Update**: `CommandItem` now automatically handles quote sanitization for the `value` prop.
- **Improved Coverage**: Ensured `value` props are explicitly passed in critical areas (recipient selector, template flow) to trigger the automated fix.
## Verification
1. Created a recipient named `Test "Quote" User`.
2. Verified that opening the recipient selector no longer triggers a 500 error.
3. Verified that search still finds the user correctly.



Fixes #2779 
