### PR TITLE
fix: convert DOCX template uploads to PDF

### DIFF
--- a/packages/trpc/server/template-router/router.ts
+++ b/packages/trpc/server/template-router/router.ts
@@ -3,6 +3,7 @@ import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import { jobs } from '@documenso/lib/jobs/client';
 import { getDocumentWithDetailsById } from '@documenso/lib/server-only/document/get-document-with-details-by-id';
 import { sendDocument } from '@documenso/lib/server-only/document/send-document';
+import { convertToPdf } from '@documenso/lib/server-only/document-conversion';
 import { createDocumentData } from '@documenso/lib/server-only/document-data/create-document-data';
 import { createEnvelope } from '@documenso/lib/server-only/envelope/create-envelope';
 import { duplicateEnvelope } from '@documenso/lib/server-only/envelope/duplicate-envelope';
@@ -269,9 +270,18 @@ export const templateRouter = router({
         attachments,
       } = payload;
 
-      const { id: templateDocumentDataId } = await putNormalizedPdfFileServerSide(file, {
-        flattenForm: false,
-      });
+      const pdf = await convertToPdf(file, ctx.logger);
+
+      const { id: templateDocumentDataId } = await putNormalizedPdfFileServerSide(
+        {
+          name: file.name,
+          type: 'application/pdf',
+          arrayBuffer: async () => Promise.resolve(pdf),
+        },
+        {
+          flattenForm: false,
+        },
+      );
 
       ctx.logger.info({
         input: {


### PR DESCRIPTION
## Description

Legacy template uploads accept DOCX but `createTemplate` skipped `convertToPdf`,
so the raw DOCX hit PDF normalization and failed with a misleading
`INVALID_DOCUMENT_FILE` error. Matches the legacy document upload path.

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->

## Changes Made

- Route `createTemplate` uploads through `convertToPdf` before normalization.

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->

## Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
