### PR TITLE
fix(docs): correct broken internal docs links

### DIFF
--- a/apps/docs/content/docs/compliance/standards.mdx
+++ b/apps/docs/content/docs/compliance/standards.mdx
@@ -97,12 +97,12 @@ Documenso implements digital signatures with the following characteristics:
 - **Timestamps**: RFC 3161 timestamps can be applied to signatures
 - **Signature visualization**: Signed documents include visual signature representations
 
-For specific implementation details and configuration options, refer to the [signing certificates](/signing-certificates/overview) documentation.
+For specific implementation details and configuration options, refer to the [signing certificates](/docs/concepts/signing-certificates) documentation.
 
 Self-hosted deployments can configure their own signing certificates and timestamp authorities to meet specific compliance requirements.
 
 ## Related
 
-- [Legal Validity](/compliance/legal-validity) - Legal frameworks for electronic signatures
-- [Signing Certificates Overview](/signing-certificates/overview) - Certificate configuration
-- [Audit Log](/features/audit-log) - Document activity tracking
+- [E-Sign Compliance](/docs/compliance/esign) - Legal frameworks for electronic signatures
+- [Signing Certificates](/docs/concepts/signing-certificates) - Certificate configuration
+- [Signing Workflow](/docs/concepts/signing-workflow) - Document activity and audit trail

--- a/apps/docs/content/docs/concepts/recipient-roles.mdx
+++ b/apps/docs/content/docs/concepts/recipient-roles.mdx
@@ -167,5 +167,5 @@ To enable sequential signing:
 
 ## Related
 
-- [Add Recipients](/users/documents/add-recipients) - How to add recipients to a document
-- [Field Types](/concepts/field-types) - Learn about the different field types you can assign to recipients
+- [Add Recipients](/docs/users/documents/add-recipients) - How to add recipients to a document
+- [Field Types](/docs/concepts/field-types) - Learn about the different field types you can assign to recipients


### PR DESCRIPTION
## What changed

Corrects broken internal docs links in the compliance standards and recipient roles pages.

## Why

Some links pointed to old/non-existent routes such as `/users/...`, `/concepts/...`, `/signing-certificates/overview`, and `/features/audit-log`.

## Testing

- Ran `git diff --check`
- Verified the updated `/docs/...` links resolve to existing MDX content
