### PR TITLE
fix(prisma): stop large-team-seed running on import

### DIFF
--- a/packages/prisma/seed/large-team-seed.ts
+++ b/packages/prisma/seed/large-team-seed.ts
@@ -63,4 +63,6 @@ const main = async () => {
   }
 };
 
-void main();
+if (require.main === module) {
+  void main();
+}


### PR DESCRIPTION
## Problem

Resetting and re-seeding the DB fails partway through `medium-account-seed.ts`:

```
PrismaClientUnknownRequestError:
Invalid `prisma.recipient.create()` invocation in
packages/prisma/seed/medium-account-seed.ts:48:30
Response from the Engine was empty
```

## Cause

`packages/prisma/seed-database.ts` `require()`s every file in `seed/` to look for a `seedDatabase` export. `large-team-seed.ts` invokes `void main()` at the top level, so the require() side-effect kicks off its work concurrently with the sequential seed wrapper. When `large-team-seed.ts`'s `finally` block calls `prisma.$disconnect()` it closes the client mid-flight — `medium-account-seed.ts`'s next write fails with "Response from the Engine was empty".

The interleaved log proves the race:

```
[SEEDING]: initial-seed.ts
[SEEDING]: Creating team with 200 organisation members...   ← from large-team-seed
[SEEDING]: medium-account-seed.ts
[SEEDING]: Creating medium account with 1000 documents...
[SEEDING]: Created 0/1000 documents...
[SEEDING]: Attaching 50 org members to the team's role group...   ← large-team-seed continuing
[SEEDING]: Done.   ← large-team-seed about to $disconnect()
...
[SEEDING]: Seed failed for medium-account-seed.ts
```

## Fix

Guard `void main()` with `require.main === module` so `large-team-seed.ts` only auto-runs when invoked directly (`tsx packages/prisma/seed/large-team-seed.ts`), matching its documented one-off usage.