### PR TITLE
docs: require English for PRs and issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ If you plan to contribute to Documenso, please take a moment to feel awesome ✨
 - Consider the results from the discussion on the issue
 - Accept the [Contributor License Agreement](https://documen.so/cla) to ensure we can accept your contributions.
 
+## English only PRs and Issues
+
+Please write all issues, pull requests, and related comments in English so maintainers and the wider contributor community can follow the discussion.
+
 ## Taking issues
 
 Before taking an issue, ensure that:


### PR DESCRIPTION
## Description

Adds a contributing guideline asking contributors to write issues, pull requests, and related comments in English so maintainers and the wider community can follow discussions.
