### PR TITLE
fix: prevent crash when removing last dropdown option in removeValue

### DIFF
--- a/apps/remix/app/components/forms/editor/editor-field-dropdown-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-dropdown-form.tsx
@@ -116,11 +116,12 @@ export const EditorFieldDropdownForm = ({
     }
 
     const newValues = [...currentValues];
+    const removedValue = currentValues[index].value;
     newValues.splice(index, 1);
 
     form.setValue('values', newValues);
 
-    if (form.getValues('defaultValue') === newValues[index].value) {
+    if (form.getValues('defaultValue') === removedValue) {
       form.setValue('defaultValue', undefined);
     }
   };


### PR DESCRIPTION
## Summary

Fixes bug #6 from the Faultmark scan (issue #2829): `removeValue` crashes when removing the last item from the dropdown options list.

### Root cause
After `newValues.splice(index, 1)`, the code checked `newValues[index].value`. But `newValues[index]` is the element that shifted into that position after the splice. If the removed item was the last one, `newValues[index]` is `undefined` -> runtime crash.

### Fix
Capture the `removedValue` from `currentValues[index].value` before the splice, then compare `defaultValue` against the captured value.

Partially addresses #2829