### PR TITLE
fix(i18n): mark for translation common errors

### DIFF
--- a/apps/remix/app/components/forms/password.tsx
+++ b/apps/remix/app/components/forms/password.tsx
@@ -22,7 +22,7 @@ export const ZPasswordFormSchema = z
     repeatedPassword: ZPasswordSchema,
   })
   .refine((data) => data.password === data.repeatedPassword, {
-    message: 'Passwords do not match',
+    message: msg`Passwords do not match`.id,
     path: ['repeatedPassword'],
   });
 

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -9,7 +9,7 @@ const config: LinguiConfig = {
   catalogs: [
     {
       path: '<rootDir>/packages/lib/translations/{locale}/web',
-      include: ['apps/remix/app', 'packages/ui', 'packages/lib', 'packages/email'],
+      include: ['apps/remix/app', 'packages/ui', 'packages/lib', 'packages/email', 'packages/trpc/server'],
       exclude: ['**/node_modules/**'],
     },
   ],

--- a/packages/lib/constants/auth.ts
+++ b/packages/lib/constants/auth.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import MailChecker from 'mailchecker';
 import { z } from 'zod';
 
@@ -14,10 +15,10 @@ export const URL_PATTERN = /https?:\/\/|www\./i;
 export const ZNameSchema = z
   .string()
   .trim()
-  .min(3, { message: 'Please enter a valid name.' })
-  .max(255, { message: 'Name cannot be more than 255 characters.' })
+  .min(3, { message: msg`Please enter a valid name`.id })
+  .max(255, { message: msg`Name cannot be more than 255 characters`.id })
   .refine((value) => !URL_PATTERN.test(value), {
-    message: 'Name cannot contain URLs.',
+    message: msg`Name cannot contain URLs`.id,
   });
 
 export const IDENTITY_PROVIDER_NAME: Record<string, string> = {

--- a/packages/lib/utils/zod.ts
+++ b/packages/lib/utils/zod.ts
@@ -1,4 +1,3 @@
-import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
 /**
@@ -12,7 +11,7 @@ import { z } from 'zod';
 const EMAIL_REGEX =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\u{0080}-\u{FFFF}-]+@[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?(?:\.[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?)*$/u;
 
-const DEFAULT_EMAIL_MESSAGE = msg`Invalid email address`.id;
+const DEFAULT_EMAIL_MESSAGE = 'Invalid email address';
 
 /**
  * Creates a Zod email schema using an RFC 5322 compliant regex.

--- a/packages/lib/utils/zod.ts
+++ b/packages/lib/utils/zod.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
 /**
@@ -11,7 +12,7 @@ import { z } from 'zod';
 const EMAIL_REGEX =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\u{0080}-\u{FFFF}-]+@[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?(?:\.[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?)*$/u;
 
-const DEFAULT_EMAIL_MESSAGE = 'Invalid email address';
+const DEFAULT_EMAIL_MESSAGE = msg`Invalid email address`.id;
 
 /**
  * Creates a Zod email schema using an RFC 5322 compliant regex.

--- a/packages/trpc/server/auth-router/schema.ts
+++ b/packages/trpc/server/auth-router/schema.ts
@@ -1,20 +1,24 @@
+import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
-export const ZCurrentPasswordSchema = z.string().min(6, { message: 'Must be at least 6 characters in length' }).max(72);
+export const ZCurrentPasswordSchema = z
+  .string()
+  .min(6, { message: msg`Must be at least 6 characters in length`.id })
+  .max(72, { message: msg`Cannot be more than 72 characters in length`.id });
 
 export const ZPasswordSchema = z
   .string()
-  .min(8, { message: 'Must be at least 8 characters in length' })
-  .max(72, { message: 'Cannot be more than 72 characters in length' })
+  .min(8, { message: msg`Must be at least 8 characters in length`.id })
+  .max(72, { message: msg`Cannot be more than 72 characters in length`.id })
   .refine((value) => value.length > 25 || /[A-Z]/.test(value), {
-    message: 'One uppercase character',
+    message: msg`One uppercase character is required`.id,
   })
   .refine((value) => value.length > 25 || /[a-z]/.test(value), {
-    message: 'One lowercase character',
+    message: msg`One lowercase character is required`.id,
   })
   .refine((value) => value.length > 25 || /\d/.test(value), {
-    message: 'One number',
+    message: msg`One number is required`.id,
   })
   .refine((value) => value.length > 25 || /[`~<>?,./!@#$%^&*()\-_"'+=|{}[\];:\\]/.test(value), {
-    message: 'One special character is required',
+    message: msg`One special character is required`.id,
   });

--- a/packages/trpc/server/organisation-router/create-organisation-group.types.ts
+++ b/packages/trpc/server/organisation-router/create-organisation-group.types.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { OrganisationMemberRole } from '@prisma/client';
 import { z } from 'zod';
 
@@ -14,7 +15,7 @@ import { z } from 'zod';
 export const ZCreateOrganisationGroupRequestSchema = z.object({
   organisationId: z.string(),
   organisationRole: z.nativeEnum(OrganisationMemberRole),
-  name: z.string().max(100),
+  name: z.string().max(100, { message: msg`Cannot be more than 100 characters in length`.id }),
   memberIds: z.array(z.string()),
 });
 

--- a/packages/trpc/server/organisation-router/create-organisation.types.ts
+++ b/packages/trpc/server/organisation-router/create-organisation.types.ts
@@ -13,8 +13,8 @@ import { z } from 'zod';
 
 export const ZOrganisationNameSchema = z
   .string()
-  .min(3, { message: msg`Minimum 3 characters`.id })
-  .max(50, { message: msg`Maximum 50 characterss`.id });
+  .min(3, { message: msg`Must be at least 3 characters in length`.id })
+  .max(50, { message: msg`Cannot be more than 50 characters in length`.id });
 
 export const ZCreateOrganisationRequestSchema = z.object({
   name: ZOrganisationNameSchema,

--- a/packages/trpc/server/organisation-router/create-organisation.types.ts
+++ b/packages/trpc/server/organisation-router/create-organisation.types.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
 // export const createOrganisationMeta: TrpcOpenApiMeta = {
@@ -12,8 +13,8 @@ import { z } from 'zod';
 
 export const ZOrganisationNameSchema = z
   .string()
-  .min(3, { message: 'Minimum 3 characters' })
-  .max(50, { message: 'Maximum 50 characters' });
+  .min(3, { message: msg`Minimum 3 characters`.id })
+  .max(50, { message: msg`Maximum 50 characterss`.id });
 
 export const ZCreateOrganisationRequestSchema = z.object({
   name: ZOrganisationNameSchema,

--- a/packages/trpc/server/team-router/schema.ts
+++ b/packages/trpc/server/team-router/schema.ts
@@ -26,11 +26,13 @@ export const ZTeamUrlSchema = z
   .min(3, { message: msg`Team URL must be at least 3 characters long.`.id })
   .max(30, { message: msg`Team URL must not exceed 30 characters.`.id })
   .toLowerCase()
-  .regex(/^[a-z0-9].*[^_-]$/, 'Team URL cannot start or end with dashes or underscores.')
-  .regex(/^(?!.*[-_]{2})/, 'Team URL cannot contain consecutive dashes or underscores.')
-  .regex(/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/, 'Team URL can only contain letters, numbers, dashes and underscores.')
+  .regex(/^[a-z0-9].*[^_-]$/, { message: msg`Team URL cannot start or end with dashes or underscores.`.id })
+  .regex(/^(?!.*[-_]{2})/, { message: msg`Team URL cannot contain consecutive dashes or underscores.`.id })
+  .regex(/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/, {
+    message: msg`Team URL can only contain letters, numbers, dashes and underscores.`.id,
+  })
   .refine((value) => !PROTECTED_TEAM_URLS.includes(value), {
-    message: 'This URL is already in use.',
+    message: msg`This URL is already in use.`.id,
   });
 
 export const ZTeamNameSchema = z

--- a/packages/trpc/server/team-router/schema.ts
+++ b/packages/trpc/server/team-router/schema.ts
@@ -47,7 +47,7 @@ export const ZTeamNameSchema = z
 export const ZCreateTeamEmailVerificationMutationSchema = z.object({
   teamId: z.number(),
   name: ZNameSchema,
-  email: zEmail().trim().toLowerCase().min(1, 'Please enter a valid email.'),
+  email: zEmail().trim().toLowerCase().min(1, msg`Please enter a valid email.`.id),
 });
 
 export const ZDeleteTeamEmailMutationSchema = z.object({

--- a/packages/trpc/server/team-router/schema.ts
+++ b/packages/trpc/server/team-router/schema.ts
@@ -1,6 +1,7 @@
 import { URL_PATTERN, ZNameSchema } from '@documenso/lib/constants/auth';
 import { PROTECTED_TEAM_URLS } from '@documenso/lib/constants/teams';
 import { zEmail } from '@documenso/lib/utils/zod';
+import { msg } from '@lingui/core/macro';
 import { TeamMemberRole } from '@prisma/client';
 import { z } from 'zod';
 
@@ -22,8 +23,8 @@ import { z } from 'zod';
 export const ZTeamUrlSchema = z
   .string()
   .trim()
-  .min(3, { message: 'Team URL must be at least 3 characters long.' })
-  .max(30, { message: 'Team URL must not exceed 30 characters.' })
+  .min(3, { message: msg`Team URL must be at least 3 characters long.`.id })
+  .max(30, { message: msg`Team URL must not exceed 30 characters.`.id })
   .toLowerCase()
   .regex(/^[a-z0-9].*[^_-]$/, 'Team URL cannot start or end with dashes or underscores.')
   .regex(/^(?!.*[-_]{2})/, 'Team URL cannot contain consecutive dashes or underscores.')

--- a/packages/trpc/server/team-router/schema.ts
+++ b/packages/trpc/server/team-router/schema.ts
@@ -38,10 +38,10 @@ export const ZTeamUrlSchema = z
 export const ZTeamNameSchema = z
   .string()
   .trim()
-  .min(3, { message: 'Team name must be at least 3 characters long.' })
-  .max(30, { message: 'Team name must not exceed 30 characters.' })
+  .min(3, { message: msg`Team name must be at least 3 characters long.`.id })
+  .max(30, { message: msg`Team name must not exceed 30 characters.`.id })
   .refine((value) => !URL_PATTERN.test(value), {
-    message: 'Team name cannot contain URLs.',
+    message: msg`Team name cannot contain URLs.`.id,
   });
 
 export const ZCreateTeamEmailVerificationMutationSchema = z.object({


### PR DESCRIPTION
## Description

App contains multiple validation errors for form inputs, but most of them were hardcoded and not marked for translation. I have updated these error strings to support localization, improving overall user experience.

Examples before changes:

<img width="814" height="619" alt="Zrzut ekranu 2026-06-05 231220" src="https://github.com/user-attachments/assets/9e41de7f-c4cd-47a1-be6f-385a2420f43f" />
<img width="866" height="786" alt="Zrzut ekranu 2026-06-05 231235" src="https://github.com/user-attachments/assets/cce0b45e-78cf-4f87-9039-5b10b7d37292" />

## Changes Made

Mark for translation errors in
- login / sign up forms
- password fields
- team forms
- organisation forms
- group forms

Additionally, I edited `lingui.config.ts` file to handle these.

In some cases, I edited message. Errors should have specific form (ex. not `One number` but `One number is required` etc).

## Testing Performed

- Tested UI locally
- Ran build

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.
