### PR TITLE
fix: point Railway deploy button at the working template URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For full instructions, requirements, and configuration details, see the [Self Ho
 
 #### Railway
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/bG6D4p)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/DjrRRX?referralCode=EZR3s0&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 #### Render
 

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -60,7 +60,7 @@ We support a variety of deployment methods, and are actively working on adding m
 
 ## Railway
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/DjrRRX)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/DjrRRX?referralCode=EZR3s0&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 ## Render
 

--- a/apps/docs/content/docs/self-hosting/deployment/railway.mdx
+++ b/apps/docs/content/docs/self-hosting/deployment/railway.mdx
@@ -24,7 +24,7 @@ Before deploying, you need:
 
 The fastest way to deploy Documenso on Railway is using the official template:
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/bG6D4p)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/DjrRRX?referralCode=EZR3s0&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 This template automatically provisions:
 


### PR DESCRIPTION
The one-click "Deploy on Railway" button 404'd: the old `railway.app/template/<id>` URL format is deprecated and the referenced templates were removed/stale.

This repoints the button to the current `railway.com/deploy/DjrRRX` URL across the README, `SIGNING.md`, and the self-hosting docs.

Closes #2916