### PR TITLE
fix: email dictated direct template signer

### DIFF
--- a/packages/app-tests/e2e/templates/direct-templates.spec.ts
+++ b/packages/app-tests/e2e/templates/direct-templates.spec.ts
@@ -18,6 +18,20 @@ const formatTemplatesPath = (teamUrl: string) => `/t/${teamUrl}/templates`;
 
 const nanoid = customAlphabet('1234567890abcdef', 10);
 
+const expectSigningRequestJobForRecipient = async (recipientId: number) => {
+  const job = await prisma.backgroundJob.findFirst({
+    where: {
+      jobId: 'send.signing.requested.email',
+      payload: {
+        path: ['recipientId'],
+        equals: recipientId,
+      },
+    },
+  });
+
+  expect(job).not.toBeNull();
+};
+
 test('[DIRECT_TEMPLATES]: create direct link for template', async ({ page }) => {
   const { team, owner, organisation } = await seedTeam({
     createTeamMembers: 1,
@@ -309,8 +323,15 @@ test('[DIRECT_TEMPLATES]: V1 use direct template link with 2 recipients with nex
 
   const updatedSecondRecipient = createdEnvelopeRecipients.find((recipient) => recipient.signingOrder === 2);
 
-  expect(updatedSecondRecipient?.name).toBe(newName);
-  expect(updatedSecondRecipient?.email).toBe(newSecondSignerEmail);
+  expect(updatedSecondRecipient).toBeDefined();
+
+  if (!updatedSecondRecipient) {
+    throw new Error('Expected second recipient to exist');
+  }
+
+  expect(updatedSecondRecipient.name).toBe(newName);
+  expect(updatedSecondRecipient.email).toBe(newSecondSignerEmail);
+  await expectSigningRequestJobForRecipient(updatedSecondRecipient.id);
 });
 
 test('[DIRECT_TEMPLATES]: V2 use direct template link with 2 recipients with next signer dictation', async ({
@@ -394,6 +415,13 @@ test('[DIRECT_TEMPLATES]: V2 use direct template link with 2 recipients with nex
 
   const updatedSecondRecipient = createdEnvelopeRecipients.find((recipient) => recipient.signingOrder === 2);
 
-  expect(updatedSecondRecipient?.name).toBe(newName);
-  expect(updatedSecondRecipient?.email).toBe(newSecondSignerEmail);
+  expect(updatedSecondRecipient).toBeDefined();
+
+  if (!updatedSecondRecipient) {
+    throw new Error('Expected second recipient to exist');
+  }
+
+  expect(updatedSecondRecipient.name).toBe(newName);
+  expect(updatedSecondRecipient.email).toBe(newSecondSignerEmail);
+  await expectSigningRequestJobForRecipient(updatedSecondRecipient.id);
 });

--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -307,7 +307,7 @@ export const createDocumentFromDirectTemplate = async ({
 
   const incrementedDocumentId = await incrementDocumentId();
 
-  const { createdEnvelope, recipientId, token } = await prisma.$transaction(async (tx) => {
+  const { createdEnvelope, recipientId, token, nextRecipientId } = await prisma.$transaction(async (tx) => {
     // Create the envelope and non direct template recipients.
     const createdEnvelope = await tx.envelope.create({
       data: {
@@ -610,6 +610,8 @@ export const createDocumentFromDirectTemplate = async ({
       }),
     ];
 
+    let nextRecipientId: number | undefined;
+
     if (nextSigner) {
       const pendingRecipients = await tx.recipient.findMany({
         select: {
@@ -636,6 +638,8 @@ export const createDocumentFromDirectTemplate = async ({
       const nextRecipient = pendingRecipients[0];
 
       if (nextRecipient) {
+        nextRecipientId = nextRecipient.id;
+
         auditLogsToCreate.push(
           createDocumentAuditLogData({
             type: DOCUMENT_AUDIT_LOG_TYPE.RECIPIENT_UPDATED,
@@ -707,6 +711,7 @@ export const createDocumentFromDirectTemplate = async ({
       createdEnvelope,
       token: createdDirectRecipient.token,
       recipientId: createdDirectRecipient.id,
+      nextRecipientId,
     };
   });
 
@@ -718,6 +723,18 @@ export const createDocumentFromDirectTemplate = async ({
       payload: {
         envelopeId: createdEnvelope.id,
         recipientId,
+      },
+    });
+  }
+
+  if (nextRecipientId) {
+    await jobs.triggerJob({
+      name: 'send.signing.requested.email',
+      payload: {
+        userId: createdEnvelope.userId,
+        documentId: incrementedDocumentId.documentId,
+        recipientId: nextRecipientId,
+        requestMetadata: requestMetadata?.requestMetadata,
       },
     });
   }


### PR DESCRIPTION
## Description

Fixes #2485.

Direct-template next-signer dictation updated the next recipient, but the signing request email job was never queued because that recipient was already marked as sent before the send path considered recipients to notify.

This captures the dictated next recipient during direct-template document creation and explicitly queues `send.signing.requested.email`, matching the normal sequential signing completion flow.

## Changes

- Queue a signing-request email job for the dictated next direct-template recipient.
- Keep the existing recipient delivery-state update used by direct-template creation.
- Add V1 and V2 direct-template E2E assertions that the signing-request job is queued for the dictated recipient.

## Testing

- `npx biome check --formatter-enabled=false packages/lib/server-only/template/create-document-from-direct-template.ts packages/app-tests/e2e/templates/direct-templates.spec.ts`
- `npx dotenv -e .env.example -- npm run build:app -w @documenso/remix`
- `npx dotenv -e .env.example -- npm run build:server -w @documenso/remix`
- `npx dotenv -e .env.example -- npx playwright test packages/app-tests/e2e/templates/direct-templates.spec.ts -g 'next signer dictation' --project=ui --config packages/app-tests/playwright.config.ts --workers=1 --retries=0 --reporter=list --timeout=120000`