### PR TITLE
fix(ui): direct signing templates window layout

### DIFF
--- a/apps/remix/app/components/dialogs/public-profile-template-manage-dialog.tsx
+++ b/apps/remix/app/components/dialogs/public-profile-template-manage-dialog.tsx
@@ -222,7 +222,7 @@ export const ManagePublicTemplateDialog = ({
             .with({ currentStep: 'SELECT_TEMPLATE' }, () => (
               <DialogContent>
                 <DialogHeader>
-                  <DialogTitle>
+                  <DialogTitle className="w-full max-w-full whitespace-pre-line break-words">
                     {team?.name ? (
                       <Trans>{team.name} direct signing templates</Trans>
                     ) : (


### PR DESCRIPTION
## Description

I fixed direct signing templates window layout on `/settings/public-profile` page. When title is longer (for example in other languages), window layout is broken. Simple CSS class fixes it.

Before:
<img width="1103" height="583" alt="Zrzut ekranu 2026-06-01 210259" src="https://github.com/user-attachments/assets/e1e529f9-8fcc-4302-bc3f-c9f9ad023b32" />

After:
<img width="943" height="622" alt="Zrzut ekranu 2026-06-01 210354" src="https://github.com/user-attachments/assets/efd155b7-1b08-4169-adba-fab4e7e4ea5d" />


## Changes Made

- Add CSS class to DialogTitle.

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- Tested locally
- `npm run build`

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
