### PR TITLE
fix(lib): harden branding CSS sanitizer against escaped url() bypass

### DIFF
--- a/packages/lib/utils/sanitize-branding-css.test.ts
+++ b/packages/lib/utils/sanitize-branding-css.test.ts
@@ -252,6 +252,31 @@ describe('sanitizeBrandingCss', () => {
       expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0].kind).toBe('value');
     });
+
+    it('drops a url() smuggled past the blocklist via a CSS escape (\\75rl)', () => {
+      // `\75rl(...)` is `url(...)` to a browser but contains no literal
+      // "url(" substring, so a raw match would let it through.
+      const result = sanitizeBrandingCss('.x { background: \\75rl("http://evil"); }');
+
+      expect(result.css).not.toContain('evil');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].kind).toBe('value');
+    });
+
+    it('drops a url() written with fully escaped, mixed-case characters (\\55RL)', () => {
+      const result = sanitizeBrandingCss('.x { background: \\55RL("http://evil"); }');
+
+      expect(result.css).not.toContain('evil');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].kind).toBe('value');
+    });
+
+    it('keeps a harmless value that merely contains CSS escapes (\\72 ed -> red)', () => {
+      const result = sanitizeBrandingCss('.x { color: \\72 ed; }');
+
+      expect(result.warnings).toEqual([]);
+      expect(result.css).toContain('color');
+    });
   });
 
   describe('!important stripping', () => {

--- a/packages/lib/utils/sanitize-branding-css.ts
+++ b/packages/lib/utils/sanitize-branding-css.ts
@@ -140,8 +140,34 @@ const validateSelector = (rawSelector: string): SelectorValidationResult => {
   return { kind: 'ok' };
 };
 
+/**
+ * Decode CSS escape sequences so they can't smuggle a blocked token past the
+ * substring check below. CSS lets any character in a value be written as an
+ * escape, so `\75rl(` is just `url(` to the browser and `url\28 …\29` is
+ * `url(…)` — but a naive `.includes('url(')` never sees them. We decode first.
+ * Malformed escapes are mapped to U+FFFD (never throw) per CSS Syntax §4.3.7.
+ */
+const decodeCssEscapes = (input: string): string =>
+  input.replace(
+    /\\([0-9a-fA-F]{1,6})[ \t\n\f\r]?|\\\n|\\([^\n])/g,
+    (_match, hex: string | undefined, char: string | undefined) => {
+      if (hex !== undefined) {
+        const codePoint = Number.parseInt(hex, 16);
+
+        if (codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+          return '�';
+        }
+
+        return String.fromCodePoint(codePoint);
+      }
+
+      // `\\\n` (line continuation) matches neither group — it is removed.
+      return char ?? '';
+    },
+  );
+
 const valueIsBlocked = (rawValue: string): boolean => {
-  const lowered = rawValue.toLowerCase();
+  const lowered = decodeCssEscapes(rawValue).toLowerCase();
 
   return BLOCKED_VALUE_SUBSTRINGS.some((needle) => lowered.includes(needle));
 };


### PR DESCRIPTION
## Summary

`sanitizeBrandingCss` blocks dangerous value tokens (`url(`, `expression(`, `@import`, `javascript:`) with a lowercased substring match. Because CSS lets any character in a value be written as an escape sequence, these tokens can be smuggled past the check:

- `\75rl("https://attacker.example/x.png")` is `url("…")` to the browser, but contains no literal `url(` substring.
- `\55RL(…)` — fully escaped and mixed-case — slips through the same way.

`background`, `background-image`, `cursor`, etc. are not in `BLOCKED_PROPERTIES`, so this `url(` value check is the only thing preventing branding CSS (configured per-organisation, rendered to recipients) from loading external resources. The bypass re-enables exactly what the sanitizer is meant to stop: external resource loads that can leak a recipient IP / User-Agent, enable view tracking, or pull in attacker-controlled images and fonts.

## Fix

Decode CSS escape sequences before the blocklist check, so `\75rl(` collapses back to `url(` and is caught. The decoder follows [CSS Syntax 4.3.7](https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point) and maps null / out-of-range / surrogate escapes to `U+FFFD`, so it can never throw on hostile input.

## Tests

Added to `sanitize-branding-css.test.ts`:
- escaped `\75rl(...)` is dropped
- fully-escaped, mixed-case `\55RL(...)` is dropped
- a harmless value containing escapes (`\72 ed` -> `red`) is retained (guards against over-blocking)

All sanitizer tests pass (79); `biome check` is clean on the changed file.
