### PR TITLE
fix: trigger document webhooks before completed emails

### DIFF
--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -8,31 +8,28 @@ import { prisma } from '@documenso/prisma';
 import { signPdf } from '@documenso/signing';
 import { PDF } from '@libpdf/core';
 import type { DocumentData, Envelope, EnvelopeItem, Field } from '@prisma/client';
-import { DocumentStatus, EnvelopeType, RecipientRole, SigningStatus, WebhookTriggerEvents } from '@prisma/client';
+import { DocumentStatus, EnvelopeType, RecipientRole, SigningStatus } from '@prisma/client';
 import { nanoid } from 'nanoid';
 import { groupBy } from 'remeda';
 
 import { NEXT_PRIVATE_USE_PLAYWRIGHT_PDF } from '../../../constants/app';
 import { AppError, AppErrorCode } from '../../../errors/app-error';
-import { sendCompletedEmail } from '../../../server-only/document/send-completed-email';
 import { getAuditLogsPdf } from '../../../server-only/htmltopdf/get-audit-logs-pdf';
 import { getCertificatePdf } from '../../../server-only/htmltopdf/get-certificate-pdf';
 import { insertFieldInPDFV1 } from '../../../server-only/pdf/insert-field-in-pdf-v1';
 import { insertFieldInPDFV2 } from '../../../server-only/pdf/insert-field-in-pdf-v2';
 import { legacy_insertFieldInPDF } from '../../../server-only/pdf/legacy-insert-field-in-pdf';
 import { getTeamSettings } from '../../../server-only/team/get-team-settings';
-import { triggerWebhook } from '../../../server-only/webhooks/trigger/trigger-webhook';
 import { DOCUMENT_AUDIT_LOG_TYPE, type TDocumentAuditLog } from '../../../types/document-audit-logs';
-import { mapEnvelopeToWebhookDocumentPayload, ZWebhookDocumentSchema } from '../../../types/webhook-payload';
 import { prefixedId } from '../../../universal/id';
 import { getFileServerSide } from '../../../universal/upload/get-file.server';
 import { putPdfFileServerSide } from '../../../universal/upload/put-file.server';
 import { fieldsContainUnsignedRequiredField } from '../../../utils/advanced-fields-helpers';
-import { isDocumentCompleted } from '../../../utils/document';
 import { createDocumentAuditLogData } from '../../../utils/document-audit-logs';
 import { mapDocumentIdToSecondaryId } from '../../../utils/envelope';
 import type { JobRunIO } from '../../client/_internal/job';
 import type { TSealDocumentJobDefinition } from './seal-document';
+import { runPostSealDocumentTasks } from './seal-document.post-seal';
 
 export const run = async ({ payload, io }: { payload: TSealDocumentJobDefinition; io: JobRunIO }) => {
   const { documentId, sendEmail = true, isResealing = false, requestMetadata } = payload;
@@ -294,36 +291,14 @@ export const run = async ({ payload, io }: { payload: TSealDocumentJobDefinition
     };
   });
 
-  await io.runTask('send-completed-email', async () => {
-    let shouldSendCompletedEmail = sendEmail && !isResealing && !isRejected;
-
-    if (isResealing && !isDocumentCompleted(envelopeStatus)) {
-      shouldSendCompletedEmail = sendEmail;
-    }
-
-    if (shouldSendCompletedEmail) {
-      await sendCompletedEmail({
-        id: { type: 'envelopeId', id: envelopeId },
-        requestMetadata,
-      });
-    }
-  });
-
-  const updatedEnvelope = await prisma.envelope.findFirstOrThrow({
-    where: {
-      id: envelopeId,
-    },
-    include: {
-      documentMeta: true,
-      recipients: true,
-    },
-  });
-
-  await triggerWebhook({
-    event: isRejected ? WebhookTriggerEvents.DOCUMENT_REJECTED : WebhookTriggerEvents.DOCUMENT_COMPLETED,
-    data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(updatedEnvelope)),
-    userId: updatedEnvelope.userId,
-    teamId: updatedEnvelope.teamId ?? undefined,
+  await runPostSealDocumentTasks({
+    envelopeId,
+    envelopeStatus,
+    isRejected,
+    isResealing,
+    requestMetadata,
+    sendEmail,
+    io,
   });
 };
 

--- a/packages/lib/jobs/definitions/internal/seal-document.post-seal.test.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.post-seal.test.ts
@@ -1,0 +1,118 @@
+import { prisma } from '@documenso/prisma';
+import { DocumentStatus, WebhookTriggerEvents } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sendCompletedEmail } from '../../../server-only/document/send-completed-email';
+import { triggerWebhook } from '../../../server-only/webhooks/trigger/trigger-webhook';
+import type { JobRunIO } from '../../client/_internal/job';
+import { runPostSealDocumentTasks } from './seal-document.post-seal';
+
+vi.mock('@documenso/prisma', () => ({
+  prisma: {
+    envelope: {
+      findFirstOrThrow: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../../server-only/document/send-completed-email', () => ({
+  sendCompletedEmail: vi.fn(),
+}));
+
+vi.mock('../../../server-only/webhooks/trigger/trigger-webhook', () => ({
+  triggerWebhook: vi.fn(),
+}));
+
+vi.mock('../../../types/webhook-payload', () => ({
+  mapEnvelopeToWebhookDocumentPayload: vi.fn((envelope) => ({ id: envelope.id })),
+  ZWebhookDocumentSchema: {
+    parse: vi.fn((payload) => payload),
+  },
+}));
+
+const createJobRunIO = () =>
+  ({
+    runTask: vi.fn(async (_cacheKey, callback) => callback()),
+    triggerJob: vi.fn(),
+    wait: vi.fn(),
+    logger: {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      log: vi.fn(),
+    },
+  }) satisfies JobRunIO;
+
+describe('runPostSealDocumentTasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const envelope = {
+      id: 'envelope_123',
+      userId: 1,
+      teamId: 2,
+    } as unknown as Awaited<ReturnType<typeof prisma.envelope.findFirstOrThrow>>;
+
+    vi.mocked(prisma.envelope.findFirstOrThrow).mockResolvedValue(envelope);
+  });
+
+  it('triggers the completion webhook before sending completed emails', async () => {
+    const io = createJobRunIO();
+    const calls: string[] = [];
+
+    vi.mocked(triggerWebhook).mockImplementation(() => {
+      calls.push('webhook');
+      return Promise.resolve();
+    });
+
+    vi.mocked(sendCompletedEmail).mockImplementation(() => {
+      calls.push('email');
+      return Promise.reject(new Error('SMTP connection failed'));
+    });
+
+    await expect(
+      runPostSealDocumentTasks({
+        envelopeId: 'envelope_123',
+        envelopeStatus: DocumentStatus.COMPLETED,
+        isRejected: false,
+        isResealing: false,
+        sendEmail: true,
+        io,
+      }),
+    ).rejects.toThrow('SMTP connection failed');
+
+    expect(calls).toEqual(['webhook', 'email']);
+    expect(vi.mocked(io.runTask).mock.calls.map(([cacheKey]) => cacheKey)).toEqual([
+      'trigger-document-webhook',
+      'send-completed-email',
+    ]);
+    expect(triggerWebhook).toHaveBeenCalledWith({
+      event: WebhookTriggerEvents.DOCUMENT_COMPLETED,
+      data: { id: 'envelope_123' },
+      userId: 1,
+      teamId: 2,
+    });
+  });
+
+  it('triggers rejected webhooks without sending completed emails', async () => {
+    const io = createJobRunIO();
+
+    await runPostSealDocumentTasks({
+      envelopeId: 'envelope_123',
+      envelopeStatus: DocumentStatus.REJECTED,
+      isRejected: true,
+      isResealing: false,
+      sendEmail: true,
+      io,
+    });
+
+    expect(triggerWebhook).toHaveBeenCalledWith({
+      event: WebhookTriggerEvents.DOCUMENT_REJECTED,
+      data: { id: 'envelope_123' },
+      userId: 1,
+      teamId: 2,
+    });
+    expect(sendCompletedEmail).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/jobs/definitions/internal/seal-document.post-seal.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.post-seal.ts
@@ -1,0 +1,64 @@
+import { prisma } from '@documenso/prisma';
+import type { DocumentStatus } from '@prisma/client';
+import { WebhookTriggerEvents } from '@prisma/client';
+
+import { sendCompletedEmail } from '../../../server-only/document/send-completed-email';
+import { triggerWebhook } from '../../../server-only/webhooks/trigger/trigger-webhook';
+import { mapEnvelopeToWebhookDocumentPayload, ZWebhookDocumentSchema } from '../../../types/webhook-payload';
+import type { RequestMetadata } from '../../../universal/extract-request-metadata';
+import { isDocumentCompleted } from '../../../utils/document';
+import type { JobRunIO } from '../../client/_internal/job';
+
+type RunPostSealDocumentTasksOptions = {
+  envelopeId: string;
+  envelopeStatus: DocumentStatus;
+  isRejected: boolean;
+  isResealing: boolean;
+  requestMetadata?: RequestMetadata;
+  sendEmail: boolean;
+  io: JobRunIO;
+};
+
+export const runPostSealDocumentTasks = async ({
+  envelopeId,
+  envelopeStatus,
+  isRejected,
+  isResealing,
+  requestMetadata,
+  sendEmail,
+  io,
+}: RunPostSealDocumentTasksOptions) => {
+  await io.runTask('trigger-document-webhook', async () => {
+    const updatedEnvelope = await prisma.envelope.findFirstOrThrow({
+      where: {
+        id: envelopeId,
+      },
+      include: {
+        documentMeta: true,
+        recipients: true,
+      },
+    });
+
+    await triggerWebhook({
+      event: isRejected ? WebhookTriggerEvents.DOCUMENT_REJECTED : WebhookTriggerEvents.DOCUMENT_COMPLETED,
+      data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(updatedEnvelope)),
+      userId: updatedEnvelope.userId,
+      teamId: updatedEnvelope.teamId ?? undefined,
+    });
+  });
+
+  await io.runTask('send-completed-email', async () => {
+    let shouldSendCompletedEmail = sendEmail && !isResealing && !isRejected;
+
+    if (isResealing && !isDocumentCompleted(envelopeStatus)) {
+      shouldSendCompletedEmail = sendEmail;
+    }
+
+    if (shouldSendCompletedEmail) {
+      await sendCompletedEmail({
+        id: { type: 'envelopeId', id: envelopeId },
+        requestMetadata,
+      });
+    }
+  });
+};


### PR DESCRIPTION
## Description

Closes #2814.

This updates the seal-document job so document completion/rejection webhooks are dispatched in their own cached job task before completed email delivery runs.

That means an SMTP outage, blocked SMTP port, or completed-email rendering/sending failure can no longer prevent `DOCUMENT_COMPLETED` / `DOCUMENT_REJECTED` webhooks from being queued after the document has already been sealed.

The completed-email logic is unchanged; it was moved into the same post-seal helper so the side-effect ordering is covered by tests.

## Testing

- `npm run test -w @documenso/lib`
- `npx biome check packages/lib/jobs/definitions/internal/seal-document.handler.ts packages/lib/jobs/definitions/internal/seal-document.post-seal.ts packages/lib/jobs/definitions/internal/seal-document.post-seal.test.ts`
- `npx tsc --noEmit --project packages/lib/tsconfig.json --pretty false` *(fails locally on existing Prisma type errors outside this change: `get-completed-fields-for-document.ts`, `get-active-subscriptions-by-user-id.ts`, `find-organisation-invoices.ts`)*