### PR TITLE
feat: allow additional envelope duplicate settings

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-duplicate-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-duplicate-dialog.tsx
@@ -1,6 +1,7 @@
 import { formatDocumentsPath, formatTemplatesPath } from '@documenso/lib/utils/teams';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
+import { Checkbox } from '@documenso/ui/primitives/checkbox';
 import {
   Dialog,
   DialogClose,
@@ -11,10 +12,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@documenso/ui/primitives/dialog';
+import { Label } from '@documenso/ui/primitives/label';
 import { useToast } from '@documenso/ui/primitives/use-toast';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { EnvelopeType } from '@prisma/client';
 import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
 import { useCurrentTeam } from '~/providers/team';
@@ -37,6 +40,15 @@ export const EnvelopeDuplicateDialog = ({ envelopeId, envelopeType, trigger }: E
 
   const isDocument = envelopeType === EnvelopeType.DOCUMENT;
 
+  const form = useForm({
+    defaultValues: {
+      includeRecipients: true,
+      includeFields: true,
+    },
+  });
+
+  const includeRecipients = form.watch('includeRecipients');
+
   const { mutateAsync: duplicateEnvelope, isPending: isDuplicating } = trpc.envelope.duplicate.useMutation({
     onSuccess: async ({ id }) => {
       toast({
@@ -55,8 +67,14 @@ export const EnvelopeDuplicateDialog = ({ envelopeId, envelopeType, trigger }: E
   });
 
   const onDuplicate = async () => {
+    const { includeRecipients, includeFields } = form.getValues();
+
     try {
-      await duplicateEnvelope({ envelopeId });
+      await duplicateEnvelope({
+        envelopeId,
+        includeRecipients,
+        includeFields: includeRecipients && includeFields,
+      });
     } catch {
       toast({
         title: t`Something went wrong`,
@@ -70,7 +88,20 @@ export const EnvelopeDuplicateDialog = ({ envelopeId, envelopeType, trigger }: E
   };
 
   return (
-    <Dialog open={open} onOpenChange={(value) => !isDuplicating && setOpen(value)}>
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        if (isDuplicating) {
+          return;
+        }
+
+        setOpen(value);
+
+        if (!value) {
+          form.reset();
+        }
+      }}
+    >
       {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
 
       <DialogContent>
@@ -86,6 +117,49 @@ export const EnvelopeDuplicateDialog = ({ envelopeId, envelopeType, trigger }: E
             )}
           </DialogDescription>
         </DialogHeader>
+
+        <div className="space-y-4">
+          <Controller
+            control={form.control}
+            name="includeRecipients"
+            render={({ field }) => (
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="envelopeDuplicateIncludeRecipients"
+                  checked={field.value}
+                  onCheckedChange={(checked) => {
+                    field.onChange(checked === true);
+
+                    if (!checked) {
+                      form.setValue('includeFields', false);
+                    }
+                  }}
+                />
+                <Label htmlFor="envelopeDuplicateIncludeRecipients">
+                  <Trans>Include Recipients</Trans>
+                </Label>
+              </div>
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="includeFields"
+            render={({ field }) => (
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="envelopeDuplicateIncludeFields"
+                  checked={field.value}
+                  disabled={!includeRecipients}
+                  onCheckedChange={(checked) => field.onChange(checked === true)}
+                />
+                <Label htmlFor="envelopeDuplicateIncludeFields" className={!includeRecipients ? 'opacity-50' : ''}>
+                  <Trans>Include Fields</Trans>
+                </Label>
+              </div>
+            )}
+          />
+        </div>
 
         <DialogFooter>
           <DialogClose asChild>

--- a/packages/app-tests/e2e/envelope-editor-v2/envelope-actions.spec.ts
+++ b/packages/app-tests/e2e/envelope-editor-v2/envelope-actions.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { NEXT_PUBLIC_WEBAPP_URL } from '@documenso/lib/constants/app';
 import { createApiToken } from '@documenso/lib/server-only/public-api/create-api-token';
 import { prisma } from '@documenso/prisma';
+import { seedDraftDocument } from '@documenso/prisma/seed/documents';
 import { seedTemplate } from '@documenso/prisma/seed/templates';
 import { seedUser } from '@documenso/prisma/seed/users';
 import type {
@@ -300,6 +301,95 @@ test.describe('document editor', () => {
 
     // Should have original + duplicate.
     expect(envelopes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('duplicate document without recipients excludes recipients and fields', async ({ page }) => {
+    const { user, team } = await seedUser();
+
+    // Seed a draft document that has a recipient with a field.
+    const document = await seedDraftDocument(user, team.id, ['signer@test.documenso.com'], {
+      key: `dup-exclude-recipients-${Date.now()}`,
+      internalVersion: 2,
+    });
+
+    await apiSignin({
+      page,
+      email: user.email,
+      redirectPath: `/t/${team.url}/documents/${document.id}/edit`,
+    });
+
+    await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible();
+
+    // Open the duplicate dialog.
+    await page.locator('button[title="Duplicate Envelope"]').click();
+    await expect(page.getByRole('heading', { name: 'Duplicate Document' })).toBeVisible();
+
+    // Uncheck "Include Recipients" — this also disables and unchecks "Include Fields".
+    await page.getByLabel('Include Recipients').click();
+    await expect(page.getByLabel('Include Fields')).toBeDisabled();
+
+    // Duplicate.
+    await page.getByRole('button', { name: 'Duplicate' }).click();
+    await expectToastTextToBeVisible(page, 'Document Duplicated');
+    await expect(page).toHaveURL(/\/documents\/.*\/edit/);
+
+    // The duplicate should have neither recipients nor fields.
+    const duplicate = await prisma.envelope.findFirstOrThrow({
+      where: {
+        teamId: team.id,
+        type: EnvelopeType.DOCUMENT,
+        id: { not: document.id },
+      },
+      include: { recipients: true, fields: true },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    expect(duplicate.recipients).toHaveLength(0);
+    expect(duplicate.fields).toHaveLength(0);
+  });
+
+  test('duplicate document without fields keeps recipients but excludes fields', async ({ page }) => {
+    const { user, team } = await seedUser();
+
+    // Seed a draft document that has a recipient with a field.
+    const document = await seedDraftDocument(user, team.id, ['signer@test.documenso.com'], {
+      key: `dup-exclude-fields-${Date.now()}`,
+      internalVersion: 2,
+    });
+
+    await apiSignin({
+      page,
+      email: user.email,
+      redirectPath: `/t/${team.url}/documents/${document.id}/edit`,
+    });
+
+    await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible();
+
+    // Open the duplicate dialog.
+    await page.locator('button[title="Duplicate Envelope"]').click();
+    await expect(page.getByRole('heading', { name: 'Duplicate Document' })).toBeVisible();
+
+    // Uncheck only "Include Fields" (recipients stay included).
+    await page.getByLabel('Include Fields').click();
+
+    // Duplicate.
+    await page.getByRole('button', { name: 'Duplicate' }).click();
+    await expectToastTextToBeVisible(page, 'Document Duplicated');
+    await expect(page).toHaveURL(/\/documents\/.*\/edit/);
+
+    // The duplicate should keep the recipient but have no fields.
+    const duplicate = await prisma.envelope.findFirstOrThrow({
+      where: {
+        teamId: team.id,
+        type: EnvelopeType.DOCUMENT,
+        id: { not: document.id },
+      },
+      include: { recipients: true, fields: true },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    expect(duplicate.recipients).toHaveLength(1);
+    expect(duplicate.fields).toHaveLength(0);
   });
 
   test('download PDF dialog shows envelope items', async ({ page }) => {

--- a/packages/trpc/server/envelope-router/duplicate-envelope.ts
+++ b/packages/trpc/server/envelope-router/duplicate-envelope.ts
@@ -13,7 +13,7 @@ export const duplicateEnvelopeRoute = authenticatedProcedure
   .output(ZDuplicateEnvelopeResponseSchema)
   .mutation(async ({ input, ctx }) => {
     const { teamId } = ctx;
-    const { envelopeId } = input;
+    const { envelopeId, includeRecipients, includeFields } = input;
 
     ctx.logger.info({
       input: {
@@ -27,6 +27,10 @@ export const duplicateEnvelopeRoute = authenticatedProcedure
       id: {
         type: 'envelopeId',
         id: envelopeId,
+      },
+      overrides: {
+        includeRecipients,
+        includeFields,
       },
     });
 

--- a/packages/trpc/server/envelope-router/duplicate-envelope.types.ts
+++ b/packages/trpc/server/envelope-router/duplicate-envelope.types.ts
@@ -13,7 +13,17 @@ export const duplicateEnvelopeMeta: TrpcRouteMeta = {
 };
 
 export const ZDuplicateEnvelopeRequestSchema = z.object({
-  envelopeId: z.string(),
+  envelopeId: z.string().min(1).describe('The ID of the envelope to duplicate.'),
+  includeRecipients: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether to copy the recipients to the duplicated envelope. Defaults to true.'),
+  includeFields: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Whether to copy the fields to the duplicated envelope. Requires includeRecipients. Defaults to true.'),
 });
 
 export const ZDuplicateEnvelopeResponseSchema = z.object({


### PR DESCRIPTION
## Description

Allow these additional options when duplicating envelopes
- Include recipients
- Include fields

## API changes

Since this is a public route it will cause API/SDK changes, both values are defaulted to true