### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+Thanks for taking the time to help keep this project and its users safe.
+
+## Supported versions
+
+We accept reports against the latest released version and the current `main` / `master` branch. Older versions are best-effort.
+
+| Version | Supported |
+|---|---|
+| Latest release | yes |
+| `main` / `master` | yes |
+| Previous minor | best-effort |
+| Older | no |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue, discussion, or pull request for security bugs.** Use one of the following private channels instead:
+
+- **Preferred:** GitHub Private Vulnerability Reporting at <https://github.com/documenso/documenso/security/advisories/new>
+- **Email:** `security@documenso.com`
+
+In your report, please include:
+
+- A clear description of the issue and its impact.
+- Steps to reproduce, or a minimal proof-of-concept. Self-contained PoCs help us triage quickly.
+- The affected version(s) and platform.
+- Suggested remediation, if you have one.
+
+## What to expect
+
+- **Acknowledgement:** within 5 business days.
+- **Triage and initial assessment:** within 7 business days, including a severity estimate (CVSS v3.1) and a target fix timeline.
+- **Status updates:** at least every 14 days while the report is open.
+- **Fix and coordinated disclosure:** the embargo length depends on severity. We aim for a patched release within 90 days; critical issues are prioritized.
+
+If you do not hear back within the acknowledgement window, please escalate by replying to the same thread or contacting the email address above.
+
+## Scope
+
+In scope:
+
+- The code in this repository.
+- Official release artifacts (binaries, container images) published from this repository.
+- Configuration defaults shipped in this repository.
+
+Out of scope (please report these upstream instead):
+
+- Vulnerabilities in third-party dependencies that are not reachable from any code path in this project.
+- Issues in users' self-hosted infrastructure that are unrelated to this project's code (network exposure, weak operator passwords, etc.).
+- Reports generated solely by automated scanners with no demonstrated impact.
+
+## Coordinated disclosure
+
+We follow responsible disclosure. Please give us a reasonable window to ship a fix before any public discussion. We will credit reporters in the published advisory unless they request otherwise along with creating a CVE for the report.


### PR DESCRIPTION
Expanded the security policy to include detailed reporting guidelines and expectations for vulnerability reporting using Github.

I saw that this is officially documented at https://docs.documenso.com/docs/policies/security with a link to GitHub security advisories but currently this project does not accept reports this way due to a lacking SECURITY.MD

I was not sure if this was intended or not so made a rough copy but did see an older request at https://github.com/documenso/documenso/pull/2213 which was only denied from them not having signed your license.

I've added CVE's to be made if the report is valid and published to give credit to the researchers.

Please review the timelines and if they're acceptable or not or any changes that might be useful.