### PR TITLE
chore(jobs): log failed internal job dispatch in the local provider

### DIFF
--- a/packages/lib/jobs/client/local.ts
+++ b/packages/lib/jobs/client/local.ts
@@ -372,12 +372,39 @@ export class LocalJobProvider extends BaseJobProvider {
     }
 
     console.log('Submitting job to endpoint:', endpoint);
+
+    // Fire-and-forget: we only wait up to 150ms so the caller isn't blocked on
+    // the handler running. The dispatch itself can still fail (the endpoint is
+    // unreachable, misconfigured NEXT_PRIVATE_INTERNAL_WEBAPP_URL, or a non-2xx
+    // response), and when it does the BackgroundJob row is left PENDING with no
+    // signal. Log those outcomes so a silently-undelivered job is diagnosable
+    // (e.g. webhooks never firing) instead of vanishing.
+    const dispatch = fetch(endpoint, {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers,
+    })
+      .then((res) => {
+        if (!res.ok) {
+          console.error(
+            `[JOBS]: dispatch for ${jobDefinitionId}/${jobId} returned HTTP ${res.status}; job may remain PENDING`,
+          );
+        }
+
+        return res;
+      })
+      .catch((err: unknown) => {
+        console.error(
+          `[JOBS]: dispatch for ${jobDefinitionId}/${jobId} failed (${
+            err instanceof Error ? err.message : String(err)
+          }); job may remain PENDING`,
+        );
+
+        return null;
+      });
+
     await Promise.race([
-      fetch(endpoint, {
-        method: 'POST',
-        body: JSON.stringify(data),
-        headers,
-      }).catch(() => null),
+      dispatch,
       new Promise((resolve) => {
         setTimeout(resolve, 150);
       }),


### PR DESCRIPTION
## Background

Follow-up to #2949. While diagnosing why `document.completed` webhooks never fired on a self-host, the hardest part was that nothing was observable — the queued delivery job simply never ran, with no error anywhere.

## Problem

`LocalJobProvider.submitJobToEndpoint` dispatches a job's handler via a fire-and-forget HTTP POST to the app's own `/api/jobs/:def/:id` endpoint, raced against a 150ms timeout:

```ts
await Promise.race([
  fetch(endpoint, { ... }).catch(() => null),
  new Promise((resolve) => setTimeout(resolve, 150)),
]);
```

If that internal dispatch fails — endpoint unreachable, a misconfigured `NEXT_PRIVATE_INTERNAL_WEBAPP_URL`, or a non-2xx response — the `.catch(() => null)` swallows it and the `BackgroundJob` row is left `PENDING` forever. The job silently never runs and there's no log to point at, which is exactly what makes "my webhooks never fire" (or any background job quietly not executing) so hard to debug on a self-host.

## Change

Log dispatch failures — both a thrown fetch error and a non-2xx response — **without changing the fire-and-forget timing** (still returns control after at most 150ms). The handler outcome itself is unchanged; this only surfaces a dispatch that didn't land.

```
[JOBS]: dispatch for internal.execute-webhook/<id> returned HTTP 502; job may remain PENDING
[JOBS]: dispatch for internal.execute-webhook/<id> failed (fetch failed); job may remain PENDING
```

Observability-only, no behavior change to successful dispatches.