### PR TITLE
feat: add API endpoints for downloading certificate and audit log PDFs

### DIFF
--- a/apps/remix/app/components/general/document/document-audit-log-download-button.tsx
+++ b/apps/remix/app/components/general/document/document-audit-log-download-button.tsx
@@ -11,10 +11,10 @@ import { DownloadIcon } from 'lucide-react';
 
 export type DocumentAuditLogDownloadButtonProps = {
   className?: string;
-  documentId: number;
+  envelopeId: string;
 };
 
-export const DocumentAuditLogDownloadButton = ({ className, documentId }: DocumentAuditLogDownloadButtonProps) => {
+export const DocumentAuditLogDownloadButton = ({ className, envelopeId }: DocumentAuditLogDownloadButtonProps) => {
   const { toast } = useToast();
   const { _ } = useLingui();
 
@@ -22,7 +22,7 @@ export const DocumentAuditLogDownloadButton = ({ className, documentId }: Docume
 
   const onDownloadAuditLogsClick = async () => {
     try {
-      const { data, envelopeTitle } = await downloadAuditLogs({ documentId });
+      const { data, envelopeTitle } = await downloadAuditLogs({ envelopeId });
 
       const buffer = new Uint8Array(base64.decode(data));
       const blob = new Blob([buffer], { type: 'application/pdf' });

--- a/apps/remix/app/components/general/document/document-certificate-download-button.tsx
+++ b/apps/remix/app/components/general/document/document-certificate-download-button.tsx
@@ -13,13 +13,13 @@ import { DownloadIcon } from 'lucide-react';
 
 export type DocumentCertificateDownloadButtonProps = {
   className?: string;
-  documentId: number;
+  envelopeId: string;
   documentStatus: DocumentStatus;
 };
 
 export const DocumentCertificateDownloadButton = ({
   className,
-  documentId,
+  envelopeId,
   documentStatus,
 }: DocumentCertificateDownloadButtonProps) => {
   const { toast } = useToast();
@@ -29,7 +29,7 @@ export const DocumentCertificateDownloadButton = ({
 
   const onDownloadCertificatesClick = async () => {
     try {
-      const { data, envelopeTitle } = await downloadCertificate({ documentId });
+      const { data, envelopeTitle } = await downloadCertificate({ envelopeId });
 
       const buffer = new Uint8Array(base64.decode(data));
       const blob = new Blob([buffer], { type: 'application/pdf' });

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents.$id.logs.tsx
@@ -153,11 +153,11 @@ export default function DocumentsLogsPage({ loaderData }: Route.ComponentProps) 
           <div className="mt-4 flex w-full flex-row sm:mt-0 sm:w-auto sm:self-end">
             <DocumentCertificateDownloadButton
               className="mr-2"
-              documentId={document.id}
+              envelopeId={document.envelopeId}
               documentStatus={document.status}
             />
 
-            <DocumentAuditLogDownloadButton documentId={document.id} />
+            <DocumentAuditLogDownloadButton envelopeId={document.envelopeId} />
           </div>
         </div>
       </div>

--- a/apps/remix/server/api/download/download.ts
+++ b/apps/remix/server/api/download/download.ts
@@ -1,19 +1,51 @@
+import { PDF_SIZE_A4_72PPI } from '@documenso/lib/constants/pdf';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
-import { getEnvelopeById } from '@documenso/lib/server-only/envelope/get-envelope-by-id';
+import { getEnvelopeById, getEnvelopeWhereInput } from '@documenso/lib/server-only/envelope/get-envelope-by-id';
+import { generateAuditLogPdf } from '@documenso/lib/server-only/pdf/generate-audit-log-pdf';
+import { generateCertificatePdf } from '@documenso/lib/server-only/pdf/generate-certificate-pdf';
 import { getApiTokenByToken } from '@documenso/lib/server-only/public-api/get-api-token-by-token';
+import { isDocumentCompleted } from '@documenso/lib/utils/document';
 import { buildTeamWhereQuery } from '@documenso/lib/utils/teams';
 import { prisma } from '@documenso/prisma';
 import { sValidator } from '@hono/standard-validator';
-import { EnvelopeType } from '@prisma/client';
+import { DocumentStatus, EnvelopeType } from '@prisma/client';
+import contentDisposition from 'content-disposition';
 import { Hono } from 'hono';
 
 import type { HonoEnv } from '../../router';
 import { handleEnvelopeItemFileRequest } from '../files/files.helpers';
 import {
   ZDownloadDocumentRequestParamsSchema,
+  ZDownloadEnvelopeAuditLogPdfRequestParamsSchema,
+  ZDownloadEnvelopeCertificatePdfRequestParamsSchema,
   ZDownloadEnvelopeItemRequestParamsSchema,
   ZDownloadEnvelopeItemRequestQuerySchema,
 } from './download.types';
+
+/**
+ * Resolve and validate an API token from the Authorization header.
+ *
+ * Supports both "Authorization: Bearer api_xxx" and "Authorization: api_xxx".
+ */
+const resolveApiToken = async (authorizationHeader: string | undefined) => {
+  const [token] = (authorizationHeader || '').split('Bearer ').filter((s) => s.length > 0);
+
+  if (!token) {
+    throw new AppError(AppErrorCode.UNAUTHORIZED, {
+      message: 'API token was not provided',
+    });
+  }
+
+  const apiToken = await getApiTokenByToken({ token });
+
+  if (apiToken.user.disabled) {
+    throw new AppError(AppErrorCode.UNAUTHORIZED, {
+      message: 'User is disabled',
+    });
+  }
+
+  return apiToken;
+};
 
 export const downloadRoute = new Hono<HonoEnv>()
   /**
@@ -30,24 +62,8 @@ export const downloadRoute = new Hono<HonoEnv>()
       try {
         const { envelopeItemId } = c.req.valid('param');
         const { version } = c.req.valid('query');
-        const authorizationHeader = c.req.header('authorization');
 
-        // Support for both "Authorization: Bearer api_xxx" and "Authorization: api_xxx"
-        const [token] = (authorizationHeader || '').split('Bearer ').filter((s) => s.length > 0);
-
-        if (!token) {
-          throw new AppError(AppErrorCode.UNAUTHORIZED, {
-            message: 'API token was not provided',
-          });
-        }
-
-        const apiToken = await getApiTokenByToken({ token });
-
-        if (apiToken.user.disabled) {
-          throw new AppError(AppErrorCode.UNAUTHORIZED, {
-            message: 'User is disabled',
-          });
-        }
+        const apiToken = await resolveApiToken(c.req.header('authorization'));
 
         logger.info({
           auth: 'api',
@@ -126,6 +142,180 @@ export const downloadRoute = new Hono<HonoEnv>()
     },
   )
   /**
+   * Download the audit log for a document as a PDF.
+   * Requires API key authentication via Authorization header.
+   */
+  .get(
+    '/envelope/:envelopeId/audit-log/pdf',
+    sValidator('param', ZDownloadEnvelopeAuditLogPdfRequestParamsSchema),
+    async (c) => {
+      const logger = c.get('logger');
+
+      try {
+        const { envelopeId } = c.req.valid('param');
+
+        const apiToken = await resolveApiToken(c.req.header('authorization'));
+
+        logger.info({
+          auth: 'api',
+          source: 'apiV2',
+          path: c.req.path,
+          userId: apiToken.user.id,
+          apiTokenId: apiToken.id,
+          envelopeId,
+        });
+
+        const envelope = await getEnvelopeById({
+          id: {
+            type: 'envelopeId',
+            id: envelopeId,
+          },
+          type: EnvelopeType.DOCUMENT,
+          userId: apiToken.user.id,
+          teamId: apiToken.teamId,
+        }).catch(() => null);
+
+        if (!envelope) {
+          return c.json({ error: 'Document not found' }, 404);
+        }
+
+        const auditLogPdf = await generateAuditLogPdf({
+          envelope,
+          recipients: envelope.recipients,
+          fields: envelope.fields,
+          language: envelope.documentMeta.language,
+          envelopeOwner: {
+            email: envelope.user.email,
+            name: envelope.user.name || '',
+          },
+          envelopeItems: envelope.envelopeItems.map((item) => item.title),
+          pageWidth: PDF_SIZE_A4_72PPI.width,
+          pageHeight: PDF_SIZE_A4_72PPI.height,
+        });
+
+        const result = await auditLogPdf.save();
+
+        const baseTitle = envelope.title.replace(/\.pdf$/i, '');
+
+        c.header('Content-Type', 'application/pdf');
+        c.header('Content-Disposition', contentDisposition(`${baseTitle}_audit-log.pdf`));
+        c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+
+        return c.body(result);
+      } catch (error) {
+        logger.error(error);
+
+        if (error instanceof AppError) {
+          const { status, body } = AppError.toRestAPIError(error);
+
+          return c.json({ error: body.message, code: error.code }, status);
+        }
+
+        return c.json({ error: 'Internal server error' }, 500);
+      }
+    },
+  )
+  /**
+   * Download the signing certificate for a completed document as a PDF.
+   * Requires API key authentication via Authorization header.
+   */
+  .get(
+    '/envelope/:envelopeId/certificate/pdf',
+    sValidator('param', ZDownloadEnvelopeCertificatePdfRequestParamsSchema),
+    async (c) => {
+      const logger = c.get('logger');
+
+      try {
+        const { envelopeId } = c.req.valid('param');
+
+        const apiToken = await resolveApiToken(c.req.header('authorization'));
+
+        logger.info({
+          auth: 'api',
+          source: 'apiV2',
+          path: c.req.path,
+          userId: apiToken.user.id,
+          apiTokenId: apiToken.id,
+          envelopeId,
+        });
+
+        const { envelopeWhereInput } = await getEnvelopeWhereInput({
+          id: {
+            type: 'envelopeId',
+            id: envelopeId,
+          },
+          type: EnvelopeType.DOCUMENT,
+          userId: apiToken.user.id,
+          teamId: apiToken.teamId,
+        });
+
+        const envelope = await prisma.envelope.findFirst({
+          where: envelopeWhereInput,
+          include: {
+            recipients: true,
+            fields: {
+              include: {
+                signature: true,
+              },
+            },
+            documentMeta: true,
+            user: {
+              select: {
+                email: true,
+                name: true,
+              },
+            },
+          },
+        });
+
+        if (!envelope) {
+          return c.json({ error: 'Document not found' }, 404);
+        }
+
+        // A cancelled document was never sealed/completed, so a signing certificate
+        // must not be generated for it.
+        if (!isDocumentCompleted(envelope.status) || envelope.status === DocumentStatus.CANCELLED) {
+          throw new AppError('DOCUMENT_NOT_COMPLETE', {
+            message: 'Document is not complete',
+          });
+        }
+
+        const certificatePdf = await generateCertificatePdf({
+          envelope,
+          recipients: envelope.recipients,
+          fields: envelope.fields,
+          language: envelope.documentMeta.language,
+          envelopeOwner: {
+            email: envelope.user.email,
+            name: envelope.user.name || '',
+          },
+          pageWidth: PDF_SIZE_A4_72PPI.width,
+          pageHeight: PDF_SIZE_A4_72PPI.height,
+        });
+
+        const result = await certificatePdf.save();
+
+        const baseTitle = envelope.title.replace(/\.pdf$/i, '');
+
+        c.header('Content-Type', 'application/pdf');
+        c.header('Content-Disposition', contentDisposition(`${baseTitle}_certificate.pdf`));
+        c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+
+        return c.body(result);
+      } catch (error) {
+        logger.error(error);
+
+        if (error instanceof AppError) {
+          const { status, body } = AppError.toRestAPIError(error);
+
+          return c.json({ error: body.message, code: error.code }, status);
+        }
+
+        return c.json({ error: 'Internal server error' }, 500);
+      }
+    },
+  )
+  /**
    * Download a document by its ID.
    * Requires API key authentication via Authorization header.
    */
@@ -134,24 +324,8 @@ export const downloadRoute = new Hono<HonoEnv>()
 
     try {
       const { documentId, version } = c.req.valid('param');
-      const authorizationHeader = c.req.header('authorization');
 
-      // Support for both "Authorization: Bearer api_xxx" and "Authorization: api_xxx"
-      const [token] = (authorizationHeader || '').split('Bearer ').filter((s) => s.length > 0);
-
-      if (!token) {
-        throw new AppError(AppErrorCode.UNAUTHORIZED, {
-          message: 'API token was not provided',
-        });
-      }
-
-      const apiToken = await getApiTokenByToken({ token });
-
-      if (apiToken.user.disabled) {
-        throw new AppError(AppErrorCode.UNAUTHORIZED, {
-          message: 'User is disabled',
-        });
-      }
+      const apiToken = await resolveApiToken(c.req.header('authorization'));
 
       logger.info({
         auth: 'api',
@@ -200,11 +374,9 @@ export const downloadRoute = new Hono<HonoEnv>()
       logger.error(error);
 
       if (error instanceof AppError) {
-        if (error.code === AppErrorCode.UNAUTHORIZED) {
-          return c.json({ error: error.message }, 401);
-        }
+        const { status, body } = AppError.toRestAPIError(error);
 
-        return c.json({ error: error.message }, 400);
+        return c.json({ error: body.message, code: error.code }, status);
       }
 
       return c.json({ error: 'Internal server error' }, 500);

--- a/apps/remix/server/api/download/download.types.ts
+++ b/apps/remix/server/api/download/download.types.ts
@@ -30,3 +30,17 @@ export const ZDownloadDocumentRequestParamsSchema = z.object({
 });
 
 export type TDownloadDocumentRequestParams = z.infer<typeof ZDownloadDocumentRequestParamsSchema>;
+
+export const ZDownloadEnvelopeAuditLogPdfRequestParamsSchema = z.object({
+  envelopeId: z.string().describe('The ID of the envelope to download the audit log for.'),
+});
+
+export type TDownloadEnvelopeAuditLogPdfRequestParams = z.infer<typeof ZDownloadEnvelopeAuditLogPdfRequestParamsSchema>;
+
+export const ZDownloadEnvelopeCertificatePdfRequestParamsSchema = z.object({
+  envelopeId: z.string().describe('The ID of the envelope to download the certificate for.'),
+});
+
+export type TDownloadEnvelopeCertificatePdfRequestParams = z.infer<
+  typeof ZDownloadEnvelopeCertificatePdfRequestParamsSchema
+>;

--- a/packages/trpc/server/document-router/download-document-audit-logs.ts
+++ b/packages/trpc/server/document-router/download-document-audit-logs.ts
@@ -15,18 +15,18 @@ export const downloadDocumentAuditLogsRoute = authenticatedProcedure
   .output(ZDownloadDocumentAuditLogsResponseSchema)
   .mutation(async ({ input, ctx }) => {
     const { teamId } = ctx;
-    const { documentId } = input;
+    const { envelopeId } = input;
 
     ctx.logger.info({
       input: {
-        documentId,
+        envelopeId,
       },
     });
 
     const envelope = await getEnvelopeById({
       id: {
-        type: 'documentId',
-        id: documentId,
+        type: 'envelopeId',
+        id: envelopeId,
       },
       type: EnvelopeType.DOCUMENT,
       userId: ctx.user.id,
@@ -55,10 +55,8 @@ export const downloadDocumentAuditLogsRoute = authenticatedProcedure
 
     const result = await certificatePdf.save();
 
-    const base64 = Buffer.from(result).toString('base64');
-
     return {
-      data: base64,
+      data: Buffer.from(result).toString('base64'),
       envelopeTitle: envelope.title,
     };
   });

--- a/packages/trpc/server/document-router/download-document-audit-logs.types.ts
+++ b/packages/trpc/server/document-router/download-document-audit-logs.types.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const ZDownloadDocumentAuditLogsRequestSchema = z.object({
-  documentId: z.number(),
+  envelopeId: z.string(),
 });
 
 export const ZDownloadDocumentAuditLogsResponseSchema = z.object({

--- a/packages/trpc/server/document-router/download-document-certificate.ts
+++ b/packages/trpc/server/document-router/download-document-certificate.ts
@@ -17,18 +17,18 @@ export const downloadDocumentCertificateRoute = authenticatedProcedure
   .output(ZDownloadDocumentCertificateResponseSchema)
   .mutation(async ({ input, ctx }) => {
     const { teamId } = ctx;
-    const { documentId } = input;
+    const { envelopeId } = input;
 
     ctx.logger.info({
       input: {
-        documentId,
+        envelopeId,
       },
     });
 
     const { envelopeWhereInput } = await getEnvelopeWhereInput({
       id: {
-        type: 'documentId',
-        id: documentId,
+        type: 'envelopeId',
+        id: envelopeId,
       },
       type: EnvelopeType.DOCUMENT,
       userId: ctx.user.id,
@@ -81,10 +81,8 @@ export const downloadDocumentCertificateRoute = authenticatedProcedure
 
     const result = await certificatePdf.save();
 
-    const base64 = Buffer.from(result).toString('base64');
-
     return {
-      data: base64,
+      data: Buffer.from(result).toString('base64'),
       envelopeTitle: envelope.title,
     };
   });

--- a/packages/trpc/server/document-router/download-document-certificate.types.ts
+++ b/packages/trpc/server/document-router/download-document-certificate.types.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const ZDownloadDocumentCertificateRequestSchema = z.object({
-  documentId: z.number(),
+  envelopeId: z.string(),
 });
 
 export const ZDownloadDocumentCertificateResponseSchema = z.object({

--- a/packages/trpc/server/envelope-router/download-envelope-audit-log-pdf.ts
+++ b/packages/trpc/server/envelope-router/download-envelope-audit-log-pdf.ts
@@ -1,0 +1,23 @@
+import { authenticatedProcedure } from '../trpc';
+import {
+  downloadEnvelopeAuditLogPdfMeta,
+  ZDownloadEnvelopeAuditLogPdfRequestSchema,
+  ZDownloadEnvelopeAuditLogPdfResponseSchema,
+} from './download-envelope-audit-log-pdf.types';
+
+export const downloadEnvelopeAuditLogPdfRoute = authenticatedProcedure
+  .meta(downloadEnvelopeAuditLogPdfMeta)
+  .input(ZDownloadEnvelopeAuditLogPdfRequestSchema)
+  .output(ZDownloadEnvelopeAuditLogPdfResponseSchema)
+  .query(({ input, ctx }) => {
+    const { envelopeId } = input;
+
+    ctx.logger.info({
+      input: {
+        envelopeId,
+      },
+    });
+
+    // This endpoint is purely for V2 API, which is implemented in the Hono remix server.
+    throw new Error('NOT_IMPLEMENTED');
+  });

--- a/packages/trpc/server/envelope-router/download-envelope-audit-log-pdf.types.ts
+++ b/packages/trpc/server/envelope-router/download-envelope-audit-log-pdf.types.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import type { TrpcRouteMeta } from '../trpc';
+
+export const downloadEnvelopeAuditLogPdfMeta: TrpcRouteMeta = {
+  openapi: {
+    method: 'GET',
+    path: '/envelope/{envelopeId}/audit-log/pdf',
+    summary: 'Download envelope audit log PDF',
+    description: 'Download the audit log for a document as a PDF.',
+    tags: ['Envelope'],
+    responseHeaders: z.object({
+      'Content-Type': z.literal('application/pdf'),
+    }),
+  },
+};
+
+export const ZDownloadEnvelopeAuditLogPdfRequestSchema = z.object({
+  envelopeId: z.string().describe('The ID of the envelope to download the audit log for.'),
+});
+
+export const ZDownloadEnvelopeAuditLogPdfResponseSchema = z.instanceof(Uint8Array);
+
+export type TDownloadEnvelopeAuditLogPdfRequest = z.infer<typeof ZDownloadEnvelopeAuditLogPdfRequestSchema>;
+export type TDownloadEnvelopeAuditLogPdfResponse = z.infer<typeof ZDownloadEnvelopeAuditLogPdfResponseSchema>;

--- a/packages/trpc/server/envelope-router/download-envelope-certificate-pdf.ts
+++ b/packages/trpc/server/envelope-router/download-envelope-certificate-pdf.ts
@@ -1,0 +1,23 @@
+import { authenticatedProcedure } from '../trpc';
+import {
+  downloadEnvelopeCertificatePdfMeta,
+  ZDownloadEnvelopeCertificatePdfRequestSchema,
+  ZDownloadEnvelopeCertificatePdfResponseSchema,
+} from './download-envelope-certificate-pdf.types';
+
+export const downloadEnvelopeCertificatePdfRoute = authenticatedProcedure
+  .meta(downloadEnvelopeCertificatePdfMeta)
+  .input(ZDownloadEnvelopeCertificatePdfRequestSchema)
+  .output(ZDownloadEnvelopeCertificatePdfResponseSchema)
+  .query(({ input, ctx }) => {
+    const { envelopeId } = input;
+
+    ctx.logger.info({
+      input: {
+        envelopeId,
+      },
+    });
+
+    // This endpoint is purely for V2 API, which is implemented in the Hono remix server.
+    throw new Error('NOT_IMPLEMENTED');
+  });

--- a/packages/trpc/server/envelope-router/download-envelope-certificate-pdf.types.ts
+++ b/packages/trpc/server/envelope-router/download-envelope-certificate-pdf.types.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import type { TrpcRouteMeta } from '../trpc';
+
+export const downloadEnvelopeCertificatePdfMeta: TrpcRouteMeta = {
+  openapi: {
+    method: 'GET',
+    path: '/envelope/{envelopeId}/certificate/pdf',
+    summary: 'Download envelope certificate PDF',
+    description: 'Download the signing certificate for a completed document as a PDF.',
+    tags: ['Envelope'],
+    responseHeaders: z.object({
+      'Content-Type': z.literal('application/pdf'),
+    }),
+  },
+};
+
+export const ZDownloadEnvelopeCertificatePdfRequestSchema = z.object({
+  envelopeId: z.string().describe('The ID of the envelope to download the certificate for.'),
+});
+
+export const ZDownloadEnvelopeCertificatePdfResponseSchema = z.instanceof(Uint8Array);
+
+export type TDownloadEnvelopeCertificatePdfRequest = z.infer<typeof ZDownloadEnvelopeCertificatePdfRequestSchema>;
+export type TDownloadEnvelopeCertificatePdfResponse = z.infer<typeof ZDownloadEnvelopeCertificatePdfResponseSchema>;

--- a/packages/trpc/server/envelope-router/router.ts
+++ b/packages/trpc/server/envelope-router/router.ts
@@ -12,6 +12,8 @@ import { createEnvelopeItemsRoute } from './create-envelope-items';
 import { deleteEnvelopeRoute } from './delete-envelope';
 import { deleteEnvelopeItemRoute } from './delete-envelope-item';
 import { distributeEnvelopeRoute } from './distribute-envelope';
+import { downloadEnvelopeAuditLogPdfRoute } from './download-envelope-audit-log-pdf';
+import { downloadEnvelopeCertificatePdfRoute } from './download-envelope-certificate-pdf';
 import { downloadEnvelopeItemRoute } from './download-envelope-item';
 import { duplicateEnvelopeRoute } from './duplicate-envelope';
 import { createEnvelopeFieldsRoute } from './envelope-fields/create-envelope-fields';
@@ -85,6 +87,10 @@ export const envelopeRouter = router({
   find: findEnvelopesRoute,
   auditLog: {
     find: findEnvelopeAuditLogsRoute,
+    downloadPdf: downloadEnvelopeAuditLogPdfRoute,
+  },
+  certificate: {
+    downloadPdf: downloadEnvelopeCertificatePdfRoute,
   },
   bulk: {
     move: bulkMoveEnvelopesRoute,


### PR DESCRIPTION
Add V2 API routes to download an envelope's certificate and audit log
separately, and align the internal cert/audit log downloads to use
envelopeId.

Enforces document visibility via getEnvelopeWhereInput and loads field
signatures so certificates render correctly.
