### PR TITLE
fix(docker): add unless-stopped restart policies to production compose

### DIFF
--- a/docker/production/compose.yml
+++ b/docker/production/compose.yml
@@ -3,6 +3,7 @@ name: documenso-production
 services:
   database:
     image: postgres:15
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:?err}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?err}
@@ -17,6 +18,7 @@ services:
 
   documenso:
     image: documenso/documenso:latest
+    restart: unless-stopped
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
Fixes #2721

This PR adds the `restart: unless-stopped` policy to both the database and the Documenso app containers in `docker/production/compose.yml` to prevent them from staying down in production if they crash.