### PR TITLE
fix: auto-publish Docker images when a version tag is pushed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish Docker
 on:
   push:
     branches: ['release']
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       tag:
@@ -45,9 +46,11 @@ jobs:
           BUILD_PLATFORM: ${{ matrix.os == 'warp-ubuntu-latest-arm64-4x' && 'arm64' || 'amd64' }}
           NEXT_PRIVATE_TELEMETRY_KEY: ${{ secrets.NEXT_PRIVATE_TELEMETRY_KEY }}
           NEXT_PRIVATE_TELEMETRY_HOST: ${{ secrets.NEXT_PRIVATE_TELEMETRY_HOST }}
-          APP_VERSION: ${{ inputs.tag || '' }}
+          APP_VERSION: ${{ inputs.tag || github.ref_name || '' }}
         run: |
           if [ -z "$APP_VERSION" ]; then
+            APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          elif [ "$APP_VERSION" = "release" ]; then
             APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
           fi
           GIT_SHA="$(git rev-parse HEAD)"
@@ -101,9 +104,11 @@ jobs:
 
       - name: Create and push DockerHub manifest
         env:
-          APP_VERSION: ${{ inputs.tag || '' }}
+          APP_VERSION: ${{ inputs.tag || github.ref_name || '' }}
         run: |
           if [ -z "$APP_VERSION" ]; then
+            APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          elif [ "$APP_VERSION" = "release" ]; then
             APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
           fi
           GIT_SHA="$(git rev-parse HEAD)"
@@ -142,9 +147,11 @@ jobs:
 
       - name: Create and push Github Container Registry manifest
         env:
-          APP_VERSION: ${{ inputs.tag || '' }}
+          APP_VERSION: ${{ inputs.tag || github.ref_name || '' }}
         run: |
           if [ -z "$APP_VERSION" ]; then
+            APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
+          elif [ "$APP_VERSION" = "release" ]; then
             APP_VERSION="$(git name-rev --tags --name-only $(git rev-parse HEAD) | head -n 1 | sed 's/\^0//')"
           fi
           GIT_SHA="$(git rev-parse HEAD)"


### PR DESCRIPTION
## Description

The Docker publish workflow only ran on pushes to the elease branch or via manual workflow_dispatch. When a GitHub Release was created (which pushes a * tag), no Docker image was published to GHCR or DockerHub. This left the v2.11.0 release with no published container image.

## Changes

1. Added 	ags: ['v*'] trigger alongside the existing ranches: ['release'] trigger
2. Updated APP_VERSION resolution to use github.ref_name for tag-triggered runs (more reliable than git name-rev), while falling back to git name-rev for elease-branch-triggered runs

## For the existing v2.11.0 release

After this is merged, someone with repo secrets access should either:
- Trigger the workflow manually via workflow_dispatch with 	ag=v2.11.0
- Or push the v2.11.0 tag again (which would trigger the new tag rule)

Closes #2951