### PR TITLE
fix: remove duplicate loadingSpinnerGroup.destroy() in DROPDOWN sign

### DIFF
--- a/apps/remix/app/components/general/envelope-signing/envelope-signer-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-signing/envelope-signer-page-renderer.tsx
@@ -334,8 +334,6 @@ export const EnvelopeSignerPageRenderer = ({ pageData }: { pageData: PageRenderD
                 fieldGroup.add(loadingSpinnerGroup);
                 await signField(field.id, payload);
               }
-
-              loadingSpinnerGroup.destroy();
             })
             .finally(() => {
               loadingSpinnerGroup.destroy();


### PR DESCRIPTION
## Summary

Fixes bug #4 from the Faultmark scan (issue #2829): `loadingSpinnerGroup.destroy()` was called both inside `.then()` (line 338) and `.finally()` (line 341). Since `.finally()` always runs after `.then()`, the Konva group was destroyed twice on every successful DROPDOWN sign.

### Fix
Removed the destroy() call inside `.then()` — the `.finally()` block handles cleanup in all cases (success or error).

Partially addresses #2829