### PR TITLE
fix(webhooks): scope event-trigger webhook lookup by team, not document-owner membership

### DIFF
--- a/packages/lib/server-only/webhooks/get-all-webhooks-by-event-trigger.ts
+++ b/packages/lib/server-only/webhooks/get-all-webhooks-by-event-trigger.ts
@@ -1,25 +1,42 @@
 import { prisma } from '@documenso/prisma';
 import type { WebhookTriggerEvents } from '@prisma/client';
 
-import { buildTeamWhereQuery } from '../../utils/teams';
-
 export type GetAllWebhooksByEventTriggerOptions = {
   event: WebhookTriggerEvents;
-  userId: number;
   teamId: number;
 };
 
-export const getAllWebhooksByEventTrigger = async ({ event, userId, teamId }: GetAllWebhooksByEventTriggerOptions) => {
-  return prisma.webhook.findMany({
+/**
+ * Find every enabled webhook a team has registered for a given event.
+ *
+ * This is a SYSTEM lookup, run when an event fires (e.g. a document is sealed
+ * in a background job) to decide which webhooks to deliver. It is intentionally
+ * scoped by `teamId` ALONE: webhooks belong to a team (`Webhook.teamId` is a
+ * required column) and a domain event belongs to a team, so team identity is
+ * the only thing that decides delivery.
+ *
+ * It must NOT be narrowed by the document owner's org-group membership (the
+ * `buildTeamWhereQuery` user-membership join that the settings-list query
+ * `getWebhooksByTeamId` uses). That join answers an authorization question —
+ * "may this logged-in user see this team's webhooks" — which is meaningless
+ * here: the "user" attached to a completion event is the document's owner,
+ * which may be the organisation owner (for team-scoped API tokens, see
+ * get-api-token-by-token.ts), a member who has since left the team, or a
+ * self-host whose org-group rows were never backfilled. In every such case the
+ * join matches nothing and the event is dropped silently — which is why
+ * API-created documents never delivered `document.completed`.
+ */
+export const getAllWebhooksByEventTrigger = async ({
+  event,
+  teamId,
+}: GetAllWebhooksByEventTriggerOptions) => {
+  return await prisma.webhook.findMany({
     where: {
       enabled: true,
       eventTriggers: {
         has: event,
       },
-      team: buildTeamWhereQuery({
-        teamId,
-        userId,
-      }),
+      teamId,
     },
   });
 };

--- a/packages/lib/server-only/webhooks/trigger/handler.ts
+++ b/packages/lib/server-only/webhooks/trigger/handler.ts
@@ -38,9 +38,9 @@ export const handlerTriggerWebhooks = async (req: Request) => {
     return Response.json({ success: false, error: 'Invalid request body' }, { status: 400 });
   }
 
-  const { event, data, userId, teamId } = result.data;
+  const { event, data, teamId } = result.data;
 
-  const allWebhooks = await getAllWebhooksByEventTrigger({ event, userId, teamId });
+  const allWebhooks = await getAllWebhooksByEventTrigger({ event, teamId });
 
   await Promise.allSettled(
     allWebhooks.map(async (webhook) => {

--- a/packages/lib/server-only/webhooks/trigger/trigger-webhook.ts
+++ b/packages/lib/server-only/webhooks/trigger/trigger-webhook.ts
@@ -6,13 +6,19 @@ import { getAllWebhooksByEventTrigger } from '../get-all-webhooks-by-event-trigg
 export type TriggerWebhookOptions = {
   event: WebhookTriggerEvents;
   data: Record<string, unknown>;
+  /**
+   * Retained for caller compatibility and context, but NOT used to scope the
+   * lookup: webhooks are delivered to every enabled webhook on `teamId` for the
+   * event, regardless of which user owns the triggering resource. See
+   * get-all-webhooks-by-event-trigger.ts for why.
+   */
   userId: number;
   teamId: number;
 };
 
-export const triggerWebhook = async ({ event, data, userId, teamId }: TriggerWebhookOptions) => {
+export const triggerWebhook = async ({ event, data, teamId }: TriggerWebhookOptions) => {
   try {
-    const registeredWebhooks = await getAllWebhooksByEventTrigger({ event, userId, teamId });
+    const registeredWebhooks = await getAllWebhooksByEventTrigger({ event, teamId });
 
     if (registeredWebhooks.length === 0) {
       return;


### PR DESCRIPTION
## Problem

`document.completed` (and every other event) webhooks are never delivered for documents whose owner isn't a current org-group member of the team — most notably **any document created via a team-scoped API token**, because such tokens resolve their user to the organisation owner (`get-api-token-by-token.ts`). The **"Test webhook"** button also reports success while delivering nothing.

Reproduced on a self-hosted **v2.11.0** instance: create a document via API token → sign + complete → status `COMPLETED`, PDF sealed correctly, but **Team → Webhooks → Logs stays empty** and no delivery is attempted.

## Cause

`getAllWebhooksByEventTrigger()` — the system lookup that decides which webhooks fire on an event (e.g. from the `seal-document` job) — scopes the query with the authorization helper `buildTeamWhereQuery({ teamId, userId })`:

```ts
team: buildTeamWhereQuery({ teamId, userId }),
```

That helper additionally requires `userId` to be a current member of the team via `teamGroup → organisationGroup → organisationGroupMembers → organisationMember.userId`. It's the right scoping for *user-facing reads*, but on a webhook **event** there is no acting/authenticated user — the `userId` passed in is the **document owner**, which can be:

- the **organisation owner** (team-scoped API tokens resolve to the org owner),
- a member who has since **left the team**, or
- a self-host whose org-group rows were never backfilled.

In all of those cases the join matches nothing, `getAllWebhooksByEventTrigger` returns `[]`, and `triggerWebhook` hits its silent `return` — no delivery, no `WebhookCall` row, no error. (Same path explains the "Test webhook" false success: `triggerTestWebhook → triggerWebhook` swallows the empty result and returns `{ success: true }`.)

## Fix

Scope the event lookup by `teamId` alone. `Webhook.teamId` and `Envelope.teamId` are both required columns, so team identity fully determines delivery — the document owner's org-group membership has no bearing on which of a team's webhooks should fire. The user-membership join is retained where it belongs: the settings-list read (`getWebhooksByTeamId`) and the create/edit/delete permission gates.

## Verification

Faithful SQL reproduction of the generated relation-filter against Postgres (current vs fixed):

| Scenario | current (`buildTeamWhereQuery`) | fixed (`teamId`-only) |
|---|---|---|
| webhook on team T, document owned by **org owner** (API-token case) | **0 rows** ❌ | **1 row** ✅ |
| same team T, document owned by a user who *is* in the org-group | 1 row | 1 row |
| team whose org-group rows were never backfilled, any user | **0 rows** ❌ | **1 row** ✅ |

The middle row shows the failure is conditional on *who owns the document*, not on the team.

## Notes

- Touches three files: the query function plus its two callers (`trigger/trigger-webhook.ts` and the legacy `trigger/handler.ts`). `triggerWebhook`'s `userId` option is retained for caller compatibility but no longer scopes the lookup.
- Separately, the silent `return` on an empty match in `trigger-webhook.ts` is what hid this for so long. Happy to follow up with an observability-only PR (a debug log there, plus surfacing failed internal-job dispatch in the local jobs provider) if that'd be welcome.
