### PR TITLE
fix: correctly strip background job values

### DIFF
--- a/packages/lib/jobs/client/bullmq.ts
+++ b/packages/lib/jobs/client/bullmq.ts
@@ -233,13 +233,17 @@ export class BullMQJobProvider extends BaseJobProvider {
       backgroundJobId?: string;
     };
 
+    let payload = jobData.payload;
+
     if (definition.trigger.schema) {
-      const result = definition.trigger.schema.safeParse(jobData.payload);
+      const result = definition.trigger.schema.safeParse(payload);
 
       if (!result.success) {
         console.error(`[JOBS]: Payload validation failed for ${definitionId}`, result.error);
         throw new Error(`Payload validation failed for ${definitionId}`);
       }
+
+      payload = result.data;
     }
 
     const backgroundJobId = jobData.backgroundJobId;
@@ -260,11 +264,11 @@ export class BullMQJobProvider extends BaseJobProvider {
         .catch(() => null);
     }
 
-    console.log(`[JOBS]: Processing job ${definitionId} with payload`, jobData.payload);
+    console.log(`[JOBS]: Processing job ${definitionId} with payload`, payload);
 
     try {
       await definition.handler({
-        payload: jobData.payload,
+        payload,
         io: this.createJobRunIO(backgroundJobId ?? job.id ?? definitionId),
       });
 

--- a/packages/lib/jobs/client/local.ts
+++ b/packages/lib/jobs/client/local.ts
@@ -272,7 +272,7 @@ export class LocalJobProvider extends BaseJobProvider {
         payload = result.data;
       }
 
-      console.log(`[JOBS]: Triggering job ${options.name} with payload`, options.payload);
+      console.log(`[JOBS]: Triggering job ${options.name} with payload`, payload);
 
       let backgroundJob = await prisma.backgroundJob
         .update({

--- a/packages/lib/jobs/client/local.ts
+++ b/packages/lib/jobs/client/local.ts
@@ -260,12 +260,16 @@ export class LocalJobProvider extends BaseJobProvider {
         return c.text('Unauthorized', 401);
       }
 
+      let payload = options.payload;
+
       if (definition.trigger.schema) {
-        const result = definition.trigger.schema.safeParse(options.payload);
+        const result = definition.trigger.schema.safeParse(payload);
 
         if (!result.success) {
           return c.text('Bad request', 400);
         }
+
+        payload = result.data;
       }
 
       console.log(`[JOBS]: Triggering job ${options.name} with payload`, options.payload);
@@ -292,7 +296,7 @@ export class LocalJobProvider extends BaseJobProvider {
 
       try {
         await definition.handler({
-          payload: options.payload,
+          payload,
           io: this.createJobRunIO(jobId),
         });
 


### PR DESCRIPTION
## Description

Currently values via the Bullmq/Local jobs are not stripped via the schema.

This resolves it by using the parsed payload.