### PR TITLE
fix: render signing page in the document's language for anonymous recipients

### DIFF
--- a/apps/remix/app/entry.server.tsx
+++ b/apps/remix/app/entry.server.tsx
@@ -11,6 +11,7 @@ import type { AppLoadContext, EntryContext } from 'react-router';
 import { ServerRouter } from 'react-router';
 
 import { langCookie } from './storage/lang-cookie.server';
+import { getRecipientDocumentLanguage } from './utils/recipient-document-language.server';
 
 export const streamTimeout = 5_000;
 
@@ -21,7 +22,13 @@ export default async function handleRequest(
   routerContext: EntryContext,
   loadContext: AppLoadContext,
 ) {
-  let language = await langCookie.parse(request.headers.get('cookie') ?? '');
+  // Public recipient signing routes (`/sign/...`, `/d/...`) should render in the
+  // document's configured language (`DocumentMeta.language`) rather than the
+  // recipient's browser `accept-language`. Returns `null` for every other route,
+  // so the default cookie/accept-language resolution below is preserved.
+  const documentLanguage = await getRecipientDocumentLanguage(request);
+
+  let language = documentLanguage ?? (await langCookie.parse(request.headers.get('cookie') ?? ''));
 
   if (!APP_I18N_OPTIONS.supportedLangs.includes(language)) {
     language = extractLocaleData({ headers: request.headers }).lang;

--- a/apps/remix/app/root.tsx
+++ b/apps/remix/app/root.tsx
@@ -28,6 +28,7 @@ import { langCookie } from './storage/lang-cookie.server';
 import { themeSessionResolver } from './storage/theme-session.server';
 import { appMetaTags } from './utils/meta';
 import { nonce } from './utils/nonce';
+import { getRecipientDocumentLanguage } from './utils/recipient-document-language.server';
 
 export const links: Route.LinksFunction = () => [{ rel: 'stylesheet', href: stylesheet }];
 
@@ -49,11 +50,22 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   const cookieHeader = request.headers.get('cookie') ?? '';
 
-  let lang: SupportedLanguageCodes = await langCookie.parse(cookieHeader);
+  // Resolve the persisted/browser locale first. This is what we keep storing in
+  // the `lang` cookie so a recipient who later visits the rest of the app is not
+  // permanently switched to a document's language.
+  let cookieLang: SupportedLanguageCodes = await langCookie.parse(cookieHeader);
 
-  if (!APP_I18N_OPTIONS.supportedLangs.includes(lang)) {
-    lang = extractLocaleData({ headers: request.headers }).lang;
+  if (!APP_I18N_OPTIONS.supportedLangs.includes(cookieLang)) {
+    cookieLang = extractLocaleData({ headers: request.headers }).lang;
   }
+
+  // For the public signing routes, the rendered UI language (and therefore the
+  // `<html lang>` attribute that drives client-side hydration in
+  // `entry.client.tsx`) follows the document's configured language. Returns
+  // `null` everywhere else, so non-signing routes keep the cookie/browser lang.
+  const documentLang = await getRecipientDocumentLanguage(request);
+
+  const lang: SupportedLanguageCodes = documentLang ?? cookieLang;
 
   const disableAnimations = cookieHeader.includes('__disable_animations=true');
 
@@ -83,7 +95,10 @@ export async function loader({ context, request }: Route.LoaderArgs) {
     },
     {
       headers: {
-        'Set-Cookie': await langCookie.serialize(lang),
+        // Persist the cookie/browser lang only — never the per-document signing
+        // language — so visiting a `pt-BR` signing link doesn't permanently
+        // change the recipient's locale for the rest of the app.
+        'Set-Cookie': await langCookie.serialize(cookieLang),
       },
     },
   );

--- a/apps/remix/app/utils/recipient-document-language.server.ts
+++ b/apps/remix/app/utils/recipient-document-language.server.ts
@@ -1,0 +1,88 @@
+import { type SupportedLanguageCodes, isValidLanguageCode } from '@documenso/lib/constants/i18n';
+import { prisma } from '@documenso/prisma';
+
+/**
+ * Matches the public recipient signing routes and captures the token:
+ *   - `/sign/<token>`        (recipient signing — token lives on `Recipient`)
+ *   - `/d/<token>`           (direct template link — token lives on `TemplateDirectLink`)
+ *
+ * Any trailing sub-path (`/sign/<token>/waiting`, `/complete`, ...) still
+ * matches so the whole signing flow stays in the document's language.
+ */
+const SIGN_TOKEN_PATHNAME = /^\/sign\/([^/]+)(?:\/|$)/;
+const DIRECT_TOKEN_PATHNAME = /^\/d\/([^/]+)(?:\/|$)/;
+
+/**
+ * Resolve the UI language for an anonymous recipient from the *document's*
+ * configured language (`DocumentMeta.language`) instead of the browser's
+ * `accept-language` header.
+ *
+ * Documenso normally derives the SSR locale from the `lang` cookie /
+ * accept-language (see `extractLocaleData`), which leaves the public signing
+ * page in English even when the document was created as e.g. `pt-BR`.
+ *
+ * This helper is intentionally scoped: it ONLY returns a language for the
+ * recipient signing routes (`/sign/...`, `/d/...`). For every other route it
+ * returns `null`, so the caller falls back to the existing locale resolution
+ * and global behaviour is untouched.
+ *
+ * Returns a supported language code, or `null` when:
+ *   - the request is not a signing route,
+ *   - no document is found for the token,
+ *   - the stored language is missing / not in `SUPPORTED_LANGUAGE_CODES`.
+ */
+export const getRecipientDocumentLanguage = async (
+  request: Request,
+): Promise<SupportedLanguageCodes | null> => {
+  let token: string | null = null;
+  let lookup: 'recipient' | 'directLink' | null = null;
+
+  try {
+    const { pathname } = new URL(request.url);
+
+    const signMatch = pathname.match(SIGN_TOKEN_PATHNAME);
+    if (signMatch) {
+      token = decodeURIComponent(signMatch[1]);
+      lookup = 'recipient';
+    } else {
+      const directMatch = pathname.match(DIRECT_TOKEN_PATHNAME);
+      if (directMatch) {
+        token = decodeURIComponent(directMatch[1]);
+        lookup = 'directLink';
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  if (!token || !lookup) {
+    return null;
+  }
+
+  try {
+    // Both lookups resolve the same path: token -> Envelope -> DocumentMeta.language.
+    const language =
+      lookup === 'recipient'
+        ? await prisma.recipient
+            .findFirst({
+              where: { token },
+              select: { envelope: { select: { documentMeta: { select: { language: true } } } } },
+            })
+            .then((r) => r?.envelope?.documentMeta?.language ?? null)
+        : await prisma.templateDirectLink
+            .findFirst({
+              where: { token },
+              select: { envelope: { select: { documentMeta: { select: { language: true } } } } },
+            })
+            .then((d) => d?.envelope?.documentMeta?.language ?? null);
+
+    if (language && isValidLanguageCode(language)) {
+      return language;
+    }
+
+    return null;
+  } catch {
+    // Never let an i18n lookup break the signing page render.
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary

Anonymous recipients always see the signing page (`/sign/<token>`, `/d/<token>`) in **English**, regardless of the document's language. The locale is resolved in `entry.server.tsx` / `root.tsx` from the cookie / `Accept-Language` **before** route loaders run, so the document's `DocumentMeta.language` is never consulted for the SSR render.

This adds a small server helper, `getRecipientDocumentLanguage(request)`, that — **only** for `/sign/<token>` and `/d/<token>` URLs — looks up the envelope's `documentMeta.language` by token and, when it is a supported language, uses it for:
- the SSR lingui activation (`entry.server.tsx`), and
- the `<html lang>` value (`root.tsx`),

falling back to the existing cookie / `Accept-Language` behaviour otherwise. The browser-language cookie still persists the **cookie value** (not the document language), so opening a `pt-BR` signing link does not permanently switch the visitor's app locale. All lookups are wrapped in `try/catch` so an i18n failure never breaks the signing page. Non-recipient routes are unaffected.

## Test plan
- Set a document's `meta.language` to e.g. `pt-BR`, open its `/sign/<token>` link in a browser sending `Accept-Language: en-US` → the signing UI renders in Portuguese and `<html lang="pt-BR">`.
- Open any non-recipient route → locale unchanged (cookie / Accept-Language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
