### PR TITLE
fix: evaluate session cookie expiry at set-time rather than module-load time

### DIFF
--- a/packages/auth/server/lib/session/session-cookies.ts
+++ b/packages/auth/server/lib/session/session-cookies.ts
@@ -30,7 +30,6 @@ export const sessionCookieOptions = {
   sameSite: useSecureCookies ? 'none' : 'lax',
   secure: useSecureCookies,
   domain: getCookieDomain(),
-  expires: new Date(Date.now() + AUTH_SESSION_LIFETIME),
 } as const;
 
 export const extractSessionCookieFromHeaders = (headers: Headers): string | null => {
@@ -56,7 +55,10 @@ export const getSessionCookie = async (c: Context): Promise<string | null> => {
  * @param sessionToken - The session token to set.
  */
 export const setSessionCookie = async (c: Context, sessionToken: string) => {
-  await setSignedCookie(c, sessionCookieName, sessionToken, getAuthSecret(), sessionCookieOptions).catch((err) => {
+  await setSignedCookie(c, sessionCookieName, sessionToken, getAuthSecret(), {
+    ...sessionCookieOptions,
+    expires: new Date(Date.now() + AUTH_SESSION_LIFETIME),
+  }).catch((err) => {
     appLog('SetSessionCookie', `Error setting signed cookie: ${err}`);
 
     throw err;


### PR DESCRIPTION
## Description

This PR fixes a bug where the session cookie `expires` timestamp is computed once at module-load time and never updated, causing all session cookies to share the same fixed expiration timestamp (calculated from server start time). After `AUTH_SESSION_LIFETIME` (default 7 days) has elapsed since the server started, all newly issued session cookies have an expiration in the past, immediately logging users out.

## Related Issue

Resolves #2666

## Changes Made

- Removed the static `expires` property from the global `sessionCookieOptions` object so the expiration is not frozen at module import time.
- Added the `expires` property dynamically in `setSessionCookie()` using `expires: new Date(Date.now() + AUTH_SESSION_LIFETIME)`, ensuring the timestamp is computed at the moment the cookie is actually set.

## Note

The `deleteSessionCookie` and `setCsrfCookie` functions also use `sessionCookieOptions` — `deleteCookie` works via `maxAge` semantics and does not depend on `expires`, and `setCsrfCookie` already overrides `expires: undefined` explicitly.

## CLA

This PR is ready for review once the contributor has signed the CLA at https://documen.so/cla