### PR TITLE
fix(signing): enforce drawn/uploaded signature toggles on the server

### DIFF
--- a/packages/lib/server-only/field/sign-field-with-token.ts
+++ b/packages/lib/server-only/field/sign-field-with-token.ts
@@ -25,6 +25,7 @@ import {
 import type { RequestMetadata } from '../../universal/extract-request-metadata';
 import { createDocumentAuditLogData } from '../../utils/document-audit-logs';
 import { assertRecipientNotExpired } from '../../utils/recipients';
+import { assertSignatureModeAllowed } from '../../utils/signature-mode';
 import { validateFieldAuth } from '../document/validate-field-auth';
 
 export type SignFieldWithTokenOptions = {
@@ -204,8 +205,12 @@ export const signFieldWithToken = async ({
     throw new Error('Signature field must have a signature');
   }
 
-  if (isSignatureField && documentMeta?.typedSignatureEnabled === false && typedSignature) {
-    throw new Error('Typed signatures are not allowed. Please draw your signature');
+  if (isSignatureField && documentMeta) {
+    if (typedSignature) {
+      assertSignatureModeAllowed('typed', documentMeta);
+    } else if (signatureImageAsBase64) {
+      assertSignatureModeAllowed('image', documentMeta);
+    }
   }
 
   if (field.fieldMeta?.readOnly && !AUTO_SIGNABLE_FIELD_TYPES.includes(field.type)) {

--- a/packages/lib/utils/envelope-signing.ts
+++ b/packages/lib/utils/envelope-signing.ts
@@ -15,6 +15,7 @@ import {
   ZTextFieldMeta,
 } from '@documenso/lib/types/field-meta';
 import { toCheckboxCustomText, toRadioCustomText } from '@documenso/lib/utils/fields';
+import { assertSignatureModeAllowed } from '@documenso/lib/utils/signature-mode';
 import { zEmail } from '@documenso/lib/utils/zod';
 import type { TSignEnvelopeFieldValue } from '@documenso/trpc/server/envelope-router/sign-envelope-field.types';
 import { checkboxValidationSigns } from '@documenso/ui/primitives/document-flow/field-items-advanced-settings/constants';
@@ -27,7 +28,10 @@ import { z } from 'zod';
 export type ExtractFieldInsertionValuesOptions = {
   fieldValue: TSignEnvelopeFieldValue;
   field: Field;
-  documentMeta: Pick<TDocumentMeta, 'timezone' | 'dateFormat' | 'typedSignatureEnabled'>;
+  documentMeta: Pick<
+    TDocumentMeta,
+    'timezone' | 'dateFormat' | 'typedSignatureEnabled' | 'drawSignatureEnabled' | 'uploadSignatureEnabled'
+  >;
 };
 
 export const extractFieldInsertionValues = ({
@@ -238,11 +242,7 @@ export const extractFieldInsertionValues = ({
 
       const isBase64 = isBase64Image(value);
 
-      if (documentMeta.typedSignatureEnabled === false && !isBase64) {
-        throw new AppError(AppErrorCode.INVALID_BODY, {
-          message: 'Typed signatures are not allowed. Please draw your signature',
-        });
-      }
+      assertSignatureModeAllowed(isBase64 ? 'image' : 'typed', documentMeta);
 
       return {
         customText: '',

--- a/packages/lib/utils/signature-mode.test.ts
+++ b/packages/lib/utils/signature-mode.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertSignatureModeAllowed, isSignatureModeAllowed } from './signature-mode';
+
+describe('isSignatureModeAllowed', () => {
+  describe('typed signatures', () => {
+    it('is allowed when typedSignatureEnabled is true', () => {
+      expect(isSignatureModeAllowed('typed', { typedSignatureEnabled: true })).toBe(true);
+    });
+
+    it('is allowed when typedSignatureEnabled is unset (default-on)', () => {
+      expect(isSignatureModeAllowed('typed', {})).toBe(true);
+    });
+
+    it('is allowed when typedSignatureEnabled is null (default-on)', () => {
+      expect(isSignatureModeAllowed('typed', { typedSignatureEnabled: null })).toBe(true);
+    });
+
+    it('is rejected only when typedSignatureEnabled is explicitly false', () => {
+      expect(isSignatureModeAllowed('typed', { typedSignatureEnabled: false })).toBe(false);
+    });
+  });
+
+  describe('image signatures (drawn or uploaded)', () => {
+    it('is allowed when both drawSignatureEnabled and uploadSignatureEnabled are unset', () => {
+      expect(isSignatureModeAllowed('image', {})).toBe(true);
+    });
+
+    it('is allowed when only drawSignatureEnabled is true', () => {
+      expect(
+        isSignatureModeAllowed('image', {
+          drawSignatureEnabled: true,
+          uploadSignatureEnabled: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('is allowed when only uploadSignatureEnabled is true', () => {
+      expect(
+        isSignatureModeAllowed('image', {
+          drawSignatureEnabled: false,
+          uploadSignatureEnabled: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('is rejected only when BOTH drawSignatureEnabled and uploadSignatureEnabled are false', () => {
+      expect(
+        isSignatureModeAllowed('image', {
+          drawSignatureEnabled: false,
+          uploadSignatureEnabled: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('treats null the same as unset (default-on)', () => {
+      expect(
+        isSignatureModeAllowed('image', {
+          drawSignatureEnabled: null,
+          uploadSignatureEnabled: null,
+        }),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('assertSignatureModeAllowed', () => {
+  it('does not throw when mode is allowed', () => {
+    expect(() => assertSignatureModeAllowed('typed', { typedSignatureEnabled: true })).not.toThrow();
+    expect(() =>
+      assertSignatureModeAllowed('image', { drawSignatureEnabled: true, uploadSignatureEnabled: false }),
+    ).not.toThrow();
+  });
+
+  it('throws with the typed-specific message when typed is disabled', () => {
+    expect(() => assertSignatureModeAllowed('typed', { typedSignatureEnabled: false })).toThrow(
+      /typed signatures are not allowed/i,
+    );
+  });
+
+  it('throws with the image-specific message when both drawn and uploaded are disabled', () => {
+    expect(() =>
+      assertSignatureModeAllowed('image', {
+        drawSignatureEnabled: false,
+        uploadSignatureEnabled: false,
+      }),
+    ).toThrow(/drawn or uploaded signatures are not allowed/i);
+  });
+});

--- a/packages/lib/utils/signature-mode.ts
+++ b/packages/lib/utils/signature-mode.ts
@@ -1,0 +1,45 @@
+import { AppError, AppErrorCode } from '../errors/app-error';
+
+export type SignatureMode = 'typed' | 'image';
+
+/**
+ * Subset of documentMeta needed to evaluate whether a given signature
+ * input mode is permitted. All three flags are tri-state in the DB
+ * (true / false / null|undefined); only an explicit `false` disables.
+ */
+export type SignatureModeSettings = {
+  typedSignatureEnabled?: boolean | null;
+  drawSignatureEnabled?: boolean | null;
+  uploadSignatureEnabled?: boolean | null;
+};
+
+/**
+ * Decide whether a signature submitted in `mode` is permitted by the
+ * document's signature-input settings.
+ *
+ * Note: the server cannot distinguish a drawn signature from an uploaded
+ * one — both arrive as a PNG data URL. We therefore treat the `image`
+ * mode as allowed when *either* `drawSignatureEnabled` or
+ * `uploadSignatureEnabled` is enabled, and only reject when *both* are
+ * explicitly disabled.
+ */
+export const isSignatureModeAllowed = (mode: SignatureMode, settings: SignatureModeSettings): boolean => {
+  if (mode === 'typed') {
+    return settings.typedSignatureEnabled !== false;
+  }
+
+  return settings.drawSignatureEnabled !== false || settings.uploadSignatureEnabled !== false;
+};
+
+export const assertSignatureModeAllowed = (mode: SignatureMode, settings: SignatureModeSettings): void => {
+  if (isSignatureModeAllowed(mode, settings)) {
+    return;
+  }
+
+  const message =
+    mode === 'typed'
+      ? 'Typed signatures are not allowed. Please draw your signature'
+      : 'Drawn or uploaded signatures are not allowed. Please type your signature';
+
+  throw new AppError(AppErrorCode.INVALID_BODY, { message });
+};


### PR DESCRIPTION
## Summary

A document author can disable each of the three signature-input modes independently via `documentMeta.typedSignatureEnabled`, `drawSignatureEnabled`, and `uploadSignatureEnabled`. The UI hides the inputs accordingly, but only the **typed** mode was enforced server-side. A direct API caller (or anyone bypassing the UI) could still submit a drawn or uploaded signature for a document where the author had disabled those modes, silently bypassing the author's configured policy.

## The gap

Two server-side signing paths existed, each checking only `typedSignatureEnabled`:

- `packages/lib/server-only/field/sign-field-with-token.ts:207` (V1 signing path)
- `packages/lib/utils/envelope-signing.ts:241` (V2 signing path)

A grep across `packages/lib/server-only/field` and `packages/lib/server-only/document` for `drawSignatureEnabled` / `uploadSignatureEnabled` returned no enforcement points.

## Fix

Introduce a small pure helper, `assertSignatureModeAllowed`, in `packages/lib/utils/signature-mode.ts`, and call it from both signing paths.

**Design note on drawn vs. uploaded:** the server cannot distinguish the two — both arrive as a `data:image/png;base64,…` data URL (see `packages/lib/constants/signatures.ts:4`). The helper therefore treats the `image` mode as one category and rejects it only when **both** `drawSignatureEnabled` and `uploadSignatureEnabled` are explicitly `false`. If either is enabled, image signatures continue to be accepted. This matches the existing tri-state convention where `null` / `undefined` is treated as "enabled".

The typed-mode path is unchanged in behaviour; it now flows through the same helper for consistency. Rejections raise `AppError(INVALID_BODY)` so API clients receive a structured 400 rather than an opaque 500.

## Files changed

| File | Change |
|---|---|
| `packages/lib/utils/signature-mode.ts` | new — pure helper |
| `packages/lib/utils/signature-mode.test.ts` | new — 12 unit tests |
| `packages/lib/server-only/field/sign-field-with-token.ts` | route both modes through the helper |
| `packages/lib/utils/envelope-signing.ts` | same; extend the `documentMeta` `Pick` to expose the two new flags |

## Test plan

- [x] `npx vitest run` in `packages/lib` → **121 passing, 0 failing** (12 new + 109 pre-existing)
- [x] `biome check` on touched files → clean
- [x] `tsc --noEmit` → no new errors on touched files
- [ ] Manual repro in the dev app: create a document with `drawSignatureEnabled: false` **and** `uploadSignatureEnabled: false`, attempt to sign with a drawn signature via the API/tRPC, expect a 400 with the new message. *(Not run by me; maintainer or reviewer to verify in a running env.)*

## Out of scope / follow-ups

- No e2e (Playwright) coverage added. The existing e2e suite under `packages/app-tests/e2e` does not appear to exercise the draw/upload-disabled paths; happy to add one in a follow-up if desired.
- The same tri-state rule (only `=== false` disables) is preserved. If the project would prefer "any falsy disables", that is a separate behaviour change and should be discussed before being made.

## Notes for the maintainer

This is my first contribution here — please tell me if any of the following should change:
- commit / PR title format
- where the helper lives (currently colocated in `packages/lib/utils/` alongside `sanitize-branding-css.ts` etc., matching the existing test-file colocation pattern)
- whether the typed-mode rejection should also migrate from `throw new Error(...)` to `AppError` for consistency (kept the original `throw` to minimise surface area of this PR)
