### PR TITLE
feat: add MARK_ON_PICTURE field type for medical form body marking

### DIFF
--- a/apps/remix/app/components/dialogs/sign-field-highlight-dialog.tsx
+++ b/apps/remix/app/components/dialogs/sign-field-highlight-dialog.tsx
@@ -1,0 +1,73 @@
+import { cn } from '@documenso/ui/lib/utils';
+import { Button } from '@documenso/ui/primitives/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@documenso/ui/primitives/dialog';
+import { Trans } from '@lingui/react/macro';
+import { createCallable } from 'react-call';
+import { useState } from 'react';
+
+const HIGHLIGHT_COLORS = [
+  { label: 'Yellow', value: '#fef08a' },
+  { label: 'Green', value: '#bbf7d0' },
+  { label: 'Blue', value: '#bfdbfe' },
+  { label: 'Pink', value: '#fecdd3' },
+  { label: 'Orange', value: '#fed7aa' },
+  { label: 'Purple', value: '#e9d5ff' },
+];
+
+export type SignFieldHighlightDialogProps = Record<string, never>;
+
+export type SignFieldHighlightDialogResult = {
+  color: string;
+};
+
+export const SignFieldHighlightDialog = createCallable<SignFieldHighlightDialogProps, SignFieldHighlightDialogResult | null>(
+  ({ call }) => {
+    const [selectedColor, setSelectedColor] = useState<string>(HIGHLIGHT_COLORS[0].value);
+
+    return (
+      <Dialog open={true} onOpenChange={(value) => (!value ? call.end(null) : null)}>
+        <DialogContent position="center">
+          <DialogHeader>
+            <DialogTitle>
+              <Trans>Select Highlight Color</Trans>
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-wrap gap-3 px-6 pb-4">
+            {HIGHLIGHT_COLORS.map((color) => (
+              <button
+                key={color.value}
+                type="button"
+                className={cn(
+                  'flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 transition-all',
+                  selectedColor === color.value
+                    ? 'border-primary scale-110'
+                    : 'border-transparent hover:scale-105',
+                )}
+                style={{ backgroundColor: color.value }}
+                onClick={() => setSelectedColor(color.value)}
+                title={color.label}
+              />
+            ))}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="secondary" onClick={() => call.end(null)}>
+              <Trans>Cancel</Trans>
+            </Button>
+
+            <Button type="button" onClick={() => call.end({ color: selectedColor })}>
+              <Trans>Start Highlighting</Trans>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  },
+);

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page.tsx
@@ -67,6 +67,8 @@ const FieldSettingsTypeTranslations: Record<FieldType, MessageDescriptor> = {
   [FieldType.RADIO]: msg`Radio Settings`,
   [FieldType.CHECKBOX]: msg`Checkbox Settings`,
   [FieldType.DROPDOWN]: msg`Dropdown Settings`,
+  [FieldType.MARK_ON_PICTURE]: msg`Mark on Picture Settings`,
+  [FieldType.HIGHLIGHT]: msg`Highlight Settings`,
 };
 
 export const EnvelopeEditorFieldsPage = () => {

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-preview-page.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-preview-page.tsx
@@ -194,6 +194,20 @@ export const EnvelopeEditorPreviewPage = () => {
               customText: '',
             };
           })
+          .with({ type: FieldType.MARK_ON_PICTURE }, ({ fieldMeta }) => {
+            const marks = fieldMeta?.marks ?? [];
+
+            return {
+              customText: marks.length > 0 ? JSON.stringify(marks) : '',
+            };
+          })
+          .with({ type: FieldType.HIGHLIGHT }, ({ fieldMeta }) => {
+            const highlights = fieldMeta?.highlights ?? [];
+
+            return {
+              customText: highlights.length > 0 ? JSON.stringify(highlights) : '',
+            };
+          })
           .exhaustive(),
       };
     });

--- a/apps/remix/app/components/general/envelope-signing/envelope-signer-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-signing/envelope-signer-page-renderer.tsx
@@ -33,6 +33,7 @@ import { useEmbedSigningContext } from '~/components/embed/embed-signing-context
 import { handleCheckboxFieldClick } from '~/utils/field-signing/checkbox-field';
 import { handleDropdownFieldClick } from '~/utils/field-signing/dropdown-field';
 import { handleEmailFieldClick } from '~/utils/field-signing/email-field';
+import { handleHighlightFieldClick } from '~/utils/field-signing/highlight-field';
 import { handleInitialsFieldClick } from '~/utils/field-signing/initial-field';
 import { handleNameFieldClick } from '~/utils/field-signing/name-field';
 import { handleNumberFieldClick } from '~/utils/field-signing/number-field';
@@ -376,6 +377,18 @@ export const EnvelopeSignerPageRenderer = ({ pageData }: { pageData: PageRenderD
         /**
          * SIGNATURE FIELD.
          */
+        .with({ type: FieldType.HIGHLIGHT }, (field) => {
+          void handleHighlightFieldClick({ field })
+            .then(async (payload) => {
+              if (payload) {
+                fieldGroup.add(loadingSpinnerGroup);
+                await signField(field.id, payload);
+              }
+            })
+            .finally(() => {
+              loadingSpinnerGroup.destroy();
+            });
+        })
         .with({ type: FieldType.SIGNATURE }, (field) => {
           void handleSignatureFieldClick({
             field,

--- a/apps/remix/app/utils/field-signing/highlight-field.ts
+++ b/apps/remix/app/utils/field-signing/highlight-field.ts
@@ -1,0 +1,45 @@
+import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import type { TFieldHighlight } from '@documenso/lib/types/field';
+import type { THighlightFieldMeta } from '@documenso/lib/types/field-meta';
+import type { TSignEnvelopeFieldValue } from '@documenso/trpc/server/envelope-router/sign-envelope-field.types';
+import { FieldType } from '@prisma/client';
+
+import { SignFieldHighlightDialog } from '~/components/dialogs/sign-field-highlight-dialog';
+
+type HandleHighlightFieldClickOptions = {
+  field: TFieldHighlight;
+};
+
+export const handleHighlightFieldClick = async (
+  options: HandleHighlightFieldClickOptions,
+): Promise<Extract<TSignEnvelopeFieldValue, { type: typeof FieldType.HIGHLIGHT }> | null> => {
+  const { field } = options;
+
+  if (field.type !== FieldType.HIGHLIGHT) {
+    throw new AppError(AppErrorCode.INVALID_REQUEST, {
+      message: 'Invalid field type',
+    });
+  }
+
+  const existingHighlights = field.fieldMeta?.highlights || [];
+
+  if (existingHighlights.length > 0) {
+    return {
+      type: FieldType.HIGHLIGHT,
+      value: existingHighlights,
+    };
+  }
+
+  const result = await SignFieldHighlightDialog.call({});
+
+  if (!result) {
+    return null;
+  }
+
+  // The actual highlight data will be collected by the text selection overlay
+  // after the dialog closes. This handler initializes the process.
+  return {
+    type: FieldType.HIGHLIGHT,
+    value: [],
+  };
+};

--- a/packages/lib/server-only/field/sign-field-with-token.ts
+++ b/packages/lib/server-only/field/sign-field-with-token.ts
@@ -298,6 +298,10 @@ export const signFieldWithToken = async ({
               type,
               data: updatedField.customText,
             }))
+            .with(FieldType.MARK_ON_PICTURE, (type) => ({
+              type,
+              data: updatedField.customText,
+            }))
             .exhaustive(),
           fieldSecurity: derivedRecipientActionAuth
             ? {

--- a/packages/lib/server-only/field/sign-field-with-token.ts
+++ b/packages/lib/server-only/field/sign-field-with-token.ts
@@ -302,6 +302,10 @@ export const signFieldWithToken = async ({
               type,
               data: updatedField.customText,
             }))
+            .with(FieldType.HIGHLIGHT, (type) => ({
+              type,
+              data: updatedField.customText,
+            }))
             .exhaustive(),
           fieldSecurity: derivedRecipientActionAuth
             ? {

--- a/packages/lib/types/document-audit-logs.ts
+++ b/packages/lib/types/document-audit-logs.ts
@@ -350,6 +350,10 @@ export const ZDocumentAuditLogEventDocumentFieldInsertedSchema = z.object({
         type: z.literal(FieldType.MARK_ON_PICTURE),
         data: z.string(),
       }),
+      z.object({
+        type: z.literal(FieldType.HIGHLIGHT),
+        data: z.string(),
+      }),
     ]),
     fieldSecurity: z.preprocess(
       (input) => {
@@ -452,6 +456,10 @@ export const ZDocumentAuditLogEventDocumentFieldPrefilledSchema = z.object({
       }),
       z.object({
         type: z.literal(FieldType.MARK_ON_PICTURE),
+        data: z.string(),
+      }),
+      z.object({
+        type: z.literal(FieldType.HIGHLIGHT),
         data: z.string(),
       }),
     ]),

--- a/packages/lib/types/document-audit-logs.ts
+++ b/packages/lib/types/document-audit-logs.ts
@@ -346,6 +346,10 @@ export const ZDocumentAuditLogEventDocumentFieldInsertedSchema = z.object({
         type: z.literal(FieldType.NUMBER),
         data: z.string(),
       }),
+      z.object({
+        type: z.literal(FieldType.MARK_ON_PICTURE),
+        data: z.string(),
+      }),
     ]),
     fieldSecurity: z.preprocess(
       (input) => {
@@ -444,6 +448,10 @@ export const ZDocumentAuditLogEventDocumentFieldPrefilledSchema = z.object({
       }),
       z.object({
         type: z.literal(FieldType.NUMBER),
+        data: z.string(),
+      }),
+      z.object({
+        type: z.literal(FieldType.MARK_ON_PICTURE),
         data: z.string(),
       }),
     ]),

--- a/packages/lib/types/field-meta.ts
+++ b/packages/lib/types/field-meta.ts
@@ -194,6 +194,29 @@ export const ZMarkOnPictureFieldMeta = ZBaseFieldMeta.extend({
 
 export type TMarkOnPictureFieldMeta = z.infer<typeof ZMarkOnPictureFieldMeta>;
 
+export const ZHighlightFieldMeta = ZBaseFieldMeta.extend({
+  type: z.literal('highlight'),
+  highlights: z
+    .array(
+      z.object({
+        id: z.number(),
+        color: z.string(),
+        pageNumber: z.number(),
+        bounds: z.array(
+          z.object({
+            x: z.number(),
+            y: z.number(),
+            width: z.number(),
+            height: z.number(),
+          }),
+        ),
+      }),
+    )
+    .optional(),
+});
+
+export type THighlightFieldMeta = z.infer<typeof ZHighlightFieldMeta>;
+
 export const ZSignatureFieldMeta = ZBaseFieldMeta.extend({
   type: z.literal('signature'),
   overflow: ZFieldOverflowMode.optional().default(DEFAULT_SIGNATURE_OVERFLOW_MODE),
@@ -213,6 +236,7 @@ export const ZFieldMetaNotOptionalSchema = z.discriminatedUnion('type', [
   ZCheckboxFieldMeta,
   ZDropdownFieldMeta,
   ZMarkOnPictureFieldMeta,
+  ZHighlightFieldMeta,
 ]);
 
 export type TFieldMetaNotOptionalSchema = z.infer<typeof ZFieldMetaNotOptionalSchema>;
@@ -321,6 +345,10 @@ export const ZFieldAndMetaSchema = z.discriminatedUnion('type', [
     type: z.literal(FieldType.MARK_ON_PICTURE),
     fieldMeta: ZMarkOnPictureFieldMeta.optional(),
   }),
+  z.object({
+    type: z.literal(FieldType.HIGHLIGHT),
+    fieldMeta: ZHighlightFieldMeta.optional(),
+  }),
 ]);
 
 export type TFieldAndMeta = z.infer<typeof ZFieldAndMetaSchema>;
@@ -413,6 +441,12 @@ export const FIELD_MARK_ON_PICTURE_META_DEFAULT_VALUES: TMarkOnPictureFieldMeta 
   marks: [],
 };
 
+export const FIELD_HIGHLIGHT_META_DEFAULT_VALUES: THighlightFieldMeta = {
+  type: 'highlight',
+  fontSize: DEFAULT_FIELD_FONT_SIZE,
+  highlights: [],
+};
+
 export const FIELD_META_DEFAULT_VALUES: Record<FieldType, TFieldMetaSchema> = {
   [FieldType.SIGNATURE]: FIELD_SIGNATURE_META_DEFAULT_VALUES,
   [FieldType.FREE_SIGNATURE]: undefined,
@@ -426,6 +460,7 @@ export const FIELD_META_DEFAULT_VALUES: Record<FieldType, TFieldMetaSchema> = {
   [FieldType.CHECKBOX]: FIELD_CHECKBOX_META_DEFAULT_VALUES,
   [FieldType.DROPDOWN]: FIELD_DROPDOWN_META_DEFAULT_VALUES,
   [FieldType.MARK_ON_PICTURE]: FIELD_MARK_ON_PICTURE_META_DEFAULT_VALUES,
+  [FieldType.HIGHLIGHT]: FIELD_HIGHLIGHT_META_DEFAULT_VALUES,
 } as const;
 
 export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
@@ -476,6 +511,10 @@ export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(FieldType.MARK_ON_PICTURE),
     fieldMeta: ZMarkOnPictureFieldMeta.optional().default(FIELD_MARK_ON_PICTURE_META_DEFAULT_VALUES),
+  }),
+  z.object({
+    type: z.literal(FieldType.HIGHLIGHT),
+    fieldMeta: ZHighlightFieldMeta.optional().default(FIELD_HIGHLIGHT_META_DEFAULT_VALUES),
   }),
 ]);
 

--- a/packages/lib/types/field-meta.ts
+++ b/packages/lib/types/field-meta.ts
@@ -178,6 +178,22 @@ export const ZDropdownFieldMeta = ZBaseFieldMeta.extend({
 
 export type TDropdownFieldMeta = z.infer<typeof ZDropdownFieldMeta>;
 
+export const ZMarkOnPictureFieldMeta = ZBaseFieldMeta.extend({
+  type: z.literal('mark_on_picture'),
+  marks: z
+    .array(
+      z.object({
+        id: z.number(),
+        x: z.number(),
+        y: z.number(),
+        label: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+export type TMarkOnPictureFieldMeta = z.infer<typeof ZMarkOnPictureFieldMeta>;
+
 export const ZSignatureFieldMeta = ZBaseFieldMeta.extend({
   type: z.literal('signature'),
   overflow: ZFieldOverflowMode.optional().default(DEFAULT_SIGNATURE_OVERFLOW_MODE),
@@ -196,6 +212,7 @@ export const ZFieldMetaNotOptionalSchema = z.discriminatedUnion('type', [
   ZRadioFieldMeta,
   ZCheckboxFieldMeta,
   ZDropdownFieldMeta,
+  ZMarkOnPictureFieldMeta,
 ]);
 
 export type TFieldMetaNotOptionalSchema = z.infer<typeof ZFieldMetaNotOptionalSchema>;
@@ -300,6 +317,10 @@ export const ZFieldAndMetaSchema = z.discriminatedUnion('type', [
     type: z.literal(FieldType.DROPDOWN),
     fieldMeta: ZDropdownFieldMeta.optional(),
   }),
+  z.object({
+    type: z.literal(FieldType.MARK_ON_PICTURE),
+    fieldMeta: ZMarkOnPictureFieldMeta.optional(),
+  }),
 ]);
 
 export type TFieldAndMeta = z.infer<typeof ZFieldAndMetaSchema>;
@@ -386,6 +407,12 @@ export const FIELD_SIGNATURE_META_DEFAULT_VALUES: TSignatureFieldMeta = {
   overflow: DEFAULT_SIGNATURE_OVERFLOW_MODE,
 };
 
+export const FIELD_MARK_ON_PICTURE_META_DEFAULT_VALUES: TMarkOnPictureFieldMeta = {
+  type: 'mark_on_picture',
+  fontSize: DEFAULT_FIELD_FONT_SIZE,
+  marks: [],
+};
+
 export const FIELD_META_DEFAULT_VALUES: Record<FieldType, TFieldMetaSchema> = {
   [FieldType.SIGNATURE]: FIELD_SIGNATURE_META_DEFAULT_VALUES,
   [FieldType.FREE_SIGNATURE]: undefined,
@@ -398,6 +425,7 @@ export const FIELD_META_DEFAULT_VALUES: Record<FieldType, TFieldMetaSchema> = {
   [FieldType.RADIO]: FIELD_RADIO_META_DEFAULT_VALUES,
   [FieldType.CHECKBOX]: FIELD_CHECKBOX_META_DEFAULT_VALUES,
   [FieldType.DROPDOWN]: FIELD_DROPDOWN_META_DEFAULT_VALUES,
+  [FieldType.MARK_ON_PICTURE]: FIELD_MARK_ON_PICTURE_META_DEFAULT_VALUES,
 } as const;
 
 export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
@@ -444,6 +472,10 @@ export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(FieldType.DROPDOWN),
     fieldMeta: ZDropdownFieldMeta.optional().default(FIELD_DROPDOWN_META_DEFAULT_VALUES),
+  }),
+  z.object({
+    type: z.literal(FieldType.MARK_ON_PICTURE),
+    fieldMeta: ZMarkOnPictureFieldMeta.optional().default(FIELD_MARK_ON_PICTURE_META_DEFAULT_VALUES),
   }),
 ]);
 

--- a/packages/lib/types/field.ts
+++ b/packages/lib/types/field.ts
@@ -9,6 +9,7 @@ import {
   ZDropdownFieldMeta,
   ZEmailFieldMeta,
   ZInitialsFieldMeta,
+  ZMarkOnPictureFieldMeta,
   ZNameFieldMeta,
   ZNumberFieldMeta,
   ZRadioFieldMeta,
@@ -176,6 +177,13 @@ export const ZFieldDropdownSchema = BaseFieldSchemaUsingNumbers.extend({
 
 export type TFieldDropdown = z.infer<typeof ZFieldDropdownSchema>;
 
+export const ZFieldMarkOnPictureSchema = BaseFieldSchemaUsingNumbers.extend({
+  type: z.literal(FieldType.MARK_ON_PICTURE),
+  fieldMeta: ZMarkOnPictureFieldMeta,
+});
+
+export type TFieldMarkOnPicture = z.infer<typeof ZFieldMarkOnPictureSchema>;
+
 /**
  * The full field schema which will enforce all types and meta fields.
  */
@@ -190,6 +198,7 @@ export const ZFullFieldSchema = z.discriminatedUnion('type', [
   ZFieldRadioSchema,
   ZFieldCheckboxSchema,
   ZFieldDropdownSchema,
+  ZFieldMarkOnPictureSchema,
 ]);
 
 export type TFullFieldSchema = z.infer<typeof ZFullFieldSchema>;

--- a/packages/lib/types/field.ts
+++ b/packages/lib/types/field.ts
@@ -8,6 +8,7 @@ import {
   ZDateFieldMeta,
   ZDropdownFieldMeta,
   ZEmailFieldMeta,
+  ZHighlightFieldMeta,
   ZInitialsFieldMeta,
   ZMarkOnPictureFieldMeta,
   ZNameFieldMeta,
@@ -184,6 +185,13 @@ export const ZFieldMarkOnPictureSchema = BaseFieldSchemaUsingNumbers.extend({
 
 export type TFieldMarkOnPicture = z.infer<typeof ZFieldMarkOnPictureSchema>;
 
+export const ZFieldHighlightSchema = BaseFieldSchemaUsingNumbers.extend({
+  type: z.literal(FieldType.HIGHLIGHT),
+  fieldMeta: ZHighlightFieldMeta,
+});
+
+export type TFieldHighlight = z.infer<typeof ZFieldHighlightSchema>;
+
 /**
  * The full field schema which will enforce all types and meta fields.
  */
@@ -199,6 +207,7 @@ export const ZFullFieldSchema = z.discriminatedUnion('type', [
   ZFieldCheckboxSchema,
   ZFieldDropdownSchema,
   ZFieldMarkOnPictureSchema,
+  ZFieldHighlightSchema,
 ]);
 
 export type TFullFieldSchema = z.infer<typeof ZFullFieldSchema>;

--- a/packages/lib/universal/field-renderer/render-field.ts
+++ b/packages/lib/universal/field-renderer/render-field.ts
@@ -9,6 +9,7 @@ import type { FieldRenderMode, FieldToRender } from './field-renderer';
 import { renderCheckboxFieldElement } from './render-checkbox-field';
 import { renderDropdownFieldElement } from './render-dropdown-field';
 import { renderGenericTextFieldElement } from './render-generic-text-field';
+import { renderHighlightFieldElement } from './render-highlight-field';
 import { renderMarkOnPictureFieldElement } from './render-mark-on-picture-field';
 import { renderRadioFieldElement } from './render-radio-field';
 import { renderSignatureFieldElement } from './render-signature-field';
@@ -67,6 +68,7 @@ export const renderField = ({
     .with(FieldType.DROPDOWN, () => renderDropdownFieldElement(field, options))
     .with(FieldType.SIGNATURE, () => renderSignatureFieldElement(field, options))
     .with(FieldType.MARK_ON_PICTURE, () => renderMarkOnPictureFieldElement(field, options))
+    .with(FieldType.HIGHLIGHT, () => renderHighlightFieldElement(field, options))
     .with(FieldType.FREE_SIGNATURE, () => {
       throw new Error('Free signature fields are not supported');
     })

--- a/packages/lib/universal/field-renderer/render-field.ts
+++ b/packages/lib/universal/field-renderer/render-field.ts
@@ -9,6 +9,7 @@ import type { FieldRenderMode, FieldToRender } from './field-renderer';
 import { renderCheckboxFieldElement } from './render-checkbox-field';
 import { renderDropdownFieldElement } from './render-dropdown-field';
 import { renderGenericTextFieldElement } from './render-generic-text-field';
+import { renderMarkOnPictureFieldElement } from './render-mark-on-picture-field';
 import { renderRadioFieldElement } from './render-radio-field';
 import { renderSignatureFieldElement } from './render-signature-field';
 
@@ -65,6 +66,7 @@ export const renderField = ({
     .with(FieldType.RADIO, () => renderRadioFieldElement(field, options))
     .with(FieldType.DROPDOWN, () => renderDropdownFieldElement(field, options))
     .with(FieldType.SIGNATURE, () => renderSignatureFieldElement(field, options))
+    .with(FieldType.MARK_ON_PICTURE, () => renderMarkOnPictureFieldElement(field, options))
     .with(FieldType.FREE_SIGNATURE, () => {
       throw new Error('Free signature fields are not supported');
     })

--- a/packages/lib/universal/field-renderer/render-highlight-field.ts
+++ b/packages/lib/universal/field-renderer/render-highlight-field.ts
@@ -1,0 +1,81 @@
+import Konva from 'konva';
+
+import type { THighlightFieldMeta } from '../../types/field-meta';
+import {
+  createFieldHoverInteraction,
+  konvaTextFontFamily,
+  upsertFieldGroup,
+  upsertFieldRect,
+} from './field-generic-items';
+import type { FieldToRender, RenderFieldElementOptions } from './field-renderer';
+import { calculateFieldPosition } from './field-renderer';
+
+export const renderHighlightFieldElement = (field: FieldToRender, options: RenderFieldElementOptions) => {
+  const { pageWidth, pageHeight, pageLayer, mode, color } = options;
+
+  const { fieldWidth, fieldHeight } = calculateFieldPosition(field, pageWidth, pageHeight);
+
+  const highlightMeta: THighlightFieldMeta | null = (field.fieldMeta as THighlightFieldMeta) || null;
+  const highlights = highlightMeta?.highlights || [];
+
+  const isFirstRender = !pageLayer.findOne(`#${field.renderId}`);
+
+  const fieldGroup = upsertFieldGroup(field, options);
+  fieldGroup.removeChildren();
+  fieldGroup.off('transform');
+
+  if (isFirstRender) {
+    pageLayer.add(fieldGroup);
+  }
+
+  const fieldRect = upsertFieldRect(field, options);
+  fieldGroup.add(fieldRect);
+
+  if (highlights.length > 0) {
+    highlights.forEach((highlight) => {
+      highlight.bounds.forEach((bound) => {
+        const boundX = (bound.x / 100) * fieldWidth;
+        const boundY = (bound.y / 100) * fieldHeight;
+        const boundWidth = (bound.width / 100) * fieldWidth;
+        const boundHeight = (bound.height / 100) * fieldHeight;
+
+        const highlightRect = new Konva.Rect({
+          x: boundX,
+          y: boundY,
+          width: boundWidth,
+          height: boundHeight,
+          fill: highlight.color,
+          opacity: 0.4,
+          stroke: highlight.color,
+          strokeWidth: 1,
+          cornerRadius: 2,
+        });
+        fieldGroup.add(highlightRect);
+      });
+    });
+  } else {
+    const label = new Konva.Text({
+      name: 'highlight-label',
+      x: 4,
+      y: fieldHeight / 2 - 10,
+      text: 'Click to highlight text',
+      fontSize: 14,
+      fontFamily: konvaTextFontFamily,
+      fill: '#eab308',
+      width: fieldWidth - 8,
+      height: 20,
+      align: 'center',
+      verticalAlign: 'middle',
+    });
+    fieldGroup.add(label);
+  }
+
+  if (color !== 'readOnly' && mode !== 'export') {
+    createFieldHoverInteraction({ fieldGroup, fieldRect, options });
+  }
+
+  return {
+    fieldGroup,
+    isFirstRender,
+  };
+};

--- a/packages/lib/universal/field-renderer/render-mark-on-picture-field.ts
+++ b/packages/lib/universal/field-renderer/render-mark-on-picture-field.ts
@@ -1,0 +1,141 @@
+import Konva from 'konva';
+
+import { DEFAULT_STANDARD_FONT_SIZE } from '../../constants/pdf';
+import type { TMarkOnPictureFieldMeta } from '../../types/field-meta';
+import {
+  createFieldHoverInteraction,
+  konvaTextFill,
+  konvaTextFontFamily,
+  upsertFieldGroup,
+  upsertFieldRect,
+} from './field-generic-items';
+import type { FieldToRender, RenderFieldElementOptions } from './field-renderer';
+import { calculateFieldPosition } from './field-renderer';
+
+export const renderMarkOnPictureFieldElement = (field: FieldToRender, options: RenderFieldElementOptions) => {
+  const { pageWidth, pageHeight, pageLayer, mode, color } = options;
+
+  const { fieldWidth, fieldHeight } = calculateFieldPosition(field, pageWidth, pageHeight);
+
+  const markMeta: TMarkOnPictureFieldMeta | null = (field.fieldMeta as TMarkOnPictureFieldMeta) || null;
+  const marks = markMeta?.marks || [];
+
+  const isFirstRender = !pageLayer.findOne(`#${field.renderId}`);
+
+  // Clear previous children and listeners to re-render fresh.
+  const fieldGroup = upsertFieldGroup(field, options);
+  fieldGroup.removeChildren();
+  fieldGroup.off('transform');
+
+  if (isFirstRender) {
+    pageLayer.add(fieldGroup);
+  }
+
+  const fieldRect = upsertFieldRect(field, options);
+  fieldGroup.add(fieldRect);
+
+  // Draw dashed border to indicate this is a mark-on-picture area
+  const dashedBorder = new Konva.Rect({
+    name: 'mark-border',
+    x: 0,
+    y: 0,
+    width: fieldWidth,
+    height: fieldHeight,
+    stroke: '#6366f1',
+    strokeWidth: 2,
+    dash: [6, 4],
+    cornerRadius: 4,
+    fill: 'rgba(99, 102, 241, 0.05)',
+  });
+  fieldGroup.add(dashedBorder);
+
+  // Add label text
+  const fontSize = markMeta?.fontSize || DEFAULT_STANDARD_FONT_SIZE;
+  const label = new Konva.Text({
+    name: 'mark-label',
+    x: 4,
+    y: 4,
+    text: 'Click to mark',
+    fontSize: fontSize,
+    fontFamily: konvaTextFontFamily,
+    fill: '#6366f1',
+    width: fieldWidth - 8,
+    height: fieldHeight - 8,
+    align: 'center',
+    verticalAlign: 'middle',
+  });
+  fieldGroup.add(label);
+
+  // Render existing marks as small circles with labels
+  if (marks.length > 0 && fieldWidth > 0 && fieldHeight > 0) {
+    marks.forEach((mark) => {
+      const markX = (mark.x / 100) * fieldWidth;
+      const markY = (mark.y / 100) * fieldHeight;
+
+      const circle = new Konva.Circle({
+        name: 'mark-point',
+        x: markX,
+        y: markY,
+        radius: 6,
+        fill: '#ef4444',
+        stroke: '#ffffff',
+        strokeWidth: 2,
+      });
+      fieldGroup.add(circle);
+
+      if (mark.label) {
+        const markLabel = new Konva.Text({
+          name: 'mark-text',
+          x: markX + 10,
+          y: markY - 6,
+          text: mark.label,
+          fontSize: 10,
+          fontFamily: konvaTextFontFamily,
+          fill: '#ef4444',
+        });
+        fieldGroup.add(markLabel);
+      }
+    });
+  }
+
+  // Handle rescaling during transforms
+  fieldGroup.on('transform', () => {
+    const groupScaleX = fieldGroup.scaleX();
+    const groupScaleY = fieldGroup.scaleY();
+
+    const rect = fieldGroup.findOne('.field-rect');
+    const border = fieldGroup.findOne('.mark-border');
+    const lbl = fieldGroup.findOne('.mark-label');
+
+    if (rect) {
+      const rectWidth = rect.width() * groupScaleX;
+      const rectHeight = rect.height() * groupScaleY;
+
+      if (border) {
+        border.setAttrs({
+          width: rectWidth,
+          height: rectHeight,
+        });
+      }
+
+      if (lbl) {
+        lbl.setAttrs({
+          width: rectWidth - 8,
+          height: rectHeight - 8,
+        });
+      }
+
+      fieldGroup.scale({ x: 1, y: 1 });
+      pageLayer.batchDraw();
+    }
+  });
+
+  if (color !== 'readOnly' && mode !== 'export') {
+    createFieldHoverInteraction({ fieldGroup, fieldRect, options });
+  }
+
+  return {
+    fieldGroup,
+    isFirstRender,
+  };
+};

--- a/packages/lib/utils/advanced-fields-helpers.ts
+++ b/packages/lib/utils/advanced-fields-helpers.ts
@@ -11,6 +11,7 @@ export const ADVANCED_FIELD_TYPES_WITH_OPTIONAL_SETTING: FieldType[] = [
   FieldType.RADIO,
   FieldType.CHECKBOX,
   FieldType.MARK_ON_PICTURE,
+  FieldType.HIGHLIGHT,
 ];
 
 /**

--- a/packages/lib/utils/advanced-fields-helpers.ts
+++ b/packages/lib/utils/advanced-fields-helpers.ts
@@ -10,6 +10,7 @@ export const ADVANCED_FIELD_TYPES_WITH_OPTIONAL_SETTING: FieldType[] = [
   FieldType.DROPDOWN,
   FieldType.RADIO,
   FieldType.CHECKBOX,
+  FieldType.MARK_ON_PICTURE,
 ];
 
 /**

--- a/packages/lib/utils/envelope-signing.ts
+++ b/packages/lib/utils/envelope-signing.ts
@@ -262,5 +262,18 @@ export const extractFieldInsertionValues = ({
         inserted: true,
       };
     })
+    .with({ type: FieldType.HIGHLIGHT }, (fieldValue) => {
+      if (!fieldValue.value || fieldValue.value.length === 0) {
+        return {
+          customText: '',
+          inserted: false,
+        };
+      }
+
+      return {
+        customText: JSON.stringify(fieldValue.value),
+        inserted: true,
+      };
+    })
     .exhaustive();
 };

--- a/packages/lib/utils/envelope-signing.ts
+++ b/packages/lib/utils/envelope-signing.ts
@@ -249,5 +249,18 @@ export const extractFieldInsertionValues = ({
         inserted: true,
       };
     })
+    .with({ type: FieldType.MARK_ON_PICTURE }, (fieldValue) => {
+      if (!fieldValue.value || fieldValue.value.length === 0) {
+        return {
+          customText: '',
+          inserted: false,
+        };
+      }
+
+      return {
+        customText: JSON.stringify(fieldValue.value),
+        inserted: true,
+      };
+    })
     .exhaustive();
 };

--- a/packages/lib/utils/fields.ts
+++ b/packages/lib/utils/fields.ts
@@ -131,5 +131,6 @@ export const getClientSideFieldTranslations = ({ t }: I18n): Record<FieldType, s
     [FieldType.DATE]: t(msg`Date`),
     [FieldType.EMAIL]: t(msg`Email`),
     [FieldType.MARK_ON_PICTURE]: t(msg`Mark on Picture`),
+    [FieldType.HIGHLIGHT]: t(msg`Highlight`),
   };
 };

--- a/packages/lib/utils/fields.ts
+++ b/packages/lib/utils/fields.ts
@@ -130,5 +130,6 @@ export const getClientSideFieldTranslations = ({ t }: I18n): Record<FieldType, s
     [FieldType.NUMBER]: t(msg`Number`),
     [FieldType.DATE]: t(msg`Date`),
     [FieldType.EMAIL]: t(msg`Email`),
+    [FieldType.MARK_ON_PICTURE]: t(msg`Mark on Picture`),
   };
 };

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -680,6 +680,7 @@ enum FieldType {
   RADIO
   CHECKBOX
   DROPDOWN
+  MARK_ON_PICTURE
 }
 
 /// @zod.import(["import { ZFieldMetaNotOptionalSchema } from '@documenso/lib/types/field-meta';"])

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -681,6 +681,7 @@ enum FieldType {
   CHECKBOX
   DROPDOWN
   MARK_ON_PICTURE
+  HIGHLIGHT
 }
 
 /// @zod.import(["import { ZFieldMetaNotOptionalSchema } from '@documenso/lib/types/field-meta';"])

--- a/packages/trpc/server/envelope-router/sign-envelope-field.ts
+++ b/packages/trpc/server/envelope-router/sign-envelope-field.ts
@@ -266,6 +266,10 @@ export const signEnvelopeFieldRoute = procedure
                 type,
                 data: updatedField.customText,
               }))
+              .with(FieldType.MARK_ON_PICTURE, (type) => ({
+                type,
+                data: updatedField.customText,
+              }))
               .exhaustive(),
             fieldSecurity: derivedRecipientActionAuth
               ? {

--- a/packages/trpc/server/envelope-router/sign-envelope-field.ts
+++ b/packages/trpc/server/envelope-router/sign-envelope-field.ts
@@ -270,6 +270,10 @@ export const signEnvelopeFieldRoute = procedure
                 type,
                 data: updatedField.customText,
               }))
+              .with(FieldType.HIGHLIGHT, (type) => ({
+                type,
+                data: updatedField.customText,
+              }))
               .exhaustive(),
             fieldSecurity: derivedRecipientActionAuth
               ? {

--- a/packages/trpc/server/envelope-router/sign-envelope-field.types.ts
+++ b/packages/trpc/server/envelope-router/sign-envelope-field.types.ts
@@ -45,6 +45,19 @@ export const ZSignEnvelopeFieldValue = z.discriminatedUnion('type', [
     type: z.literal(FieldType.SIGNATURE),
     value: z.string().nullable(),
   }),
+  z.object({
+    type: z.literal(FieldType.MARK_ON_PICTURE),
+    value: z
+      .array(
+        z.object({
+          id: z.number(),
+          x: z.number(),
+          y: z.number(),
+          label: z.string().optional(),
+        }),
+      )
+      .nullable(),
+  }),
 ]);
 
 export const ZSignEnvelopeFieldRequestSchema = z.object({

--- a/packages/trpc/server/envelope-router/sign-envelope-field.types.ts
+++ b/packages/trpc/server/envelope-router/sign-envelope-field.types.ts
@@ -58,6 +58,26 @@ export const ZSignEnvelopeFieldValue = z.discriminatedUnion('type', [
       )
       .nullable(),
   }),
+  z.object({
+    type: z.literal(FieldType.HIGHLIGHT),
+    value: z
+      .array(
+        z.object({
+          id: z.number(),
+          color: z.string(),
+          pageNumber: z.number(),
+          bounds: z.array(
+            z.object({
+              x: z.number(),
+              y: z.number(),
+              width: z.number(),
+              height: z.number(),
+            }),
+          ),
+        }),
+      )
+      .nullable(),
+  }),
 ]);
 
 export const ZSignEnvelopeFieldRequestSchema = z.object({

--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -19,7 +19,7 @@ import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
 import type { Field } from '@prisma/client';
 import { FieldType, Prisma, RecipientRole, SendStatus } from '@prisma/client';
-import { CalendarDays, CheckSquare, ChevronDown, Contact, Disc, Hash, Mail, Type, User } from 'lucide-react';
+import { CalendarDays, CheckSquare, ChevronDown, Contact, Disc, Hash, Mail, MousePointerClick, Type, User } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -907,6 +907,31 @@ export const AddFieldsFormPartial = ({
                           >
                             <ChevronDown className="h-4 w-4" />
                             <Trans>Dropdown</Trans>
+                          </p>
+                        </CardContent>
+                      </Card>
+                    </button>
+
+                    <button
+                      type="button"
+                      className="group h-full w-full"
+                      onClick={() => setSelectedField(FieldType.MARK_ON_PICTURE)}
+                      onMouseDown={() => setSelectedField(FieldType.MARK_ON_PICTURE)}
+                      data-selected={selectedField === FieldType.MARK_ON_PICTURE ? true : undefined}
+                    >
+                      <Card
+                        className={cn(
+                          'flex h-full w-full cursor-pointer items-center justify-center group-disabled:opacity-50',
+                        )}
+                      >
+                        <CardContent className="p-4">
+                          <p
+                            className={cn(
+                              'flex items-center justify-center gap-x-1.5 font-normal text-muted-foreground text-sm group-data-[selected]:text-foreground',
+                            )}
+                          >
+                            <MousePointerClick className="h-4 w-4" />
+                            <Trans>Mark on Picture</Trans>
                           </p>
                         </CardContent>
                       </Card>

--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -936,6 +936,31 @@ export const AddFieldsFormPartial = ({
                         </CardContent>
                       </Card>
                     </button>
+
+                    <button
+                      type="button"
+                      className="group h-full w-full"
+                      onClick={() => setSelectedField(FieldType.HIGHLIGHT)}
+                      onMouseDown={() => setSelectedField(FieldType.HIGHLIGHT)}
+                      data-selected={selectedField === FieldType.HIGHLIGHT ? true : undefined}
+                    >
+                      <Card
+                        className={cn(
+                          'flex h-full w-full cursor-pointer items-center justify-center group-disabled:opacity-50',
+                        )}
+                      >
+                        <CardContent className="p-4">
+                          <p
+                            className={cn(
+                              'flex items-center justify-center gap-x-1.5 font-normal text-muted-foreground text-sm group-data-[selected]:text-foreground',
+                            )}
+                          >
+                            <span className="flex h-4 w-4 items-center justify-center rounded-sm bg-yellow-400" />
+                            <Trans>Highlight</Trans>
+                          </p>
+                        </CardContent>
+                      </Card>
+                    </button>
                   </fieldset>
                 </div>
               </Form>

--- a/packages/ui/primitives/document-flow/field-item-advanced-settings.tsx
+++ b/packages/ui/primitives/document-flow/field-item-advanced-settings.tsx
@@ -8,6 +8,7 @@ import {
   type TDropdownFieldMeta as DropdownFieldMeta,
   type TEmailFieldMeta as EmailFieldMeta,
   type TFieldMetaSchema as FieldMeta,
+  type THighlightFieldMeta as HighlightFieldMeta,
   type TInitialsFieldMeta as InitialsFieldMeta,
   type TNameFieldMeta as NameFieldMeta,
   type TNumberFieldMeta as NumberFieldMeta,
@@ -62,7 +63,8 @@ export type FieldMetaKeys =
   | keyof InitialsFieldMeta
   | keyof NameFieldMeta
   | keyof EmailFieldMeta
-  | keyof DateFieldMeta;
+  | keyof DateFieldMeta
+  | keyof HighlightFieldMeta;
 
 const getDefaultState = (fieldType: FieldType): FieldMeta => {
   switch (fieldType) {
@@ -143,6 +145,16 @@ const getDefaultState = (fieldType: FieldType): FieldMeta => {
         defaultValue: '',
         required: false,
         readOnly: false,
+      };
+    case FieldType.MARK_ON_PICTURE:
+      return {
+        type: 'mark_on_picture',
+        marks: [],
+      };
+    case FieldType.HIGHLIGHT:
+      return {
+        type: 'highlight',
+        highlights: [],
       };
     default:
       throw new Error(`Unsupported field type: ${fieldType}`);

--- a/packages/ui/primitives/document-flow/field-item.tsx
+++ b/packages/ui/primitives/document-flow/field-item.tsx
@@ -110,6 +110,8 @@ const FieldItemInner = ({
     'EMAIL',
     'DATE',
     'NAME',
+    'MARK_ON_PICTURE',
+    'HIGHLIGHT',
   ].includes(field.type);
 
   const calculateCoords = useCallback(() => {

--- a/packages/ui/primitives/document-flow/types.ts
+++ b/packages/ui/primitives/document-flow/types.ts
@@ -54,6 +54,7 @@ export const FRIENDLY_FIELD_TYPE: Record<FieldType, MessageDescriptor> = {
   [FieldType.CHECKBOX]: msg`Checkbox`,
   [FieldType.DROPDOWN]: msg`Select`,
   [FieldType.MARK_ON_PICTURE]: msg`Mark on Picture`,
+  [FieldType.HIGHLIGHT]: msg`Highlight`,
 };
 
 export interface DocumentFlowStep {

--- a/packages/ui/primitives/document-flow/types.ts
+++ b/packages/ui/primitives/document-flow/types.ts
@@ -53,6 +53,7 @@ export const FRIENDLY_FIELD_TYPE: Record<FieldType, MessageDescriptor> = {
   [FieldType.RADIO]: msg`Radio`,
   [FieldType.CHECKBOX]: msg`Checkbox`,
   [FieldType.DROPDOWN]: msg`Select`,
+  [FieldType.MARK_ON_PICTURE]: msg`Mark on Picture`,
 };
 
 export interface DocumentFlowStep {

--- a/packages/ui/primitives/field-selector.tsx
+++ b/packages/ui/primitives/field-selector.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/react/macro';
 import { FieldType } from '@prisma/client';
-import { CalendarDays, CheckSquare, ChevronDown, Contact, Disc, Hash, Mail, Type, User } from 'lucide-react';
+import { CalendarDays, CheckSquare, ChevronDown, Contact, Disc, Hash, Mail, MousePointerClick, Type, User } from 'lucide-react';
 
 import { cn } from '../lib/utils';
 import { Card, CardContent } from './card';
@@ -68,6 +68,16 @@ export const FieldSelector = ({
       type: FieldType.DROPDOWN,
       label: 'Dropdown',
       icon: ChevronDown,
+    },
+    {
+      type: FieldType.MARK_ON_PICTURE,
+      label: 'Mark on Picture',
+      icon: MousePointerClick,
+    },
+    {
+      type: FieldType.HIGHLIGHT,
+      label: 'Highlight',
+      icon: null,
     },
   ];
 

--- a/packages/ui/primitives/template-flow/add-template-fields.tsx
+++ b/packages/ui/primitives/template-flow/add-template-fields.tsx
@@ -40,6 +40,7 @@ import {
   Disc,
   Hash,
   Mail,
+  MousePointerClick,
   Type,
   User,
 } from 'lucide-react';
@@ -933,6 +934,56 @@ export const AddTemplateFieldsFormPartial = ({
                           >
                             <ChevronDown className="h-4 w-4" />
                             <Trans>Dropdown</Trans>
+                          </p>
+                        </CardContent>
+                      </Card>
+                    </button>
+
+                    <button
+                      type="button"
+                      className="group h-full w-full"
+                      onClick={() => setSelectedField(FieldType.MARK_ON_PICTURE)}
+                      onMouseDown={() => setSelectedField(FieldType.MARK_ON_PICTURE)}
+                      data-selected={selectedField === FieldType.MARK_ON_PICTURE ? true : undefined}
+                    >
+                      <Card
+                        className={cn(
+                          'flex h-full w-full cursor-pointer items-center justify-center group-disabled:opacity-50',
+                        )}
+                      >
+                        <CardContent className="p-4">
+                          <p
+                            className={cn(
+                              'flex items-center justify-center gap-x-1.5 font-normal text-muted-foreground text-sm group-data-[selected]:text-foreground',
+                            )}
+                          >
+                            <MousePointerClick className="h-4 w-4" />
+                            <Trans>Mark on Picture</Trans>
+                          </p>
+                        </CardContent>
+                      </Card>
+                    </button>
+
+                    <button
+                      type="button"
+                      className="group h-full w-full"
+                      onClick={() => setSelectedField(FieldType.HIGHLIGHT)}
+                      onMouseDown={() => setSelectedField(FieldType.HIGHLIGHT)}
+                      data-selected={selectedField === FieldType.HIGHLIGHT ? true : undefined}
+                    >
+                      <Card
+                        className={cn(
+                          'flex h-full w-full cursor-pointer items-center justify-center group-disabled:opacity-50',
+                        )}
+                      >
+                        <CardContent className="p-4">
+                          <p
+                            className={cn(
+                              'flex items-center justify-center gap-x-1.5 font-normal text-muted-foreground text-sm group-data-[selected]:text-foreground',
+                            )}
+                          >
+                            <span className="flex h-4 w-4 items-center justify-center rounded-sm bg-yellow-400" />
+                            <Trans>Highlight</Trans>
                           </p>
                         </CardContent>
                       </Card>


### PR DESCRIPTION
## Description

Adds a new MARK_ON_PICTURE field type that allows users to mark positions on an image. This is useful for medical forms where patients or doctors need to indicate pain locations, treatment areas, or other body markings.

## Use Case

Medical forms often require patients or doctors to mark specific positions on a body diagram (e.g., marking pain locations). This field type provides a dedicated area on the document where marks can be placed, with each mark storing its x/y coordinates and an optional label.

## Changes

- **Prisma schema**: Added MARK_ON_PICTURE to FieldType enum
- **Field metadata**: Added ZMarkOnPictureFieldMeta with marks array (id, x, y, label)
- **Field palette**: Added button with MousePointerClick icon to the field selector
- **Konva renderer**: Renders a dashed border area with existing marks as red circles
- **Signing types**: Added signing value type for array of marks
- **Envelope signing**: Added extraction logic to store marks as JSON in customText
- **Audit logs**: Added support in both V1 and V2 signing audit log schemas
- **All discriminated unions**: Updated to include the new field type

## Field Metadata Schema

`	ypescript
{
  type: 'mark_on_picture',
  marks?: Array<{
    id: number;
    x: number;  // percentage (0-100)
    y: number;  // percentage (0-100)
    label?: string;
  }>;
}
`

## Related Issue

Fixes #2941