### PR TITLE
fix(docs): correct API example URLs from /documents to /document

### DIFF
--- a/apps/docs/content/docs/developers/getting-started/authentication.mdx
+++ b/apps/docs/content/docs/developers/getting-started/authentication.mdx
@@ -73,14 +73,14 @@ Include the token in the `Authorization` header of your HTTP requests.
 ### cURL
 
 ```bash
-curl https://app.documenso.com/api/v2/documents \
+curl https://app.documenso.com/api/v2/document \
   -H "Authorization: api_xxxxxxxxxxxxxxxx"
 ```
 
 ### JavaScript / TypeScript
 
 ```typescript
-const response = await fetch('https://app.documenso.com/api/v2/documents', {
+const response = await fetch('https://app.documenso.com/api/v2/document', {
   method: 'GET',
   headers: {
     Authorization: 'api_xxxxxxxxxxxxxxxx',


### PR DESCRIPTION
## Description

Corrected API endpoint path from /api/v2/documents to /api/v2/document

The current example in the docs(/api/v2/documents) returns a 404 NOT_FOUND object. 