### PR TITLE
fix: add org insight document complete stat

### DIFF
--- a/apps/remix/app/components/tables/organisation-insights-table.tsx
+++ b/apps/remix/app/components/tables/organisation-insights-table.tsx
@@ -207,7 +207,7 @@ export const OrganisationInsightsTable = ({
           <SummaryCard
             icon={TrendingUp}
             title={_(msg`Documents Completed`)}
-            value={insights.summary.volumeThisPeriod}
+            value={`${insights.summary.volumeThisPeriod}/${insights.summary.documentsThisPeriod}`}
           />
         </div>
       )}
@@ -269,7 +269,7 @@ const SummaryCard = ({
 }: {
   icon: React.ComponentType<{ className?: string }>;
   title: string;
-  value: number;
+  value: number | string;
   subtitle?: string;
 }) => (
   <div className="flex items-start gap-x-2 rounded-lg border bg-card px-4 py-3">

--- a/packages/lib/server-only/admin/get-organisation-detailed-insights.ts
+++ b/packages/lib/server-only/admin/get-organisation-detailed-insights.ts
@@ -10,6 +10,7 @@ export type OrganisationSummary = {
   activeDocuments: number;
   completedDocuments: number;
   volumeThisPeriod: number;
+  documentsThisPeriod: number;
   volumeAllTime: number;
 };
 
@@ -305,6 +306,10 @@ async function getOrganisationSummary(
         ? sql<number>`count(case when e.status = 'COMPLETED' and e."createdAt" >= ${createdAtFrom} then 1 end)`
         : sql<number>`count(case when e.status = 'COMPLETED' then 1 end)`
       ).as('volumeThisPeriod'),
+      (createdAtFrom
+        ? sql<number>`count(case when e."createdAt" >= ${createdAtFrom} then 1 end)`
+        : sql<number>`count(e.id)`
+      ).as('documentsThisPeriod'),
     ])
     .executeTakeFirst();
 
@@ -321,6 +326,7 @@ async function getOrganisationSummary(
     activeDocuments: Number(envelopeStats?.activeDocuments || 0),
     completedDocuments: Number(envelopeStats?.completedDocuments || 0),
     volumeThisPeriod: Number(envelopeStats?.volumeThisPeriod || 0),
+    documentsThisPeriod: Number(envelopeStats?.documentsThisPeriod || 0),
     volumeAllTime: Number(envelopeStats?.volumeAllTime || 0),
   };
 }


### PR DESCRIPTION
## Description

Show the document completed/volume in the admin organisation insights panel

<img width="337" height="112" alt="image" src="https://github.com/user-attachments/assets/76639082-3497-4c07-9353-98e920842f6d" />

