### PR TITLE
fix: prevent SSRF via IPv4-mapped IPv6 bypass in isPrivateUrl

### DIFF
--- a/packages/lib/server-only/webhooks/assert-webhook-url.test.ts
+++ b/packages/lib/server-only/webhooks/assert-webhook-url.test.ts
@@ -88,10 +88,10 @@ describe('assertNotPrivateUrl', () => {
   });
 
   describe('DNS failure handling', () => {
-    it('should silently allow when DNS lookup throws', async () => {
+    it('should reject when DNS lookup throws', async () => {
       const lookup = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
 
-      await expect(assertNotPrivateUrl('https://nonexistent.example.com', { lookup })).resolves.toBeUndefined();
+      await expect(assertNotPrivateUrl('https://nonexistent.example.com', { lookup })).rejects.toThrow(AppError);
     });
 
     it('should re-throw AppError even within the catch block', async () => {

--- a/packages/lib/server-only/webhooks/assert-webhook-url.ts
+++ b/packages/lib/server-only/webhooks/assert-webhook-url.ts
@@ -125,6 +125,8 @@ export const assertNotPrivateUrl = async (
       throw err;
     }
 
-    return;
+    throw new AppError(AppErrorCode.WEBHOOK_INVALID_REQUEST, {
+      message: 'Webhook URL resolves to a private or loopback address',
+    });
   }
 };

--- a/packages/lib/server-only/webhooks/is-private-url.test.ts
+++ b/packages/lib/server-only/webhooks/is-private-url.test.ts
@@ -81,12 +81,12 @@ describe('isPrivateUrl', () => {
       expect(isPrivateUrl('http://[fd12::1]')).toBe(true);
     });
 
-    it('should not catch IPv4-mapped IPv6 in URL form (URL parser normalizes to hex)', () => {
-      // new URL() normalizes "::ffff:127.0.0.1" to "::ffff:7f00:1" which none
-      // of the checks handle. This is fine because dns.lookup never returns
-      // IPv4-mapped addresses — it returns plain IPv4 (family: 4) instead.
-      expect(isPrivateUrl('http://[::ffff:127.0.0.1]')).toBe(false);
-      expect(isPrivateUrl('http://[::ffff:10.0.0.1]')).toBe(false);
+    it('should detect IPv4-mapped IPv6 loopback (normalized to hex by URL parser)', () => {
+      expect(isPrivateUrl('http://[::ffff:127.0.0.1]')).toBe(true);
+      expect(isPrivateUrl('http://[::ffff:10.0.0.1]')).toBe(true);
+    });
+
+    it('should not block public IPv4-mapped IPv6 addresses', () => {
       expect(isPrivateUrl('http://[::ffff:8.8.8.8]')).toBe(false);
     });
   });

--- a/packages/lib/server-only/webhooks/is-private-url.ts
+++ b/packages/lib/server-only/webhooks/is-private-url.ts
@@ -68,11 +68,27 @@ export const isPrivateUrl = (url: string): boolean => {
       }
     }
 
-    // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1)
-    const v4Mapped = normalizedHost.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+    // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 or ::ffff:7f00:1)
+    const v4Mapped = normalizedHost.match(/^::ffff:(.+)$/i);
 
     if (v4Mapped) {
-      return isPrivateUrl(`http://${v4Mapped[1]}`);
+      const embedded = v4Mapped[1];
+
+      // Handle dotted-decimal form: ::ffff:127.0.0.1
+      if (/^\d+\.\d+\.\d+\.\d+$/.test(embedded)) {
+        return isPrivateUrl(`http://${embedded}`);
+      }
+
+      // Handle hex-group form: ::ffff:7f00:1 (normalized by URL parser)
+      const hexGroups = embedded.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+      if (hexGroups) {
+        const toOctets = (hex: string) => {
+          const padded = hex.padStart(4, '0');
+          return `${parseInt(padded.slice(0, 2), 16)}.${parseInt(padded.slice(2, 4), 16)}`;
+        };
+        const ipv4 = `${toOctets(hexGroups[1])}.${toOctets(hexGroups[2])}`;
+        return isPrivateUrl(`http://${ipv4}`);
+      }
     }
 
     return false;


### PR DESCRIPTION
## Description

Fixes SSRF vulnerability in webhook URL validation where IPv4-mapped IPv6
addresses in hex notation (e.g. `http://[::ffff:127.0.0.1]:3000/`) bypass
the `isPrivateUrl()` check. Node.js `new URL()` normalizes these to hex form
(`::ffff:7f00:1`), which didn't match the existing dotted-decimal regex.

Also fixes the "fail open" issue in `assert-webhook-url.ts` where DNS lookup
errors were silently swallowed instead of rejecting the URL.

## Related Issue

Closes #2901

## Changes Made

- **`is-private-url.ts`**: Extended IPv4-mapped IPv6 detection to handle
  hex-group notation (`::ffff:7f00:1`) by decoding hex octets back to
  dotted-decimal and re-checking.
- **`assert-webhook-url.ts`**: Changed catch block to throw AppError instead
  of silently returning on DNS lookup failure (fail closed).
- **Tests**: Updated to reflect the fixed behavior.

## Testing Performed

- `npx vitest run server-only/webhooks/` — 34/34 tests pass