### PR TITLE
refactor: remove unnecessary DateRange type assertion

### DIFF
--- a/apps/remix/app/components/filters/date-range-filter.tsx
+++ b/apps/remix/app/components/filters/date-range-filter.tsx
@@ -14,10 +14,10 @@ export const DateRangeFilter = ({ currentRange }: DateRangeFilterProps) => {
   const [isPending, startTransition] = useTransition();
   const updateSearchParams = useUpdateSearchParams();
 
-  const handleRangeChange = (value: string) => {
+  const handleRangeChange = (value: DateRange) => {
     startTransition(() => {
       updateSearchParams({
-        dateRange: value as DateRange,
+        dateRange: value,
         page: 1,
       });
     });


### PR DESCRIPTION
## Summary

Removes an unnecessary `as DateRange` type assertion since the `value`
parameter is already typed as `DateRange`.

## Changes

* Updated `handleRangeChange` parameter typing
* Removed redundant type assertion
