### PR TITLE
fix: correct reversed comparison in admin organisations table pagination

### DIFF
--- a/apps/remix/app/components/tables/admin-organisations-table.tsx
+++ b/apps/remix/app/components/tables/admin-organisations-table.tsx
@@ -238,7 +238,7 @@ export const AdminOrganisationsTable = ({
         }}
       >
         {(table) =>
-          !hidePaginationUntilOverflow || 1 > table.getPageCount() ? (
+          !hidePaginationUntilOverflow || table.getPageCount() > 1 ? (
             <DataTablePagination additionalInformation="VisibleCount" table={table} />
           ) : null
         }


### PR DESCRIPTION
## Summary

Fixes bug #5 from the Faultmark scan (issue #2829): the admin organisations table pagination was permanently hidden because the comparison was reversed.

### Root cause
Line 241 had `1 > table.getPageCount()` — the literal `1` and `getPageCount()` were swapped. `1 > getPageCount()` is only true when there are zero pages, which never happens in practice. The pagination bar was never shown.

### Fix
Changed to `table.getPageCount() > 1` — pagination now correctly shows when there are multiple pages.

Partially addresses #2829