### PR TITLE
fix(auth): guard missing password reset token and fix broken reset link URL

### DIFF
--- a/packages/lib/server-only/auth/send-forgot-password.ts
+++ b/packages/lib/server-only/auth/send-forgot-password.ts
@@ -32,9 +32,12 @@ export const sendForgotPassword = async ({ userId }: SendForgotPasswordOptions) 
     throw new Error('User not found');
   }
 
-  const token = user.passwordResetTokens[0].token;
+  const token = user.passwordResetTokens[0]?.token;
+  if (!token) {
+    throw new Error('Password reset token not found for user');
+  }
   const assetBaseUrl = NEXT_PUBLIC_WEBAPP_URL() || 'http://localhost:3000';
-  const resetPasswordLink = `${NEXT_PUBLIC_WEBAPP_URL()}/reset-password/${token}`;
+  const resetPasswordLink = `${assetBaseUrl}/reset-password/${token}`;
 
   const template = createElement(ForgotPasswordTemplate, {
     assetBaseUrl,


### PR DESCRIPTION
## Description
Two defensive fixes in `send-forgot-password.ts` that can cause a runtime crash and a broken reset link in edge cases.

## Related Issue
N/A

## Changes Made
- Guard against empty `passwordResetTokens` array — accessing `[0].token` directly crashes if no reset token exists for the user; now throws a meaningful error instead. Mirrors the same guard used in `send-confirmation-email.ts`.
- Reuse `assetBaseUrl` for `resetPasswordLink` instead of calling `NEXT_PUBLIC_WEBAPP_URL()` a second time — the fallback to `http://localhost:3000` was being silently discarded, producing a broken relative URL in the email when the env var is unset.

## Testing Performed
- No behaviour change in the happy path — both fixes only affect edge cases.

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.

## Additional Notes
No new dependencies introduced. Looking for reviewer guidance if a specific test scenario is required.