### PR TITLE
feat: assistant always acts before signers without requiring sequential signing

### DIFF
--- a/apps/docs/content/docs/concepts/recipient-roles.mdx
+++ b/apps/docs/content/docs/concepts/recipient-roles.mdx
@@ -89,7 +89,7 @@ Viewers must acknowledge that they have viewed the document. They cannot add sig
 </Tab>
   <Tab value="Assistant">
 
-Assistants can prepare the document by pre-filling fields on behalf of other signers. This role is only available when sequential signing is enabled.
+Assistants can prepare the document by pre-filling fields on behalf of other signers. The assistant always completes their tasks before any signers receive the document, regardless of whether signing is parallel or sequential.
 
 **What they can do:**
 
@@ -101,7 +101,6 @@ Assistants can prepare the document by pre-filling fields on behalf of other sig
 
 - Sign on behalf of other recipients
 - Submit the document as complete
-- Be used in parallel signing mode
 
 **When to use this role:**
 
@@ -110,8 +109,7 @@ Assistants can prepare the document by pre-filling fields on behalf of other sig
 - Situations where you want to reduce the burden on the final signer
 
 <Callout type="info">
-  The Assistant role requires sequential signing to be enabled. You cannot use this role when
-  recipients sign in parallel.
+  The Assistant always acts before signers. When a document has an assistant, they receive the document first. After the assistant completes, signers are notified (all at once in parallel mode, or in order in sequential mode).
 </Callout>
 
 </Tab>
@@ -160,7 +158,9 @@ To enable sequential signing:
 3. Recipients with the same order number can act simultaneously
 4. The document proceeds to the next order number only when all recipients at the current level have completed their actions
 
-<Callout type="info">Sequential signing is required if you want to use the Assistant role.</Callout>
+<Callout type="info">
+  When using the Assistant role, the assistant always completes their tasks first before any signers receive the document, regardless of whether signing is parallel or sequential.
+</Callout>
 
 </Tab>
 </Tabs>

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-recipient-form.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-recipient-form.tsx
@@ -396,19 +396,8 @@ export const EnvelopeEditorRecipientForm = () => {
       const currentSigners = form.getValues('signers');
       const signingOrder = form.getValues('signingOrder');
 
-      // Handle parallel to sequential conversion for assistants
-      if (role === RecipientRole.ASSISTANT && signingOrder === DocumentSigningOrder.PARALLEL) {
-        form.setValue('signingOrder', DocumentSigningOrder.SEQUENTIAL, {
-          shouldValidate: true,
-          shouldDirty: true,
-        });
-        toast({
-          title: t`Signing order is enabled.`,
-          description: t`You cannot add assistants when signing order is disabled.`,
-          variant: 'destructive',
-        });
-        return;
-      }
+      // Assistant recipients always act before signers, regardless of signing order.
+      // No conversion needed — the workflow logic handles assistants as a pre-signing phase.
 
       const updatedSigners = currentSigners.map((signer, idx) => ({
         ...signer,
@@ -475,12 +464,9 @@ export const EnvelopeEditorRecipientForm = () => {
     setShowSigningOrderConfirmation(false);
 
     const currentSigners = form.getValues('signers');
-    const updatedSigners = currentSigners.map((signer) => ({
-      ...signer,
-      role: signer.role === RecipientRole.ASSISTANT ? RecipientRole.SIGNER : signer.role,
-    }));
 
-    form.setValue('signers', updatedSigners, {
+    // Keep assistant roles as-is — assistants always act before signers regardless of signing order.
+    form.setValue('signers', currentSigners, {
       shouldValidate: true,
       shouldDirty: true,
     });
@@ -957,7 +943,7 @@ export const EnvelopeEditorRecipientForm = () => {
                                           hideCCerRole={!editorConfig.recipients?.allowCCerRole}
                                           hideViewerRole={!editorConfig.recipients?.allowViewerRole}
                                           hideApproverRole={!editorConfig.recipients?.allowApproverRole}
-                                          isAssistantEnabled={isSigningOrderSequential}
+                                          isAssistantEnabled={true}
                                           onValueChange={(value) => {
                                             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                                             handleRoleChange(index, value as RecipientRole);

--- a/packages/lib/server-only/document/complete-document-with-token.ts
+++ b/packages/lib/server-only/document/complete-document-with-token.ts
@@ -451,6 +451,41 @@ export const completeDocumentWithToken = async ({
           requestMetadata,
         },
       });
+    } else if (
+      recipient.role === RecipientRole.ASSISTANT &&
+      envelope.documentMeta?.signingOrder !== DocumentSigningOrder.SEQUENTIAL
+    ) {
+      // In PARALLEL mode, when an assistant completes, notify all remaining non-CC signers.
+      // Assistants always act before signers regardless of signing order.
+      const unsentSigners = pendingRecipients.filter(
+        (r) => r.role !== RecipientRole.CC && r.role !== RecipientRole.ASSISTANT,
+      );
+
+      await prisma.$transaction(async (tx) => {
+        for (const signer of unsentSigners) {
+          await tx.recipient.update({
+            where: { id: signer.id },
+            data: {
+              sendStatus: SendStatus.SENT,
+              sentAt: new Date(),
+            },
+          });
+        }
+      });
+
+      await Promise.all(
+        unsentSigners.map(async (signer) => {
+          await jobs.triggerJob({
+            name: 'send.signing.requested.email',
+            payload: {
+              userId: envelope.userId,
+              documentId: legacyDocumentId,
+              recipientId: signer.id,
+              requestMetadata,
+            },
+          });
+        }),
+      );
     }
   }
 

--- a/packages/lib/server-only/document/send-document.ts
+++ b/packages/lib/server-only/document/send-document.ts
@@ -133,6 +133,16 @@ export const sendDocument = async ({ id, userId, teamId, sendEmail, requestMetad
     recipientsToNotify = envelope.recipients
       .filter((r) => r.signingStatus === SigningStatus.NOT_SIGNED && r.role !== RecipientRole.CC)
       .slice(0, 1);
+  } else {
+    // In PARALLEL mode, if there are assistant recipients, notify them first.
+    // Assistants always act before signers regardless of signing order.
+    const assistantRecipients = envelope.recipients.filter(
+      (r) => r.role === RecipientRole.ASSISTANT && r.signingStatus === SigningStatus.NOT_SIGNED,
+    );
+
+    if (assistantRecipients.length > 0) {
+      recipientsToNotify = assistantRecipients;
+    }
   }
 
   if (envelope.envelopeItems.length === 0) {

--- a/packages/lib/server-only/recipient/get-is-recipient-turn.ts
+++ b/packages/lib/server-only/recipient/get-is-recipient-turn.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@documenso/prisma';
-import { DocumentSigningOrder, EnvelopeType, SigningStatus } from '@prisma/client';
+import { DocumentSigningOrder, EnvelopeType, RecipientRole, SigningStatus } from '@prisma/client';
 
 export type GetIsRecipientTurnOptions = {
   token: string;
@@ -25,10 +25,6 @@ export async function getIsRecipientsTurnToSign({ token }: GetIsRecipientTurnOpt
     },
   });
 
-  if (envelope.documentMeta?.signingOrder !== DocumentSigningOrder.SEQUENTIAL) {
-    return true;
-  }
-
   const { recipients } = envelope;
 
   const currentRecipientIndex = recipients.findIndex((r) => r.token === token);
@@ -37,9 +33,29 @@ export async function getIsRecipientsTurnToSign({ token }: GetIsRecipientTurnOpt
     return false;
   }
 
-  for (let i = 0; i < currentRecipientIndex; i++) {
-    if (recipients[i].signingStatus !== SigningStatus.SIGNED) {
+  const currentRecipient = recipients[currentRecipientIndex];
+
+  // Assistants always act before signers, regardless of signing order.
+  // If the current recipient is not an assistant, check that all assistants have completed first.
+  if (currentRecipient.role !== RecipientRole.ASSISTANT) {
+    const hasPendingAssistants = recipients.some(
+      (r) =>
+        r.role === RecipientRole.ASSISTANT &&
+        r.signingStatus !== SigningStatus.SIGNED &&
+        r.id !== currentRecipient.id,
+    );
+
+    if (hasPendingAssistants) {
       return false;
+    }
+  }
+
+  // For SEQUENTIAL signing, check that all recipients before the current one have signed.
+  if (envelope.documentMeta?.signingOrder === DocumentSigningOrder.SEQUENTIAL) {
+    for (let i = 0; i < currentRecipientIndex; i++) {
+      if (recipients[i].signingStatus !== SigningStatus.SIGNED) {
+        return false;
+      }
     }
   }
 

--- a/packages/ui/components/recipient/recipient-role-select.tsx
+++ b/packages/ui/components/recipient/recipient-role-select.tsx
@@ -129,13 +129,10 @@ export const RecipientRoleSelect = forwardRef<HTMLButtonElement, RecipientRoleSe
                 </TooltipTrigger>
                 <TooltipContent className="z-9999 max-w-md p-4 text-foreground">
                   <p>
-                    {isAssistantEnabled ? (
-                      <Trans>
-                        The recipient can prepare the document for later signers by pre-filling suggest values.
-                      </Trans>
-                    ) : (
-                      <Trans>Assistant role is only available when the document is in sequential signing mode.</Trans>
-                    )}
+                    <Trans>
+                      The recipient can prepare the document for later signers by pre-filling suggest values. The assistant
+                      always completes their tasks before any signers receive the document.
+                    </Trans>
                   </p>
                 </TooltipContent>
               </Tooltip>


### PR DESCRIPTION
## Description

The Assistant (Form Filler) role now always completes their tasks before any signers receive the document, regardless of whether signing is parallel or sequential. This removes the previous requirement that sequential signing must be enabled to use the Assistant role.

## Changes

- **recipient-role-select.tsx**: Updated tooltip to explain that assistants always act before signers
- **envelope-editor-recipient-form.tsx**: Removed sequential signing requirement when adding assistants; assistants can now be used in PARALLEL mode
- **send-document.ts**: In PARALLEL mode, notify Assistants first before signers
- **complete-document-with-token.ts**: After Assistant completes in PARALLEL mode, notify all remaining signers simultaneously
- **get-is-recipient-turn.ts**: Always enforce that all Assistants complete before any signers can proceed
- **recipient-roles.mdx**: Updated documentation to reflect new behavior

## Workflow Behavior

### Before
- Assistant required sequential signing to be enabled
- Adding an Assistant in PARALLEL mode forced sequential mode automatically
- Disabling sequential signing converted Assistants back to Signers

### After
- Assistant works in both PARALLEL and SEQUENTIAL modes
- Workflow: **Assistant → Signers** (parallel) or **Assistant → Signers in order** (sequential)
- Signers don't require a workflow order to ensure the Assistant goes first

## Related Issue

Fixes #2973