### PR TITLE
fix: send completed document copy to CC recipients

### DIFF
--- a/packages/lib/jobs/definitions/emails/send-document-completed-emails.handler.test.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-completed-emails.handler.test.ts
@@ -1,0 +1,192 @@
+import { DocumentDistributionMethod, DocumentSource, RecipientRole } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMailMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@documenso/email/mailer', () => ({
+  mailer: {
+    sendMail: (...args: unknown[]) => sendMailMock(...args),
+  },
+}));
+
+vi.mock('@documenso/prisma', () => ({
+  prisma: {
+    envelope: {
+      findUnique: vi.fn(),
+    },
+    documentAuditLog: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+vi.mock('../../../server-only/email/get-email-context', () => ({
+  getEmailContext: vi.fn().mockResolvedValue({
+    branding: {},
+    emailLanguage: 'en',
+    senderEmail: 'Documenso <noreply@documenso.com>',
+    replyToEmail: 'noreply@documenso.com',
+  }),
+}));
+
+vi.mock('../../../universal/upload/get-file.server', () => ({
+  getFileServerSide: vi.fn().mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46])),
+}));
+
+vi.mock('../../../client-only/providers/i18n-server', () => ({
+  getI18nInstance: vi.fn().mockResolvedValue({
+    _: (message: string | { id?: string }) =>
+      typeof message === 'string' ? message : (message?.id ?? 'Signing Complete!'),
+  }),
+}));
+
+vi.mock('../../../utils/render-email-with-i18n', () => ({
+  renderEmailWithI18N: vi.fn().mockResolvedValue('<html>test</html>'),
+}));
+
+vi.mock('@lingui/core/macro', () => ({
+  msg: (strings: TemplateStringsArray) => strings[0] ?? '',
+}));
+
+import { prisma } from '@documenso/prisma';
+
+import { run } from './send-document-completed-emails.handler';
+
+const owner = {
+  id: 1,
+  email: 'example@documenso.com',
+  name: 'Example User',
+};
+
+const signer = {
+  id: 10,
+  email: 'signer@test.documenso.com',
+  name: 'Test Signer',
+  role: RecipientRole.SIGNER,
+  token: 'signer-token',
+};
+
+const ccRecipient = {
+  id: 11,
+  email: 'cc@test.documenso.com',
+  name: 'Test CC',
+  role: RecipientRole.CC,
+  token: 'cc-token',
+};
+
+const buildEnvelope = (documentMeta: Record<string, unknown>) => ({
+  id: 'envelope_test_2887',
+  title: 'Neel_Manro_Resume.pdf',
+  internalVersion: 1,
+  source: DocumentSource.DOCUMENT,
+  teamId: 1,
+  userId: owner.id,
+  documentMeta,
+  recipients: [signer, ccRecipient],
+  user: owner,
+  team: { id: 1, url: 'personal_team' },
+  envelopeItems: [
+    {
+      title: 'Neel_Manro_Resume.pdf',
+      documentData: {
+        type: 'BYTES_64',
+        id: 'docdata_1',
+        data: '',
+      },
+    },
+  ],
+});
+
+const getSentAddresses = () =>
+  sendMailMock.mock.calls.map((call) => {
+    const mailOptions = call[0] as { to: { address: string } | { address: string }[] };
+    const recipients = Array.isArray(mailOptions.to) ? mailOptions.to : [mailOptions.to];
+
+    return recipients.map((recipient) => recipient.address);
+  });
+
+const hasPdfAttachment = (callIndex: number) => {
+  const mailOptions = sendMailMock.mock.calls[callIndex]?.[0] as {
+    attachments?: { contentType?: string }[];
+  };
+
+  return mailOptions.attachments?.some((attachment) => attachment.contentType === 'application/pdf') ?? false;
+};
+
+describe('send-document-completed-emails.handler', () => {
+  beforeEach(() => {
+    sendMailMock.mockClear();
+    vi.mocked(prisma.envelope.findUnique).mockReset();
+    vi.mocked(prisma.documentAuditLog.create).mockClear();
+  });
+
+  it('emails signer and CC when document completed emails are enabled', async () => {
+    vi.mocked(prisma.envelope.findUnique).mockResolvedValue(
+      buildEnvelope({
+        distributionMethod: DocumentDistributionMethod.EMAIL,
+        emailSettings: {
+          documentCompleted: true,
+          ownerDocumentCompleted: true,
+        },
+      }) as never,
+    );
+
+    await run({
+      payload: { envelopeId: 'envelope_test_2887' },
+      io: {} as never,
+    });
+
+    const allAddresses = getSentAddresses().flat();
+
+    expect(allAddresses).toContain('signer@test.documenso.com');
+    expect(allAddresses).toContain('cc@test.documenso.com');
+    expect(sendMailMock).toHaveBeenCalled();
+    expect(hasPdfAttachment(0)).toBe(true);
+  });
+
+  it('emails CC (not signer) when distribution is NONE but owner completion emails are enabled', async () => {
+    vi.mocked(prisma.envelope.findUnique).mockResolvedValue(
+      buildEnvelope({
+        distributionMethod: DocumentDistributionMethod.NONE,
+        emailSettings: {
+          documentCompleted: true,
+          ownerDocumentCompleted: true,
+        },
+      }) as never,
+    );
+
+    await run({
+      payload: { envelopeId: 'envelope_test_2887' },
+      io: {} as never,
+    });
+
+    const allAddresses = getSentAddresses().flat();
+
+    expect(allAddresses).toContain('example@documenso.com');
+    expect(allAddresses).toContain('cc@test.documenso.com');
+    expect(allAddresses).not.toContain('signer@test.documenso.com');
+  });
+
+  it('emails owner separately when owner is not a recipient and recipient emails are off', async () => {
+    vi.mocked(prisma.envelope.findUnique).mockResolvedValue(
+      buildEnvelope({
+        distributionMethod: DocumentDistributionMethod.EMAIL,
+        emailSettings: {
+          documentCompleted: false,
+          ownerDocumentCompleted: true,
+        },
+      }) as never,
+    );
+
+    await run({
+      payload: { envelopeId: 'envelope_test_2887' },
+      io: {} as never,
+    });
+
+    const allAddresses = getSentAddresses().flat();
+
+    expect(allAddresses).toContain('example@documenso.com');
+    expect(allAddresses).toContain('cc@test.documenso.com');
+    expect(allAddresses).not.toContain('signer@test.documenso.com');
+  });
+});

--- a/packages/lib/jobs/definitions/emails/send-document-completed-emails.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-completed-emails.handler.ts
@@ -12,8 +12,8 @@ import { DOCUMENT_AUDIT_LOG_TYPE } from '../../../types/document-audit-logs';
 import { extractDerivedDocumentEmailSettings } from '../../../types/document-email';
 import { getFileServerSide } from '../../../universal/upload/get-file.server';
 import { createDocumentAuditLogData } from '../../../utils/document-audit-logs';
+import { getDocumentCompletedEmailRecipients } from '../../../utils/document-completed-email-recipients';
 import { unsafeBuildEnvelopeIdQuery } from '../../../utils/envelope';
-import { isRecipientEmailValidForSending } from '../../../utils/recipients';
 import { renderCustomEmailTemplate } from '../../../utils/render-custom-email-template';
 import { renderEmailWithI18N } from '../../../utils/render-email-with-i18n';
 import { formatDocumentsPath } from '../../../utils/teams';
@@ -164,11 +164,11 @@ export const run = async ({ payload, io }: { payload: TSendDocumentCompletedEmai
     });
   }
 
-  if (!isDocumentCompletedEmailEnabled) {
+  const recipientsToNotify = getDocumentCompletedEmailRecipients(envelope.recipients, emailSettings);
+
+  if (recipientsToNotify.length === 0) {
     return;
   }
-
-  const recipientsToNotify = envelope.recipients.filter((recipient) => isRecipientEmailValidForSending(recipient));
 
   await Promise.all(
     recipientsToNotify.map(async (recipient) => {

--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -30,7 +30,6 @@ import { fieldsContainUnsignedRequiredField } from '../../../utils/advanced-fiel
 import { isDocumentCompleted } from '../../../utils/document';
 import { createDocumentAuditLogData } from '../../../utils/document-audit-logs';
 import { mapDocumentIdToSecondaryId } from '../../../utils/envelope';
-import { jobs } from '../../client';
 import type { JobRunIO } from '../../client/_internal/job';
 import type { TSealDocumentJobDefinition } from './seal-document';
 
@@ -318,12 +317,16 @@ export const run = async ({ payload, io }: { payload: TSealDocumentJobDefinition
   }
 
   if (shouldSendCompletedEmail) {
-    await jobs.triggerJob({
-      name: 'send.document.completed.emails',
-      payload: {
-        envelopeId,
-        requestMetadata,
-      },
+    await io.runTask('send-completed-email', async () => {
+      const { run: sendDocumentCompletedEmails } = await import('../emails/send-document-completed-emails.handler');
+
+      await sendDocumentCompletedEmails({
+        payload: {
+          envelopeId,
+          requestMetadata,
+        },
+        io,
+      });
     });
   }
 };

--- a/packages/lib/utils/document-completed-email-recipients.test.ts
+++ b/packages/lib/utils/document-completed-email-recipients.test.ts
@@ -1,0 +1,46 @@
+import { RecipientRole } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import { getDocumentCompletedEmailRecipients } from './document-completed-email-recipients';
+
+const signer = { email: 'signer@example.com', role: RecipientRole.SIGNER };
+const cc = { email: 'cc@example.com', role: RecipientRole.CC };
+const invalidCc = { email: 'not-an-email', role: RecipientRole.CC };
+
+describe('getDocumentCompletedEmailRecipients', () => {
+  it('returns all deliverable recipients when document completed emails are enabled', () => {
+    expect(
+      getDocumentCompletedEmailRecipients([signer, cc], {
+        documentCompleted: true,
+        ownerDocumentCompleted: true,
+      }),
+    ).toEqual([signer, cc]);
+  });
+
+  it('returns only CC recipients when recipient emails are disabled but owner emails are enabled', () => {
+    expect(
+      getDocumentCompletedEmailRecipients([signer, cc], {
+        documentCompleted: false,
+        ownerDocumentCompleted: true,
+      }),
+    ).toEqual([cc]);
+  });
+
+  it('returns no recipients when both completion email settings are disabled', () => {
+    expect(
+      getDocumentCompletedEmailRecipients([signer, cc], {
+        documentCompleted: false,
+        ownerDocumentCompleted: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it('filters out recipients with invalid email addresses', () => {
+    expect(
+      getDocumentCompletedEmailRecipients([invalidCc, cc], {
+        documentCompleted: true,
+        ownerDocumentCompleted: true,
+      }),
+    ).toEqual([cc]);
+  });
+});

--- a/packages/lib/utils/document-completed-email-recipients.ts
+++ b/packages/lib/utils/document-completed-email-recipients.ts
@@ -1,0 +1,31 @@
+import { RecipientRole } from '@prisma/client';
+
+import type { TDocumentEmailSettings } from '../types/document-email';
+import type { TRecipientLite } from '../types/recipient';
+import { isRecipientEmailValidForSending } from './recipients';
+
+type DocumentCompletedEmailRecipient = Pick<TRecipientLite, 'id' | 'email' | 'name' | 'role' | 'token'>;
+
+/**
+ * Recipients who should receive the document-completed email (with PDF attachment).
+ *
+ * Signers/viewers follow the `documentCompleted` setting. CC recipients still need the
+ * executed agreement when only the owner completion email is enabled (for example when
+ * distribution is not EMAIL and recipient notifications are derived off).
+ */
+export const getDocumentCompletedEmailRecipients = <T extends DocumentCompletedEmailRecipient>(
+  recipients: T[],
+  emailSettings: Pick<TDocumentEmailSettings, 'documentCompleted' | 'ownerDocumentCompleted'>,
+): T[] => {
+  const deliverableRecipients = recipients.filter((recipient) => isRecipientEmailValidForSending(recipient));
+
+  if (emailSettings.documentCompleted) {
+    return deliverableRecipients;
+  }
+
+  if (!emailSettings.ownerDocumentCompleted) {
+    return [];
+  }
+
+  return deliverableRecipients.filter((recipient) => recipient.role === RecipientRole.CC);
+};

--- a/scripts/test-it.ts
+++ b/scripts/test-it.ts
@@ -1,0 +1,67 @@
+/**
+ * Automated check for issue #2887 (CC completed-document emails).
+ *
+ * Run from repo root:
+ *   npx tsx scripts/test-it.ts
+ *
+ * Optional: pass a PDF path to verify it can be read (sanity check only):
+ *   npx tsx scripts/test-it.ts ~/Desktop/Neel_Manro_Resume.pdf
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const libRoot = path.join(repoRoot, 'packages/lib');
+
+const pdfArg = process.argv[2];
+
+if (pdfArg) {
+  const pdfPath = path.resolve(pdfArg);
+
+  if (!fs.existsSync(pdfPath)) {
+    console.error(`PDF not found: ${pdfPath}`);
+    process.exit(1);
+  }
+
+  const bytes = fs.readFileSync(pdfPath);
+  const isPdf = bytes.slice(0, 4).toString() === '%PDF';
+
+  console.log(`PDF: ${pdfPath}`);
+  console.log(`Size: ${bytes.length} bytes`);
+  console.log(`Valid PDF header: ${isPdf ? 'yes' : 'no'}`);
+
+  if (!isPdf) {
+    console.error('File is not a PDF — pick a .pdf file for the sanity check.');
+    process.exit(1);
+  }
+
+  console.log('');
+}
+
+console.log('Running automated CC completed-email tests...\n');
+
+const vitest = spawnSync(
+  'npx',
+  [
+    'vitest',
+    'run',
+    'utils/document-completed-email-recipients.test.ts',
+    'jobs/definitions/emails/send-document-completed-emails.handler.test.ts',
+  ],
+  {
+    cwd: libRoot,
+    stdio: 'inherit',
+    env: process.env,
+  },
+);
+
+if (vitest.status !== 0) {
+  process.exit(vitest.status ?? 1);
+}
+
+console.log('\nAll automated checks passed.');
+console.log('Manual Inbucket check (optional): confirm cc@test.documenso.com received "Signing Complete!".');


### PR DESCRIPTION
## Description

Fixes a regression where CC recipients did not receive the completed document email with the finalized PDF attached after all required recipients signed.

The completed email flow now includes CC recipients when owner completion emails are enabled, which matches the expected behavior for the "Receives copy" role.

## Related Issue

Fixes #2887

## Changes Made

- Added recipient selection logic for completed document emails so CC recipients are included in the completed PDF delivery flow.
- Updated the completed-email handler to use that shared recipient selection logic.
- Ran completed-email delivery inside the seal task to keep the completion flow reliable.
- Added automated tests covering standard recipient delivery, CC delivery, and owner-only completion email behavior.

## Testing Performed

- Ran automated tests for completed document email recipient selection.
- Ran automated tests for the completed-email handler, including CC recipients.
- Ran `npm run build` successfully.
- Manually tested a completed document with one signer and one CC recipient.
- Verified the completed-email audit log includes `DOCUMENT_COMPLETED` entries for owner, signer, and CC recipient.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

This change is focused on restoring expected CC recipient behavior for completed documents. CC recipients do not need to take signing action, but they should receive the finalized PDF once the document is completed.