### PR TITLE
feat: add custom field label support

### DIFF
--- a/apps/remix/app/components/forms/editor/editor-field-date-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-date-form.tsx
@@ -11,9 +11,14 @@ import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
 
-import { EditorGenericFontSizeField, EditorGenericTextAlignField } from './editor-field-generic-field-forms';
+import {
+  EditorGenericFontSizeField,
+  EditorGenericLabelField,
+  EditorGenericTextAlignField,
+} from './editor-field-generic-field-forms';
 
 const ZDateFieldFormSchema = ZDateFieldMeta.pick({
+  label: true,
   fontSize: true,
   textAlign: true,
   overflow: true,
@@ -36,6 +41,7 @@ export const EditorFieldDateForm = ({
     resolver: zodResolver(ZDateFieldFormSchema),
     mode: 'onChange',
     defaultValues: {
+      label: value.label || '',
       fontSize: value.fontSize || DEFAULT_FIELD_FONT_SIZE,
       textAlign: value.textAlign ?? FIELD_DEFAULT_GENERIC_ALIGN,
       overflow: value.overflow || FIELD_DATE_META_DEFAULT_VALUES.overflow,
@@ -64,6 +70,10 @@ export const EditorFieldDateForm = ({
     <Form {...form}>
       <form>
         <fieldset className="flex flex-col gap-2">
+          <div>
+            <EditorGenericLabelField formControl={form.control} />
+          </div>
+
           <EditorGenericFontSizeField formControl={form.control} />
 
           <EditorGenericTextAlignField formControl={form.control} />

--- a/apps/remix/app/components/forms/editor/editor-field-email-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-email-form.tsx
@@ -11,9 +11,14 @@ import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
 
-import { EditorGenericFontSizeField, EditorGenericTextAlignField } from './editor-field-generic-field-forms';
+import {
+  EditorGenericFontSizeField,
+  EditorGenericLabelField,
+  EditorGenericTextAlignField,
+} from './editor-field-generic-field-forms';
 
 const ZEmailFieldFormSchema = ZEmailFieldMeta.pick({
+  label: true,
   fontSize: true,
   textAlign: true,
   overflow: true,
@@ -36,6 +41,7 @@ export const EditorFieldEmailForm = ({
     resolver: zodResolver(ZEmailFieldFormSchema),
     mode: 'onChange',
     defaultValues: {
+      label: value.label || '',
       fontSize: value.fontSize || DEFAULT_FIELD_FONT_SIZE,
       textAlign: value.textAlign ?? FIELD_DEFAULT_GENERIC_ALIGN,
       overflow: value.overflow || FIELD_EMAIL_META_DEFAULT_VALUES.overflow,
@@ -64,6 +70,7 @@ export const EditorFieldEmailForm = ({
     <Form {...form}>
       <form>
         <fieldset className="flex flex-col gap-2">
+          <EditorGenericLabelField formControl={form.control} />
           <EditorGenericFontSizeField formControl={form.control} />
 
           <EditorGenericTextAlignField formControl={form.control} />

--- a/apps/remix/app/components/forms/editor/editor-field-initials-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-initials-form.tsx
@@ -10,9 +10,14 @@ import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
 
-import { EditorGenericFontSizeField, EditorGenericTextAlignField } from './editor-field-generic-field-forms';
+import {
+  EditorGenericFontSizeField,
+  EditorGenericLabelField,
+  EditorGenericTextAlignField,
+} from './editor-field-generic-field-forms';
 
 const ZInitialsFieldFormSchema = ZInitialsFieldMeta.pick({
+  label: true,
   fontSize: true,
   textAlign: true,
 });
@@ -34,6 +39,7 @@ export const EditorFieldInitialsForm = ({
     resolver: zodResolver(ZInitialsFieldFormSchema),
     mode: 'onChange',
     defaultValues: {
+      label: value.label || '',
       fontSize: value.fontSize || DEFAULT_FIELD_FONT_SIZE,
       textAlign: value.textAlign ?? FIELD_DEFAULT_GENERIC_ALIGN,
     },
@@ -61,6 +67,7 @@ export const EditorFieldInitialsForm = ({
     <Form {...form}>
       <form>
         <fieldset className="flex flex-col gap-2">
+          <EditorGenericLabelField formControl={form.control} />
           <EditorGenericFontSizeField formControl={form.control} />
 
           <EditorGenericTextAlignField formControl={form.control} />

--- a/apps/remix/app/components/forms/editor/editor-field-name-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-name-form.tsx
@@ -10,10 +10,15 @@ import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
 
-import { EditorGenericFontSizeField, EditorGenericTextAlignField } from './editor-field-generic-field-forms';
+import {
+  EditorGenericFontSizeField,
+  EditorGenericLabelField,
+  EditorGenericTextAlignField,
+} from './editor-field-generic-field-forms';
 
 const ZNameFieldFormSchema = ZNameFieldMeta.pick({
   fontSize: true,
+  label: true,
   textAlign: true,
 });
 
@@ -35,6 +40,7 @@ export const EditorFieldNameForm = ({
     mode: 'onChange',
     defaultValues: {
       fontSize: value.fontSize || DEFAULT_FIELD_FONT_SIZE,
+      label: value.label || '',
       textAlign: value.textAlign ?? FIELD_DEFAULT_GENERIC_ALIGN,
     },
   });
@@ -61,6 +67,8 @@ export const EditorFieldNameForm = ({
     <Form {...form}>
       <form>
         <fieldset className="flex flex-col gap-2">
+          <EditorGenericLabelField formControl={form.control} />
+
           <EditorGenericFontSizeField formControl={form.control} />
 
           <EditorGenericTextAlignField formControl={form.control} />

--- a/apps/remix/app/components/forms/editor/editor-field-signature-form.tsx
+++ b/apps/remix/app/components/forms/editor/editor-field-signature-form.tsx
@@ -1,5 +1,6 @@
 import { DEFAULT_SIGNATURE_TEXT_FONT_SIZE } from '@documenso/lib/constants/pdf';
 import {
+  FIELD_DEFAULT_GENERIC_ALIGN,
   FIELD_SIGNATURE_META_DEFAULT_VALUES,
   type TSignatureFieldMeta,
   ZSignatureFieldMeta,
@@ -11,10 +12,16 @@ import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
 
-import { EditorGenericFontSizeField } from './editor-field-generic-field-forms';
+import {
+  EditorGenericFontSizeField,
+  EditorGenericLabelField,
+  EditorGenericTextAlignField,
+} from './editor-field-generic-field-forms';
 
 const ZSignatureFieldFormSchema = ZSignatureFieldMeta.pick({
+  label: true,
   fontSize: true,
+  textAlign: true,
   overflow: true,
 });
 
@@ -35,8 +42,10 @@ export const EditorFieldSignatureForm = ({
     resolver: zodResolver(ZSignatureFieldFormSchema),
     mode: 'onChange',
     defaultValues: {
+      label: value.label || '',
       overflow: value.overflow || FIELD_SIGNATURE_META_DEFAULT_VALUES.overflow,
       fontSize: value.fontSize || DEFAULT_SIGNATURE_TEXT_FONT_SIZE,
+      textAlign: value.textAlign ?? FIELD_DEFAULT_GENERIC_ALIGN,
     },
   });
 
@@ -63,10 +72,18 @@ export const EditorFieldSignatureForm = ({
       <form>
         <fieldset className="flex flex-col gap-2">
           <div>
+            <EditorGenericLabelField formControl={form.control} />
+          </div>
+
+          <div>
             <EditorGenericFontSizeField formControl={form.control} />
             <p className="mt-0.5 text-muted-foreground text-xs">
               <Trans>The typed signature font size</Trans>
             </p>
+          </div>
+
+          <div>
+            <EditorGenericTextAlignField formControl={form.control} />
           </div>
         </fieldset>
       </form>

--- a/packages/lib/server-only/field/set-fields-for-document.ts
+++ b/packages/lib/server-only/field/set-fields-for-document.ts
@@ -209,6 +209,7 @@ export const setFieldsForDocument = async ({
             positionY: field.pageY,
             width: field.pageWidth,
             height: field.pageHeight,
+            customText: field.customText ?? '',
             fieldMeta: parsedFieldMeta,
           },
           create: {
@@ -218,7 +219,7 @@ export const setFieldsForDocument = async ({
             positionY: field.pageY,
             width: field.pageWidth,
             height: field.pageHeight,
-            customText: '',
+            customText: field.customText ?? '',
             inserted: false,
             fieldMeta: parsedFieldMeta,
             envelope: {
@@ -356,6 +357,7 @@ type FieldData = {
   pageY: number;
   pageWidth: number;
   pageHeight: number;
+  customText?: string;
   fieldMeta?: FieldMeta;
 };
 
@@ -371,6 +373,7 @@ const hasFieldBeenChanged = (field: Field, newFieldData: FieldData) => {
     field.positionY.toNumber() !== newFieldData.pageY ||
     field.width.toNumber() !== newFieldData.pageWidth ||
     field.height.toNumber() !== newFieldData.pageHeight ||
+    field.customText !== newFieldData.customText ||
     !isDeepEqual(currentFieldMeta, newFieldMeta)
   );
 };

--- a/packages/lib/server-only/field/set-fields-for-template.ts
+++ b/packages/lib/server-only/field/set-fields-for-template.ts
@@ -36,6 +36,7 @@ export type SetFieldsForTemplateOptions = {
     pageY: number;
     pageWidth: number;
     pageHeight: number;
+    customText?: string;
     fieldMeta?: FieldMeta;
   }[];
 };
@@ -179,6 +180,7 @@ export const setFieldsForTemplate = async ({ userId, teamId, id, fields }: SetFi
           positionY: field.pageY,
           width: field.pageWidth,
           height: field.pageHeight,
+          customText: field.customText ?? '',
           fieldMeta: parsedFieldMeta,
         },
         create: {
@@ -188,7 +190,7 @@ export const setFieldsForTemplate = async ({ userId, teamId, id, fields }: SetFi
           positionY: field.pageY,
           width: field.pageWidth,
           height: field.pageHeight,
-          customText: '',
+          customText: field.customText ?? '',
           inserted: false,
           fieldMeta: parsedFieldMeta,
           envelope: {

--- a/packages/lib/utils/fields.ts
+++ b/packages/lib/utils/fields.ts
@@ -125,6 +125,7 @@ export const getClientSideFieldTranslations = ({ t }: I18n): Record<FieldType, s
     [FieldType.DROPDOWN]: t(msg`Select Option`),
     [FieldType.SIGNATURE]: t(msg`Signature`),
     [FieldType.FREE_SIGNATURE]: t(msg`Free Signature`),
+    [FieldType.IMAGE_UPLOAD]: t(msg`Image Upload`),
     [FieldType.INITIALS]: t(msg`Initials`),
     [FieldType.NAME]: t(msg`Name`),
     [FieldType.NUMBER]: t(msg`Number`),

--- a/packages/trpc/server/envelope-router/set-envelope-fields.types.ts
+++ b/packages/trpc/server/envelope-router/set-envelope-fields.types.ts
@@ -25,6 +25,7 @@ export const ZSetEnvelopeFieldsRequestSchema = z.object({
       positionY: ZClampedFieldPositionYSchema,
       width: ZClampedFieldWidthSchema,
       height: ZClampedFieldHeightSchema,
+      customText: z.string().optional(),
       fieldMeta: ZFieldMetaSchema,
     }),
   ),


### PR DESCRIPTION
## Description
Implements custom label support, allowing users to add custom labels to fields within the document editor.

## Changes
- Added custom label field support to various editor field forms.
- Updated backend logic to handle custom labels for fields.
- Updated field utilities and types to support custom labels.

## Testing
- Verified custom labels can be added and edited in the editor.
- Confirmed custom labels are correctly persisted and rendered in the document.
