### PR TITLE
fix:marked for translation common error messages#2974

### DIFF
--- a/apps/remix/app/components/forms/password.tsx
+++ b/apps/remix/app/components/forms/password.tsx
@@ -22,7 +22,7 @@ export const ZPasswordFormSchema = z
     repeatedPassword: ZPasswordSchema,
   })
   .refine((data) => data.password === data.repeatedPassword, {
-    message: 'Passwords do not match',
+    message: msg`Passwords do not match`.id,
     path: ['repeatedPassword'],
   });
 

--- a/packages/lib/constants/auth.ts
+++ b/packages/lib/constants/auth.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import MailChecker from 'mailchecker';
 import { z } from 'zod';
 
@@ -14,10 +15,10 @@ export const URL_PATTERN = /https?:\/\/|www\./i;
 export const ZNameSchema = z
   .string()
   .trim()
-  .min(3, { message: 'Please enter a valid name.' })
-  .max(255, { message: 'Name cannot be more than 255 characters.' })
+  .min(3, { message: msg`Please enter a valid name.`.id })
+  .max(255, { message: msg`Name cannot be more than 255 characters.`.id })
   .refine((value) => !URL_PATTERN.test(value), {
-    message: 'Name cannot contain URLs.',
+    message: msg`Name cannot contain URLs.`.id,
   });
 
 export const IDENTITY_PROVIDER_NAME: Record<string, string> = {

--- a/packages/lib/utils/zod.ts
+++ b/packages/lib/utils/zod.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
 /**
@@ -11,7 +12,7 @@ import { z } from 'zod';
 const EMAIL_REGEX =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\u{0080}-\u{FFFF}-]+@[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?(?:\.[a-zA-Z0-9\u{0080}-\u{FFFF}](?:[a-zA-Z0-9\u{0080}-\u{FFFF}-]{0,61}[a-zA-Z0-9\u{0080}-\u{FFFF}])?)*$/u;
 
-const DEFAULT_EMAIL_MESSAGE = 'Invalid email address';
+const DEFAULT_EMAIL_MESSAGE = msg`Invalid email address`.id;
 
 /**
  * Creates a Zod email schema using an RFC 5322 compliant regex.

--- a/packages/trpc/server/auth-router/schema.ts
+++ b/packages/trpc/server/auth-router/schema.ts
@@ -1,20 +1,24 @@
+import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
-export const ZCurrentPasswordSchema = z.string().min(6, { message: 'Must be at least 6 characters in length' }).max(72);
+export const ZCurrentPasswordSchema = z
+  .string()
+  .min(6, { message: msg`Must be at least 6 characters in length`.id })
+  .max(72);
 
 export const ZPasswordSchema = z
   .string()
-  .min(8, { message: 'Must be at least 8 characters in length' })
-  .max(72, { message: 'Cannot be more than 72 characters in length' })
+  .min(8, { message: msg`Must be at least 8 characters in length`.id })
+  .max(72, { message: msg`Cannot be more than 72 characters in length`.id })
   .refine((value) => value.length > 25 || /[A-Z]/.test(value), {
-    message: 'One uppercase character',
+    message: msg`One uppercase character`.id,
   })
   .refine((value) => value.length > 25 || /[a-z]/.test(value), {
-    message: 'One lowercase character',
+    message: msg`One lowercase character`.id,
   })
   .refine((value) => value.length > 25 || /\d/.test(value), {
-    message: 'One number',
+    message: msg`One number`.id,
   })
   .refine((value) => value.length > 25 || /[`~<>?,./!@#$%^&*()\-_"'+=|{}[\];:\\]/.test(value), {
-    message: 'One special character is required',
+    message: msg`One special character is required`.id,
   });

--- a/packages/trpc/server/organisation-router/create-organisation-group.types.ts
+++ b/packages/trpc/server/organisation-router/create-organisation-group.types.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { OrganisationMemberRole } from '@prisma/client';
 import { z } from 'zod';
 
@@ -14,7 +15,7 @@ import { z } from 'zod';
 export const ZCreateOrganisationGroupRequestSchema = z.object({
   organisationId: z.string(),
   organisationRole: z.nativeEnum(OrganisationMemberRole),
-  name: z.string().max(100),
+  name: z.string().max(100, { message: msg`Name cannot be more than 100 characters.`.id }),
   memberIds: z.array(z.string()),
 });
 

--- a/packages/trpc/server/organisation-router/create-organisation.types.ts
+++ b/packages/trpc/server/organisation-router/create-organisation.types.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import { z } from 'zod';
 
 // export const createOrganisationMeta: TrpcOpenApiMeta = {
@@ -12,8 +13,8 @@ import { z } from 'zod';
 
 export const ZOrganisationNameSchema = z
   .string()
-  .min(3, { message: 'Minimum 3 characters' })
-  .max(50, { message: 'Maximum 50 characters' });
+  .min(3, { message: msg`Minimum 3 characters`.id })
+  .max(50, { message: msg`Maximum 50 characters`.id });
 
 export const ZCreateOrganisationRequestSchema = z.object({
   name: ZOrganisationNameSchema,

--- a/packages/trpc/server/team-router/schema.ts
+++ b/packages/trpc/server/team-router/schema.ts
@@ -1,6 +1,7 @@
 import { URL_PATTERN, ZNameSchema } from '@documenso/lib/constants/auth';
 import { PROTECTED_TEAM_URLS } from '@documenso/lib/constants/teams';
 import { zEmail } from '@documenso/lib/utils/zod';
+import { msg } from '@lingui/core/macro';
 import { TeamMemberRole } from '@prisma/client';
 import { z } from 'zod';
 
@@ -22,29 +23,29 @@ import { z } from 'zod';
 export const ZTeamUrlSchema = z
   .string()
   .trim()
-  .min(3, { message: 'Team URL must be at least 3 characters long.' })
-  .max(30, { message: 'Team URL must not exceed 30 characters.' })
+  .min(3, { message: msg`Team URL must be at least 3 characters long.`.id })
+  .max(30, { message: msg`Team URL must not exceed 30 characters.`.id })
   .toLowerCase()
-  .regex(/^[a-z0-9].*[^_-]$/, 'Team URL cannot start or end with dashes or underscores.')
-  .regex(/^(?!.*[-_]{2})/, 'Team URL cannot contain consecutive dashes or underscores.')
-  .regex(/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/, 'Team URL can only contain letters, numbers, dashes and underscores.')
+  .regex(/^[a-z0-9].*[^_-]$/, msg`Team URL cannot start or end with dashes or underscores.`.id)
+  .regex(/^(?!.*[-_]{2})/, msg`Team URL cannot contain consecutive dashes or underscores.`.id)
+  .regex(/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/, msg`Team URL can only contain letters, numbers, dashes and underscores.`.id)
   .refine((value) => !PROTECTED_TEAM_URLS.includes(value), {
-    message: 'This URL is already in use.',
+    message: msg`This URL is already in use.`.id,
   });
 
 export const ZTeamNameSchema = z
   .string()
   .trim()
-  .min(3, { message: 'Team name must be at least 3 characters long.' })
-  .max(30, { message: 'Team name must not exceed 30 characters.' })
+  .min(3, { message: msg`Team name must be at least 3 characters long.`.id })
+  .max(30, { message: msg`Team name must not exceed 30 characters.`.id })
   .refine((value) => !URL_PATTERN.test(value), {
-    message: 'Team name cannot contain URLs.',
+    message: msg`Team name cannot contain URLs.`.id,
   });
 
 export const ZCreateTeamEmailVerificationMutationSchema = z.object({
   teamId: z.number(),
   name: ZNameSchema,
-  email: zEmail().trim().toLowerCase().min(1, 'Please enter a valid email.'),
+  email: zEmail().trim().toLowerCase().min(1, msg`Please enter a valid email.`.id),
 });
 
 export const ZDeleteTeamEmailMutationSchema = z.object({


### PR DESCRIPTION
## Description

Adds localization markers to validation error messages that were previously hardcoded, ensuring they can be translated consistently across the application.

## Related Issue

Addresses the reported missing translations for validation errors.
#2974 

## Changes Made

* Added localization markers for the "Passwords do not match" validation message in `password.tsx`.
* Added localization markers for name length validation messages in `auth.ts`.
* Added localization markers for URL validation messages in `auth.ts`.
* Updated the affected validations to use `msg\`...`.id`, matching the existing Zod validation translation pattern used throughout the repository.

## Testing Performed

* Verified the updated validation messages follow the repository's localization pattern.
* tested locally 
* Ran build

## Checklist

* [x] I have tested these changes locally and they work as expected.
* [ ] I have added/updated tests that prove the effectiveness of these changes.
* [ ] I have updated the documentation to reflect these changes, if applicable.
* [x] I have followed the project's coding style guidelines.
* [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

This change only affects localization metadata for validation messages and does not alter validation behavior.
