### PR TITLE
fix: delete dialog flash-closes when triggered from documents table dropdown

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-delete-dialog.tsx
@@ -24,6 +24,8 @@ type EnvelopeDeleteDialogProps = {
   id: string;
   type: EnvelopeType;
   trigger?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   onDelete?: () => Promise<void> | void;
   status: DocumentStatus;
   title: string;
@@ -34,6 +36,8 @@ export const EnvelopeDeleteDialog = ({
   id,
   type,
   trigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
   onDelete,
   status,
   title,
@@ -45,11 +49,20 @@ export const EnvelopeDeleteDialog = ({
 
   const deleteMessage = msg`delete`;
 
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [isDeleteEnabled, setIsDeleteEnabled] = useState(status === DocumentStatus.DRAFT);
 
   const isDocument = type === EnvelopeType.DOCUMENT;
+
+  // Support both controlled (open/onOpenChange props) and uncontrolled (trigger prop) usage.
+  const open = controlledOpen ?? internalOpen;
+
+  const onOpenChange = (value: boolean) => {
+    if (isPending) return;
+    setInternalOpen(value);
+    controlledOnOpenChange?.(value);
+  };
 
   const { mutateAsync: deleteEnvelope, isPending } = trpcReact.envelope.delete.useMutation({
     onSuccess: async () => {
@@ -71,7 +84,7 @@ export const EnvelopeDeleteDialog = ({
 
       await onDelete?.();
 
-      setOpen(false);
+      onOpenChange(false);
     },
     onError: () => {
       toast({
@@ -98,8 +111,8 @@ export const EnvelopeDeleteDialog = ({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(value) => !isPending && setOpen(value)}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
 
       <DialogContent>
         <DialogHeader>

--- a/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
+++ b/apps/remix/app/components/tables/documents-table-action-dropdown.tsx
@@ -56,6 +56,7 @@ export const DocumentsTableActionDropdown = ({ row, onMoveDocument }: DocumentsT
   const { _ } = useLingui();
   const trpcUtils = trpcReact.useUtils();
 
+  const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isRenameDialogOpen, setRenameDialogOpen] = useState(false);
   const [isSaveAsTemplateDialogOpen, setSaveAsTemplateDialogOpen] = useState(false);
 
@@ -190,21 +191,10 @@ export const DocumentsTableActionDropdown = ({ row, onMoveDocument }: DocumentsT
           Void
         </DropdownMenuItem> */}
 
-        <EnvelopeDeleteDialog
-          id={row.envelopeId}
-          type={EnvelopeType.DOCUMENT}
-          status={row.status}
-          title={row.title}
-          canManageDocument={canManageDocument}
-          trigger={
-            <DropdownMenuItem asChild onSelect={(e) => e.preventDefault()}>
-              <div>
-                <Trash2 className="mr-2 h-4 w-4" />
-                {canManageDocument ? _(msg`Delete`) : _(msg`Hide`)}
-              </div>
-            </DropdownMenuItem>
-          }
-        />
+        <DropdownMenuItem onClick={() => setDeleteDialogOpen(true)}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          {canManageDocument ? _(msg`Delete`) : _(msg`Hide`)}
+        </DropdownMenuItem>
 
         <DropdownMenuLabel>
           <Trans>Share</Trans>
@@ -239,6 +229,16 @@ export const DocumentsTableActionDropdown = ({ row, onMoveDocument }: DocumentsT
           )}
         />
       </DropdownMenuContent>
+
+      <EnvelopeDeleteDialog
+        id={row.envelopeId}
+        type={EnvelopeType.DOCUMENT}
+        status={row.status}
+        title={row.title}
+        canManageDocument={canManageDocument}
+        open={isDeleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+      />
 
       <EnvelopeSaveAsTemplateDialog
         envelopeId={row.envelopeId}


### PR DESCRIPTION
Closes #2813

## What changed

The delete dialog in the documents table action dropdown was flash-closing immediately when opened.

**Root cause:** The classic Radix UI `Dialog`-inside-`DropdownMenuContent` focus-trap collision. `EnvelopeDeleteDialog` rendered as a child of `<DropdownMenuContent>` caused both components to compete for focus on mount, making the dialog close before the user could interact with it.

**Fix:** Two-part change matching the pattern already used by `EnvelopeSaveAsTemplateDialog` and `EnvelopeRenameDialog` in the same component:

1. **`EnvelopeDeleteDialog`** — Added optional controlled `open` / `onOpenChange` props. Uncontrolled/trigger-prop usage still works for other callers.

2. **`DocumentsTableActionDropdown`** — Moved `<EnvelopeDeleteDialog>` outside `<DropdownMenuContent>` as a sibling, driven by `isDeleteDialogOpen` state. The `<DropdownMenuItem>` uses a plain `onClick` instead of the trigger-prop pattern.

## How to test

1. Go to `/documents`
2. Open the three-dot action menu on any document
3. Click **Delete** (or **Hide**)
4. The delete confirmation dialog should open and stay open ✅

Previously it would flash for one frame and immediately dismiss.