### PR TITLE
fix: pin crowdin/github-action to a commit SHA (supply-chain hardening)

### DIFF
--- a/.github/workflows/translations-force-pull.yml
+++ b/.github/workflows/translations-force-pull.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: ./.github/actions/node-install
 
       - name: Pull translations from Crowdin
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706  # v2
         with:
           upload_sources: false
           upload_translations: false

--- a/.github/workflows/translations-pull.yml
+++ b/.github/workflows/translations-pull.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Pull translations from Crowdin
         if: steps.compile_translations.outcome == 'failure'
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706  # v2
         with:
           upload_sources: false
           upload_translations: false

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload missing translations
         if: ${{ steps.compile_translations.outcome == 'failure' }}
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706  # v2
         with:
           upload_sources: true
           upload_translations: true


### PR DESCRIPTION
## Description

Pins `crowdin/github-action` from the mutable `v2` tag to the exact commit that tag currently points to (`8868a33591d21088edfc398968173a3b98d51706`), across the 3 translation workflows (3 usages). A `# v2` comment is kept on each line so the version stays legible and Dependabot can still bump it.

A mutable tag can be re-pointed by the upstream maintainer, or by an attacker who compromises that account, and the new code would then run in these workflows with the job's token. Pinning to an immutable commit SHA is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions.

## Related Issue

N/A. Supply-chain hardening, no linked issue.

## Changes Made

- Pinned `crowdin/github-action@v2` to `@8868a33591d2...  # v2` in `translations-force-pull.yml`, `translations-pull.yml`, and `translations-upload.yml`.
- Ref-only change; the SHA is the exact commit `v2` resolves to today, so behavior is unchanged.

## Testing Performed

- No runtime behavior change: the pinned SHA is the same commit the `v2` tag points to, so the Crowdin sync workflows run identically.
- Only lines referencing `crowdin/github-action` are touched.

## Checklist

- [x] I have followed the project's coding style guidelines.
- [ ] N/A. Tests / docs are not applicable to a CI workflow ref pin.

## Additional Notes

Happy to instead bump to the latest major and pin that, if the maintainers prefer.

<sub>Prepared and verified by [TaskBounty](https://task-bounty.com). Glad to adjust or close if this isn't wanted.</sub>