### PR TITLE
fix: force light theme on recipient signing routes for correct branding

### DIFF
--- a/apps/remix/app/root.tsx
+++ b/apps/remix/app/root.tsx
@@ -19,7 +19,7 @@ import {
   useLoaderData,
   useMatches,
 } from 'react-router';
-import { PreventFlashOnWrongTheme, ThemeProvider, useTheme } from 'remix-themes';
+import { PreventFlashOnWrongTheme, Theme, ThemeProvider, useTheme } from 'remix-themes';
 
 import type { Route } from './+types/root';
 import stylesheet from './app.css?url';
@@ -92,8 +92,15 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 export function Layout({ children }: { children: React.ReactNode }) {
   const { theme } = useLoaderData<typeof loader>() || {};
 
+  // Recipient/signing routes are always rendered in LIGHT theme so the brand
+  // (white surfaces) stays consistent regardless of the visitor's OS preference,
+  // and dark-mode utilities (e.g. dark:text-white on the signature input) don't
+  // override branding on the signing page.
+  const matches = useMatches();
+  const isRecipientRoute = matches.some((m) => m.id?.startsWith('routes/_recipient+'));
+
   return (
-    <ThemeProvider specifiedTheme={theme} themeAction="/api/theme">
+    <ThemeProvider specifiedTheme={isRecipientRoute ? Theme.LIGHT : theme} themeAction="/api/theme">
       <LayoutContent>{children}</LayoutContent>
     </ThemeProvider>
   );
@@ -131,7 +138,10 @@ export function LayoutContent({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links nonce={nonce(cspNonce)} />
         <meta name="google" content="notranslate" />
-        <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} nonce={nonce(cspNonce)} />
+        <PreventFlashOnWrongTheme
+          ssrTheme={isRecipientRoute ? true : Boolean(data.theme)}
+          nonce={nonce(cspNonce)}
+        />
 
         {disableAnimations && (
           <style


### PR DESCRIPTION
## Summary

When a visitor's OS/browser is in **dark mode**, the anonymous signing page renders in the dark theme (remix-themes follows `prefers-color-scheme`, with no forced theme on recipient routes). This breaks organisation/team branding on the signing page:
- the typed-signature input is `text-black dark:text-white` → it becomes **white-on-white** and invisible;
- the "Cancel" button text inherits the dark `--secondary-foreground` (green);
- brand colors set via branding settings are overridden by the dark theme.

This forces the **light theme** on recipient/signing routes (`routes/_recipient+`) so the signing experience is consistent and branding renders correctly regardless of the visitor's OS preference. It passes `Theme.LIGHT` to `ThemeProvider` and sets `PreventFlashOnWrongTheme ssrTheme` for those routes (computing `isRecipientRoute` via `useMatches`). Non-recipient routes keep following the visitor's theme.

## Test plan
- With OS/browser in dark mode, open a `/sign/<token>` link → the page renders light; `document.documentElement.className === "light"`; the typed-signature input and brand surfaces are visible.
- Non-recipient routes still respect the visitor's dark/light preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
