### PR TITLE
fix(i18n): mark webhook errors for translation

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -9,7 +9,7 @@ const config: LinguiConfig = {
   catalogs: [
     {
       path: '<rootDir>/packages/lib/translations/{locale}/web',
-      include: ['apps/remix/app', 'packages/ui', 'packages/lib', 'packages/email'],
+      include: ['apps/remix/app', 'packages/ui', 'packages/lib', 'packages/email', 'packages/trpc/server'],
       exclude: ['**/node_modules/**'],
     },
   ],

--- a/packages/trpc/server/webhook-router/schema.ts
+++ b/packages/trpc/server/webhook-router/schema.ts
@@ -1,19 +1,20 @@
 import { isPrivateUrl } from '@documenso/lib/server-only/webhooks/is-private-url';
+import { msg } from '@lingui/core/macro';
 import { WebhookTriggerEvents } from '@prisma/client';
 import { z } from 'zod';
 
 export const ZWebhookUrlSchema = z
   .string()
-  .url()
+  .url({ message: msg`Invalid URL`.id })
   .refine((url) => !isPrivateUrl(url), {
-    message: 'Webhook URL cannot point to a private or loopback address',
+    message: msg`Webhook URL cannot point to a private or loopback address`.id,
   });
 
 export const ZCreateWebhookRequestSchema = z.object({
   webhookUrl: ZWebhookUrlSchema,
   eventTriggers: z
     .array(z.nativeEnum(WebhookTriggerEvents))
-    .min(1, { message: 'At least one event trigger is required' }),
+    .min(1, { message: msg`At least one event trigger is required`.id }),
   secret: z.string().nullable(),
   enabled: z.boolean(),
 });


### PR DESCRIPTION
## Description

This PR mark errors on `/settings/webhooks` page for translation. Currently, errors are displayed only in English.

<img width="859" height="1046" alt="Zrzut ekranu 2026-06-04 190646" src="https://github.com/user-attachments/assets/2af1552c-a7ff-4681-a2e0-8730070c6f6e" />


## Changes Made

- Mark hardcoded strings for translation
- Update `lingui.config.ts` to handle this file

## Testing Performed


- Run locally
- Run build

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
