### PR TITLE
fix(i18n): add space between tag and text

### DIFF
--- a/apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
+++ b/apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
@@ -365,8 +365,7 @@ const SigningPageV1 = ({ data }: { data: Awaited<ReturnType<typeof handleV1Loade
 
           <h2 className="mt-6 max-w-[35ch] text-center font-semibold text-2xl leading-normal md:text-3xl lg:text-4xl">
             <Trans>
-              <span className="mt-1.5 block">"{document.title}"</span>
-              is no longer available to sign
+              <span className="mt-1.5 block">"{document.title}"</span> is no longer available to sign
             </Trans>
           </h2>
 
@@ -452,8 +451,7 @@ const SigningPageV2 = ({ data }: { data: Awaited<ReturnType<typeof handleV2Loade
 
           <h2 className="mt-6 max-w-[35ch] text-center font-semibold text-2xl leading-normal md:text-3xl lg:text-4xl">
             <Trans>
-              <span className="mt-1.5 block">"{envelope.title}"</span>
-              is no longer available to sign
+              <span className="mt-1.5 block">"{envelope.title}"</span> is no longer available to sign
             </Trans>
           </h2>
 


### PR DESCRIPTION
## Description

Typo in source string (wrong formatting)

Before:
```
#. placeholder {0}: document.title
#. placeholder {0}: envelope.title
#: apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
#: apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
msgid "<0>\"{0}\"</0>is no longer available to sign"
```

After:
```
#. placeholder {0}: document.title
#. placeholder {0}: envelope.title
#: apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
#: apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
msgid "<0>\"{0}\"</0> is no longer available to sign"
```

## Changes Made

- Add space between tag and text

## Testing Performed

- Ran build

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

