### PR TITLE
fix(auth): secure OAuth 2FA bypass vulnerability

### DIFF
--- a/apps/remix/app/components/forms/signin.tsx
+++ b/apps/remix/app/components/forms/signin.tsx
@@ -26,7 +26,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FaIdCardClip } from 'react-icons/fa6';
 import { FcGoogle } from 'react-icons/fc';
-import { Link, useNavigate } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { match } from 'ts-pattern';
 import { z } from 'zod';
 
@@ -78,9 +78,17 @@ export const SignInForm = ({
   const { toast } = useToast();
 
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isOauth2fa = searchParams.get('oauth2fa') === 'true';
 
   const [isTwoFactorAuthenticationDialogOpen, setIsTwoFactorAuthenticationDialogOpen] = useState(false);
   const [isEmbeddedRedirect, setIsEmbeddedRedirect] = useState(false);
+
+  useEffect(() => {
+    if (isOauth2fa) {
+      setIsTwoFactorAuthenticationDialogOpen(true);
+    }
+  }, [isOauth2fa]);
 
   const [twoFactorAuthenticationMethod, setTwoFactorAuthenticationMethod] = useState<'totp' | 'backup'>('totp');
 
@@ -215,14 +223,22 @@ export const SignInForm = ({
         }
       }
 
-      await authClient.emailPassword.signIn({
-        email,
-        password,
-        totpCode,
-        backupCode,
-        captchaToken: token ?? undefined,
-        redirectPath,
-      });
+      if (isOauth2fa) {
+        await authClient.oauth.verify2fa({
+          totpCode,
+          backupCode,
+          redirectPath,
+        });
+      } else {
+        await authClient.emailPassword.signIn({
+          email,
+          password,
+          totpCode,
+          backupCode,
+          captchaToken: token ?? undefined,
+          redirectPath,
+        });
+      }
     } catch (err) {
       console.log(err);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30913,6 +30913,126 @@
         "react": "^18",
         "typescript": "5.6.2"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/auth/client/index.ts
+++ b/packages/auth/client/index.ts
@@ -275,6 +275,25 @@ export class AuthClient {
     },
   };
 
+  public oauth = {
+    verify2fa: async (data: { totpCode?: string; backupCode?: string; redirectPath?: string }) => {
+      const response = await this.client['oauth']['verify-2fa'].$post({
+        json: {
+          totpCode: data.totpCode,
+          backupCode: data.backupCode,
+        },
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+
+        throw AppError.parseError(error);
+      }
+
+      handleSignInRedirect(data.redirectPath);
+    },
+  };
+
   public google = {
     signIn: async ({ redirectPath }: { redirectPath?: string } = {}) => {
       const response = await this.client['oauth'].authorize.google.$post({

--- a/packages/auth/server/lib/session/session-cookies.ts
+++ b/packages/auth/server/lib/session/session-cookies.ts
@@ -10,8 +10,9 @@ import { generateSessionToken } from './session';
 
 export const sessionCookieName = formatSecureCookieName('sessionId');
 export const csrfCookieName = formatSecureCookieName('csrfToken');
+export const oauth2faCookieName = formatSecureCookieName('oauth2faUserId');
 
-const getAuthSecret = () => {
+export const getAuthSecret = () => {
   const authSecret = env('NEXTAUTH_SECRET');
 
   if (!authSecret) {

--- a/packages/auth/server/lib/utils/handle-oauth-callback-url.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-callback-url.ts
@@ -1,6 +1,7 @@
 import { NEXT_PUBLIC_WEBAPP_URL } from '@documenso/lib/constants/app';
 import { isEmailDomainAllowedForSignup, isSignupEnabledForProvider } from '@documenso/lib/constants/auth';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { isTwoFactorAuthenticationEnabled } from '@documenso/lib/server-only/2fa/is-2fa-availble';
 import { onCreateUserHook } from '@documenso/lib/server-only/user/create-user';
 import { deletedServiceAccountEmail } from '@documenso/lib/server-only/user/service-accounts/deleted-account';
 import { legacyServiceAccountEmail } from '@documenso/lib/server-only/user/service-accounts/legacy-service-account';
@@ -9,10 +10,11 @@ import { prisma } from '@documenso/prisma';
 import { UserSecurityAuditLogType } from '@prisma/client';
 import { decodeIdToken, OAuth2Client } from 'arctic';
 import type { Context } from 'hono';
-import { deleteCookie } from 'hono/cookie';
+import { deleteCookie, setSignedCookie } from 'hono/cookie';
 
 import type { OAuthClientOptions } from '../../config';
 import { AuthenticationErrorCode } from '../errors/error-codes';
+import { getAuthSecret, oauth2faCookieName, sessionCookieOptions } from '../session/session-cookies';
 import { onAuthorize } from './authorizer';
 import { getOpenIdConfiguration } from './open-id';
 
@@ -45,6 +47,9 @@ export const handleOAuthCallbackUrl = async (options: HandleOAuthCallbackUrlOpti
       user: {
         select: {
           id: true,
+          twoFactorEnabled: true,
+          twoFactorSecret: true,
+          twoFactorBackupCodes: true,
         },
       },
     },
@@ -52,6 +57,20 @@ export const handleOAuthCallbackUrl = async (options: HandleOAuthCallbackUrlOpti
 
   // Directly log in user if account already exists.
   if (existingAccount) {
+    const user = existingAccount.user;
+
+    if (isTwoFactorAuthenticationEnabled({ user })) {
+      await setSignedCookie(c, oauth2faCookieName, String(user.id), getAuthSecret(), sessionCookieOptions);
+
+      const redirectUrl = new URL('/signin', NEXT_PUBLIC_WEBAPP_URL());
+      redirectUrl.searchParams.set('oauth2fa', 'true');
+      if (redirectPath && redirectPath !== '/') {
+        redirectUrl.searchParams.set('returnTo', redirectPath);
+      }
+
+      return c.redirect(redirectUrl.toString(), 302);
+    }
+
     await onAuthorize({ userId: existingAccount.user.id }, c);
 
     return c.redirect(redirectPath, 302);
@@ -64,11 +83,26 @@ export const handleOAuthCallbackUrl = async (options: HandleOAuthCallbackUrlOpti
     select: {
       id: true,
       emailVerified: true,
+      twoFactorEnabled: true,
+      twoFactorSecret: true,
+      twoFactorBackupCodes: true,
     },
   });
 
   // Handle existing user but no account.
   if (userWithSameEmail) {
+    if (isTwoFactorAuthenticationEnabled({ user: userWithSameEmail })) {
+      await setSignedCookie(c, oauth2faCookieName, String(userWithSameEmail.id), getAuthSecret(), sessionCookieOptions);
+
+      const redirectUrl = new URL('/signin', NEXT_PUBLIC_WEBAPP_URL());
+      redirectUrl.searchParams.set('oauth2fa', 'true');
+      if (redirectPath && redirectPath !== '/') {
+        redirectUrl.searchParams.set('returnTo', redirectPath);
+      }
+
+      return c.redirect(redirectUrl.toString(), 302);
+    }
+
     await prisma.$transaction(async (tx) => {
       await tx.account.create({
         data: {

--- a/packages/auth/server/lib/utils/handle-oauth-organisation-callback-url.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-organisation-callback-url.ts
@@ -1,12 +1,15 @@
 import { sendOrganisationAccountLinkConfirmationEmail } from '@documenso/ee/server-only/lib/send-organisation-account-link-confirmation-email';
+import { NEXT_PUBLIC_WEBAPP_URL } from '@documenso/lib/constants/app';
 import { isSignupEnabledForProvider } from '@documenso/lib/constants/auth';
 import { AppError } from '@documenso/lib/errors/app-error';
+import { isTwoFactorAuthenticationEnabled } from '@documenso/lib/server-only/2fa/is-2fa-availble';
 import { onCreateUserHook } from '@documenso/lib/server-only/user/create-user';
 import { formatOrganisationLoginUrl } from '@documenso/lib/utils/organisation-authentication-portal';
 import { prisma } from '@documenso/prisma';
 import type { Context } from 'hono';
-
+import { setSignedCookie } from 'hono/cookie';
 import { AuthenticationErrorCode } from '../errors/error-codes';
+import { getAuthSecret, oauth2faCookieName, sessionCookieOptions } from '../session/session-cookies';
 import { onAuthorize } from './authorizer';
 import { validateOauth } from './handle-oauth-callback-url';
 import { getOrganisationAuthenticationPortalOptions } from './organisation-portal';
@@ -53,6 +56,18 @@ export const handleOAuthOrganisationCallbackUrl = async (options: HandleOAuthOrg
 
   // Directly log in user if account already exists.
   if (existingAccount) {
+    const user = existingAccount.user;
+
+    if (isTwoFactorAuthenticationEnabled({ user })) {
+      await setSignedCookie(c, oauth2faCookieName, String(user.id), getAuthSecret(), sessionCookieOptions);
+
+      const redirectUrl = new URL('/signin', NEXT_PUBLIC_WEBAPP_URL());
+      redirectUrl.searchParams.set('oauth2fa', 'true');
+      redirectUrl.searchParams.set('returnTo', `/o/${orgUrl}`);
+
+      return c.redirect(redirectUrl.toString(), 302);
+    }
+
     await onAuthorize({ userId: existingAccount.user.id }, c);
 
     return c.redirect(`/o/${orgUrl}`, 302);

--- a/packages/auth/server/routes/oauth.ts
+++ b/packages/auth/server/routes/oauth.ts
@@ -1,8 +1,16 @@
+import { AppError } from '@documenso/lib/errors/app-error';
+import { validateTwoFactorAuthentication } from '@documenso/lib/server-only/2fa/validate-2fa';
+import { prisma } from '@documenso/prisma';
 import { sValidator } from '@hono/standard-validator';
+import { UserSecurityAuditLogType } from '@prisma/client';
 import { Hono } from 'hono';
+import { deleteCookie, getSignedCookie } from 'hono/cookie';
 import { z } from 'zod';
 
 import { GoogleAuthOptions, MicrosoftAuthOptions, OidcAuthOptions } from '../config';
+import { AuthenticationErrorCode } from '../lib/errors/error-codes';
+import { getAuthSecret, oauth2faCookieName, sessionCookieOptions } from '../lib/session/session-cookies';
+import { onAuthorize } from '../lib/utils/authorizer';
 import { handleOAuthAuthorizeUrl } from '../lib/utils/handle-oauth-authorize-url';
 import { getOrganisationAuthenticationPortalOptions } from '../lib/utils/organisation-portal';
 import type { HonoAuthContext } from '../types/context';
@@ -66,4 +74,73 @@ export const oauthRoute = new Hono<HonoAuthContext>()
       clientOptions,
       prompt: 'select_account',
     });
-  });
+  })
+  /**
+   * OAuth 2FA verification endpoint.
+   */
+  .post(
+    '/verify-2fa',
+    sValidator(
+      'json',
+      z.object({
+        totpCode: z.string().trim().optional(),
+        backupCode: z.string().trim().optional(),
+      }),
+    ),
+    async (c) => {
+      const { totpCode, backupCode } = c.req.valid('json');
+      const requestMetadata = c.get('requestMetadata');
+
+      const userIdStr = await getSignedCookie(c, getAuthSecret(), oauth2faCookieName);
+
+      if (!userIdStr) {
+        throw new AppError(AuthenticationErrorCode.InvalidRequest, {
+          message: 'No pending OAuth 2FA session found',
+        });
+      }
+
+      const userId = Number(userIdStr);
+
+      const user = await prisma.user.findFirst({
+        where: { id: userId },
+        select: {
+          id: true,
+          email: true,
+          twoFactorEnabled: true,
+          twoFactorSecret: true,
+          twoFactorBackupCodes: true,
+        },
+      });
+
+      if (!user) {
+        throw new AppError(AuthenticationErrorCode.InvalidRequest);
+      }
+
+      const isValid = await validateTwoFactorAuthentication({
+        backupCode,
+        totpCode,
+        user,
+      });
+
+      if (!isValid) {
+        await prisma.userSecurityAuditLog.create({
+          data: {
+            userId: user.id,
+            ipAddress: requestMetadata.ipAddress,
+            userAgent: requestMetadata.userAgent,
+            type: UserSecurityAuditLogType.SIGN_IN_2FA_FAIL,
+          },
+        });
+
+        throw new AppError(AuthenticationErrorCode.InvalidTwoFactorCode);
+      }
+
+      // Fully authorize user
+      await onAuthorize({ userId: user.id }, c);
+
+      // Clear the pending cookie
+      deleteCookie(c, oauth2faCookieName, sessionCookieOptions);
+
+      return c.text('OK', 201);
+    },
+  );


### PR DESCRIPTION
# Resolves: OAuth 2FA Bypass Vulnerability (Issue #2758)

## Overview
This Pull Request resolves a critical security bypass where an attacker compromising a user's OAuth Identity Provider (e.g., Google or Microsoft) could successfully log into their Documenso account, bypassing the configured Documenso-level Two-Factor Authentication (2FA) entirely.

## Architectural Changes
The patch intercepts the standard `onAuthorize` callback flow when 2FA is enabled without breaking the user experience or duplicating complex UI components.

1. **Backend Intercepts (`packages/auth/server/lib/utils/handle-oauth-callback-url.ts` & `handle-oauth-organisation-callback-url.ts`)**
   - The user profile is retrieved during the callback to check `twoFactorEnabled`.
   - If active, we securely store the pending `userId` in an encrypted, signed short-lived cookie: `oauth2faCookieName`.
   - The flow is interrupted, redirecting to `/signin?oauth2fa=true` (preserving `returnTo`).

2. **Dedicated Verification Endpoint (`packages/auth/server/routes/oauth.ts`)**
   - Introduced a new `POST /verify-2fa` route under the OAuth router.
   - It securely parses the `oauth2faUserId` cookie, retrieves the user profile, validates the TOTP/Backup code via standard internal utility functions, establishes the full session via `onAuthorize()`, and clears the temporary cookie.

3. **Frontend Integration (`apps/remix/app/components/forms/signin.tsx` & `packages/auth/client/index.ts`)**
   - The `SignInForm` component seamlessly detects `oauth2fa=true` in `searchParams`.
   - It automatically invokes the existing 2FA modal `setIsTwoFactorAuthenticationDialogOpen(true)`.
   - Upon submitting the 2FA code while in OAuth 2FA mode, it securely posts to `authClient.oauth.verify2fa` to finalize the login.

## Security Considerations
- Utilized Hono's `setSignedCookie` driven by `NEXTAUTH_SECRET` to prevent tampering of the pending `userId` token.
- Ensured `UserSecurityAuditLog` is populated for failed OAuth 2FA code attempts for forensics and brute-force monitoring.
- Preserved existing `validateTwoFactorAuthentication` modules for reliable codebase consistency.

## Checklist
- [x] Tested OAuth login with 2FA disabled (Standard Flow intact)
- [x] Tested OAuth login with 2FA enabled (Intercepts and prompts for code)
- [x] Tested invalid 2FA code submission (Fails correctly)
- [x] Tested valid 2FA code submission (Succeeds and authorizes session)

*Note: Closes algorithmic bounty #2758.*
