### PR TITLE
chore: update docs to use editor instead of authoring

### DIFF
--- a/apps/docs/content/docs/developers/embedding/editor/index.mdx
+++ b/apps/docs/content/docs/developers/embedding/editor/index.mdx
@@ -1,24 +1,24 @@
 ---
-title: Authoring
+title: Editor
 description: Embed document, template, and envelope creation directly in your application.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-In addition to embedding signing, Documenso supports embedded authoring. It allows your users to create and edit documents, templates, and envelopes without leaving your application.
+In addition to embedding signing, Documenso supports embedded editor. It allows your users to create and edit documents, templates, and envelopes without leaving your application.
 
 <Callout type="warn">
-  Embedded authoring is included with [Enterprise](https://documen.so/enterprise-cta) plans. It is
+  Embedded editor is included with [Enterprise](https://documen.so/enterprise-cta) plans. It is
   also available as a paid add-on for the [Platform Plan](https://documen.so/platform-cta-pricing).
   Contact sales for access.
 </Callout>
 
 ## Versions
 
-Embedded authoring is available in two versions:
+Embedded editor is available in two versions:
 
-- **[V1 Authoring](/docs/developers/embedding/authoring/v1)** — Works with V1 Documents and Templates.
-- **[V2 Authoring](/docs/developers/embedding/authoring/v2)** — Works with Envelopes, which are the unified model for documents and templates.
+- **[V1 Editor](/docs/developers/embedding/editor/v1)** — Works with V1 Documents and Templates.
+- **[V2 Editor](/docs/developers/embedding/editor/v2)** — Works with Envelopes, which are the unified model for documents and templates.
 
 ### Comparison
 
@@ -32,7 +32,7 @@ Embedded authoring is available in two versions:
 
 ## Presign Tokens
 
-Before using any authoring component, obtain a presign token from your backend:
+Before using any editor component, obtain a presign token from your backend:
 
 ```
 POST /api/v2/embedding/create-presign-token
@@ -50,7 +50,7 @@ See the [API documentation](https://openapi.documenso.com/reference#tag/embeddin
 
 ## Next Steps
 
-- [V1 Authoring](/docs/developers/embedding/authoring/v1) — Create and edit documents and templates using V1 components
-- [V2 Authoring](/docs/developers/embedding/authoring/v2) — Create and edit envelopes using V2 components
+- [V1 Editor](/docs/developers/embedding/editor/v1) — Create and edit documents and templates using V1 components
+- [V2 Editor](/docs/developers/embedding/editor/v2) — Create and edit envelopes using V2 components
 - [CSS Variables](/docs/developers/embedding/css-variables) — Customize the appearance of embedded components
 - [SDKs](/docs/developers/embedding/sdks) — Framework-specific SDK documentation

--- a/apps/docs/content/docs/developers/embedding/editor/meta.json
+++ b/apps/docs/content/docs/developers/embedding/editor/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Authoring",
+  "title": "Editor",
   "pages": ["v1", "v2"]
 }

--- a/apps/docs/content/docs/developers/embedding/editor/v1.mdx
+++ b/apps/docs/content/docs/developers/embedding/editor/v1.mdx
@@ -1,21 +1,21 @@
 ---
-title: V1 Authoring
+title: V1 Editor
 description: Embed V1 document and template creation directly in your application.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-V1 authoring components allow your users to create and edit documents and templates using the V1 Documents and Templates API without leaving your application.
+V1 editor components allow your users to create and edit documents and templates using the V1 Documents and Templates API without leaving your application.
 
 <Callout type="warn">
-  Embedded authoring is included with [Enterprise](https://documen.so/enterprise-cta) plans. It is
+  Embedded editor is included with [Enterprise](https://documen.so/enterprise-cta) plans. It is
   also available as a paid add-on for the [Platform Plan](https://documen.so/platform-cta-pricing).
   Contact sales for access.
 </Callout>
 
 ## Components
 
-The SDK provides four V1 authoring components:
+The SDK provides four V1 editor components:
 
 | Component               | Purpose                 |
 | ----------------------- | ----------------------- |
@@ -29,7 +29,7 @@ The SDK provides four V1 authoring components:
 
 ## Presign Tokens
 
-All authoring components require a **presign token** for authentication. See the [Authoring overview](/docs/developers/embedding/authoring) for details on obtaining presign tokens.
+All editor components require a **presign token** for authentication. See the [Editor overview](/docs/developers/embedding/editor) for details on obtaining presign tokens.
 
 
 <Callout type="warn">
@@ -131,7 +131,7 @@ const TemplateEditor = ({ presignToken, templateId }) => {
 
 ## Props
 
-### All Authoring Components
+### All Editor Components
 
 | Prop               | Type      | Required | Description                                              |
 | ------------------ | --------- | -------- | -------------------------------------------------------- |
@@ -143,7 +143,7 @@ const TemplateEditor = ({ presignToken, templateId }) => {
 | `darkModeDisabled` | `boolean` | No       | Disable dark mode (Platform Plan)                        |
 | `language`         | `string`  | No       | Set the UI language. See [Supported Languages](https://github.com/documenso/documenso/tree/main/packages/lib/constants/locales.ts) |
 | `className`        | `string`  | No       | CSS class for the iframe                                 |
-| `features`         | `object`  | No       | Feature toggles for the authoring experience             |
+| `features`         | `object`  | No       | Feature toggles for the editor experience                |
 
 ### Update Components Only
 
@@ -157,7 +157,7 @@ const TemplateEditor = ({ presignToken, templateId }) => {
 
 ## Feature Toggles
 
-Customize what options are available in the authoring experience:
+Customize what options are available in the editor experience:
 
 ```jsx
 <EmbedCreateDocumentV1
@@ -294,7 +294,7 @@ Pass extra props to the iframe for testing experimental features:
 ## See Also
 
 - [Embedding Overview](/docs/developers/embedding) - Signing embed concepts and props
-- [V2 Authoring](/docs/developers/embedding/authoring/v2) - V2 envelope authoring
+- [V2 Editor](/docs/developers/embedding/editor/v2) - V2 envelope editor
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
 - [Documents API](/docs/developers/api/documents) - Create documents via API
 - [Templates API](/docs/developers/api/templates) - Create templates via API

--- a/apps/docs/content/docs/developers/embedding/editor/v2.mdx
+++ b/apps/docs/content/docs/developers/embedding/editor/v2.mdx
@@ -1,21 +1,21 @@
 ---
-title: V2 Authoring
+title: V2 Editor
 description: Embed envelope creation and editing directly in your application.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-V2 authoring components allow your users to create and edit envelopes without leaving your application. Envelopes are the unified model for documents and templates in the V2 API.
+V2 editor components allow your users to create and edit envelopes without leaving your application. Envelopes are the unified model for documents and templates in the V2 API.
 
 <Callout type="warn">
-  Embedded authoring is included with [Enterprise](https://documen.so/enterprise-cta) plans. It is
+  Embedded editor is included with [Enterprise](https://documen.so/enterprise-cta) plans. It is
   also available as a paid add-on for the [Platform Plan](https://documen.so/platform-cta-pricing).
   Contact sales for access.
 </Callout>
 
 ## Components
 
-The SDK provides two V2 authoring components:
+The SDK provides two V2 editor components:
 
 | Component              | Purpose                  |
 | ---------------------- | ------------------------ |
@@ -26,7 +26,7 @@ The SDK provides two V2 authoring components:
 
 ## Presign Tokens
 
-All authoring components require a **presign token** for authentication. See the [Authoring overview](/docs/developers/embedding/authoring) for details on obtaining presign tokens.
+All editor components require a **presign token** for authentication. See the [Editor overview](/docs/developers/embedding/editor) for details on obtaining presign tokens.
 
 <Callout type="warn">
   A presigned token is NOT an API token
@@ -100,7 +100,7 @@ const EnvelopeEditor = ({ presignToken, envelopeId }) => {
 
 ## Props
 
-### All V2 Authoring Components
+### All V2 Editor Components
 
 | Prop             | Type      | Required | Description                                              |
 | ---------------- | --------- | -------- | -------------------------------------------------------- |
@@ -113,7 +113,7 @@ const EnvelopeEditor = ({ presignToken, envelopeId }) => {
 | `language`       | `string`  | No       | Set the UI language. See [Supported Languages](https://github.com/documenso/documenso/tree/main/packages/lib/constants/locales.ts) |
 | `className`      | `string`  | No       | CSS class for the iframe                                 |
 | `user`           | `object`  | No       | Current user info. When provided, enables the "Add Myself" button in the recipients list. Object with optional `email` and `name` fields |
-| `features`       | `object`  | No       | Feature toggles for the authoring experience             |
+| `features`       | `object`  | No       | Feature toggles for the editor experience                |
 
 ### Create Component Only
 
@@ -132,7 +132,7 @@ const EnvelopeEditor = ({ presignToken, envelopeId }) => {
 
 ## Feature Toggles
 
-V2 authoring provides rich, structured feature toggles organized into sections. Pass a partial configuration to customize the authoring experience — any omitted fields will use their defaults.
+V2 editor provides rich, structured feature toggles organized into sections. Pass a partial configuration to customize the editor experience — any omitted fields will use their defaults.
 
 ```jsx
 <EmbedCreateEnvelope
@@ -160,7 +160,7 @@ V2 authoring provides rich, structured feature toggles organized into sections. 
 
 ### General
 
-Controls the overall authoring flow and UI:
+Controls the overall editor flow and UI:
 
 | Property                        | Type      | Default | Description                                      |
 | ------------------------------- | --------- | ------- | ------------------------------------------------ |
@@ -188,7 +188,7 @@ Controls envelope configuration options. Set to `null` to hide envelope settings
 
 ### Actions
 
-Controls available actions during authoring:
+Controls available actions during editing:
 
 | Property           | Type      | Default | Description              |
 | ------------------ | --------- | ------- | ------------------------ |
@@ -221,7 +221,7 @@ Controls recipient configuration options. Set to `null` to prevent any recipient
 
 ### Disabling Steps
 
-You can also disable entire steps of the authoring flow. This allows you to skip steps that are not relevant to your use case:
+You can also disable entire steps of the editor flow. This allows you to skip steps that are not relevant to your use case:
 
 ```jsx
 <EmbedCreateEnvelope
@@ -338,7 +338,7 @@ const EnvelopeManager = ({ presignToken }) => {
 
 ## See Also
 
-- [Authoring Overview](/docs/developers/embedding/authoring) - V1 vs V2 comparison and presign tokens
-- [V1 Authoring](/docs/developers/embedding/authoring/v1) - V1 document and template authoring
+- [Editor Overview](/docs/developers/embedding/editor) - V1 vs V2 comparison and presign tokens
+- [V1 Editor](/docs/developers/embedding/editor/v1) - V1 document and template editor
 - [Embedding Overview](/docs/developers/embedding) - Signing embed concepts and props
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance

--- a/apps/docs/content/docs/developers/embedding/index.mdx
+++ b/apps/docs/content/docs/developers/embedding/index.mdx
@@ -6,14 +6,14 @@ description: Embed document signing experiences directly in your application usi
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-## Embedded Signing vs Embedded Authoring
+## Embedded Signing vs Embedded Editor
 
 Documenso offers two types of embedding:
 
 - **Embedded Signing** lets you embed the signing experience in your application. Your users sign documents without leaving your site. Available on Teams Plan and above.
-- **Embedded Authoring** lets you embed document and template _creation and editing_ in your application. This is an [Enterprise](/docs/policies/enterprise-edition) feature (also available as a Platform Plan add-on). See the [Authoring](/docs/developers/embedding/authoring) guide.
+- **Embedded Editor** lets you embed document and template _creation and editing_ in your application. This is an [Enterprise](/docs/policies/enterprise-edition) feature (also available as a Platform Plan add-on). See the [Editor](/docs/developers/embedding/editor) guide.
 
-This page covers **embedded signing**. If you need your users to create or edit documents inside your app, see [Authoring](/docs/developers/embedding/authoring).
+This page covers **embedded signing**. If you need your users to create or edit documents inside your app, see [Editor](/docs/developers/embedding/editor).
 
 ---
 
@@ -229,9 +229,9 @@ Receives an object with:
     href="/docs/developers/embedding/css-variables"
   />
   <Card
-    title="Authoring"
+    title="Editor"
     description="Embed document and template creation."
-    href="/docs/developers/embedding/authoring"
+    href="/docs/developers/embedding/editor"
   />
 </Cards>
 

--- a/apps/docs/content/docs/developers/embedding/meta.json
+++ b/apps/docs/content/docs/developers/embedding/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Embedding",
-  "pages": ["sdks", "direct-links", "css-variables", "authoring"]
+  "pages": ["sdks", "direct-links", "css-variables", "editor"]
 }

--- a/apps/docs/content/docs/developers/embedding/sdks/angular.mdx
+++ b/apps/docs/content/docs/developers/embedding/sdks/angular.mdx
@@ -89,4 +89,4 @@ export class SigningComponent {
 
 - [Embedding Overview](/docs/developers/embedding) - Props reference and concepts
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
-- [Authoring](/docs/developers/embedding/authoring) - Embed document creation
+- [Editor](/docs/developers/embedding/editor) - Embed document creation

--- a/apps/docs/content/docs/developers/embedding/sdks/preact.mdx
+++ b/apps/docs/content/docs/developers/embedding/sdks/preact.mdx
@@ -93,4 +93,4 @@ See [CSS Variables](/docs/developers/embedding/css-variables) for all available 
 
 - [Embedding Overview](/docs/developers/embedding) - Props reference and concepts
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
-- [Authoring](/docs/developers/embedding/authoring) - Embed document creation
+- [Editor](/docs/developers/embedding/editor) - Embed document creation

--- a/apps/docs/content/docs/developers/embedding/sdks/react.mdx
+++ b/apps/docs/content/docs/developers/embedding/sdks/react.mdx
@@ -133,4 +133,4 @@ const DocumentSigning = ({ token }: { token: string }) => {
 
 - [Embedding Overview](/docs/developers/embedding) - Props reference and concepts
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
-- [Authoring](/docs/developers/embedding/authoring) - Embed document creation
+- [Editor](/docs/developers/embedding/editor) - Embed document creation

--- a/apps/docs/content/docs/developers/embedding/sdks/solid.mdx
+++ b/apps/docs/content/docs/developers/embedding/sdks/solid.mdx
@@ -93,4 +93,4 @@ See [CSS Variables](/docs/developers/embedding/css-variables) for all available 
 
 - [Embedding Overview](/docs/developers/embedding) - Props reference and concepts
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
-- [Authoring](/docs/developers/embedding/authoring) - Embed document creation
+- [Editor](/docs/developers/embedding/editor) - Embed document creation

--- a/apps/docs/content/docs/developers/embedding/sdks/svelte.mdx
+++ b/apps/docs/content/docs/developers/embedding/sdks/svelte.mdx
@@ -101,4 +101,4 @@ See [CSS Variables](/docs/developers/embedding/css-variables) for all available 
 
 - [Embedding Overview](/docs/developers/embedding) - Props reference and concepts
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
-- [Authoring](/docs/developers/embedding/authoring) - Embed document creation
+- [Editor](/docs/developers/embedding/editor) - Embed document creation

--- a/apps/docs/content/docs/developers/embedding/sdks/vue.mdx
+++ b/apps/docs/content/docs/developers/embedding/sdks/vue.mdx
@@ -104,4 +104,4 @@ See [CSS Variables](/docs/developers/embedding/css-variables) for all available 
 
 - [Embedding Overview](/docs/developers/embedding) - Props reference and concepts
 - [CSS Variables](/docs/developers/embedding/css-variables) - Customize appearance
-- [Authoring](/docs/developers/embedding/authoring) - Embed document creation
+- [Editor](/docs/developers/embedding/editor) - Embed document creation

--- a/apps/docs/content/docs/policies/enterprise-edition.mdx
+++ b/apps/docs/content/docs/policies/enterprise-edition.mdx
@@ -53,8 +53,8 @@ The Enterprise Edition is required when you:
     - Document Action Reauthentication (Passkeys and 2FA)
     - 21 CFR Part 11 Compliance
     - Email Domains (custom sender addresses)
-    - Embed Authoring
-    - Embed Authoring White Label
+    - Embed Editor
+    - Embed Editor White Label
     - Custom signing certificates
     - Priority feature requests
 

--- a/apps/docs/content/docs/self-hosting/configuration/environment.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/environment.mdx
@@ -342,7 +342,7 @@ Telemetry collects only: app version, installation ID, and node ID. No personal 
 
 ## Enterprise Features
 
-These variables require an active [Enterprise Edition](/docs/policies/enterprise-edition) license. Obtain a license key from [license.documenso.com](https://license.documenso.com) and set it below to unlock enterprise features such as SSO, embed authoring, and 21 CFR Part 11 compliance.
+These variables require an active [Enterprise Edition](/docs/policies/enterprise-edition) license. Obtain a license key from [license.documenso.com](https://license.documenso.com) and set it below to unlock enterprise features such as SSO, embed editor, and 21 CFR Part 11 compliance.
 
 | Variable                             | Description                                      |
 | ------------------------------------ | ------------------------------------------------ |

--- a/apps/docs/content/docs/self-hosting/index.mdx
+++ b/apps/docs/content/docs/self-hosting/index.mdx
@@ -122,7 +122,7 @@ See the [Quick Start guide](/docs/self-hosting/getting-started/quick-start) for 
 
 ## Enterprise Edition
 
-Self-hosted Documenso includes full core functionality under the AGPL-3.0 license. If you need enterprise features such as SSO, embed authoring white label, or 21 CFR Part 11 compliance, you can activate them with a license key.
+Self-hosted Documenso includes full core functionality under the AGPL-3.0 license. If you need enterprise features such as SSO, embed editor white label, or 21 CFR Part 11 compliance, you can activate them with a license key.
 
 See [Enterprise Edition](/docs/policies/enterprise-edition) for details and [Licenses](/docs/policies/licenses) for a comparison.
 

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -296,12 +296,27 @@ const config = {
       },
       {
         source: '/developers/embedding/authoring',
-        destination: '/docs/developers/embedding/authoring',
+        destination: '/docs/developers/embedding/editor',
+        permanent: true,
+      },
+      {
+        source: '/developers/embedding/authoring/:path*',
+        destination: '/docs/developers/embedding/editor/:path*',
         permanent: true,
       },
       {
         source: '/developers/embedded-authoring',
-        destination: '/docs/developers/embedding/authoring',
+        destination: '/docs/developers/embedding/editor',
+        permanent: true,
+      },
+      {
+        source: '/docs/developers/embedding/authoring',
+        destination: '/docs/developers/embedding/editor',
+        permanent: true,
+      },
+      {
+        source: '/docs/developers/embedding/authoring/:path*',
+        destination: '/docs/developers/embedding/editor/:path*',
         permanent: true,
       },
 


### PR DESCRIPTION
## Description

Update docs to use the term "Editor" instead of "Authoring" to reduce confusion.