### PR TITLE
fix: handleInitialsFieldClick now returns initialsToInsert instead of initials

### DIFF
--- a/apps/remix/app/utils/field-signing/initial-field.ts
+++ b/apps/remix/app/utils/field-signing/initial-field.ts
@@ -40,6 +40,6 @@ export const handleInitialsFieldClick = async (
 
   return {
     type: FieldType.INITIALS,
-    value: initials,
+    value: initialsToInsert,
   };
 };


### PR DESCRIPTION
## Summary

Fixes bug #3 from the Faultmark scan (issue #2829): `handleInitialsFieldClick` always submitted `null` as the initials value because the return statement used `value: initials` (the original input parameter, always null after the dialog call) instead of `value: initialsToInsert` (the user's typed input).

### Root cause
The function stored the dialog result in `initialsToInsert` (line 31) but returned `value: initials` (line 43) — the original destructured parameter which was always null after the first successful dialog call.

### Fix
Changed line 43 from `value: initials` to `value: initialsToInsert`.

### Verification
- TypeScript compiles cleanly with `npx tsc --noEmit`

Closes ... (partially addresses #2829)