### PR TITLE
Respect hidden sender details in document invite emails

### DIFF
--- a/packages/email/templates/document-invite.tsx
+++ b/packages/email/templates/document-invite.tsx
@@ -96,6 +96,14 @@ export const DocumentInviteEmailTemplate = ({
               <Text className="mt-2 text-base text-muted-foreground">
                 {customBody ? (
                   <TemplateCustomMessageBody text={customBody} />
+                ) : organisationType === OrganisationType.ORGANISATION && !includeSenderDetails ? (
+                  <Trans>
+                    {teamName} has invited you to {action} the document "{documentName}".
+                  </Trans>
+                ) : organisationType === OrganisationType.ORGANISATION ? (
+                  <Trans>
+                    {inviterName} on behalf of "{teamName}" has invited you to {action} the document "{documentName}".
+                  </Trans>
                 ) : (
                   <Trans>
                     {inviterName} has invited you to {action} the document "{documentName}".

--- a/packages/lib/server-only/document/resend-document.ts
+++ b/packages/lib/server-only/document/resend-document.ts
@@ -169,6 +169,7 @@ export const resendDocument = async ({ id, userId, recipients, teamId, requestMe
   const {
     branding,
     emailLanguage,
+    settings,
     organisationType,
     senderEmail,
     replyToEmail,
@@ -225,11 +226,17 @@ export const resendDocument = async ({ id, userId, recipients, teamId, requestMe
 
       if (organisationType === OrganisationType.ORGANISATION) {
         emailSubject = i18n._(msg`Reminder: ${envelope.team.name} invited you to ${recipientActionVerb} a document`);
-        emailMessage =
-          envelope.documentMeta.message ||
-          i18n._(
-            msg`${user.name || user.email} on behalf of "${envelope.team.name}" has invited you to ${recipientActionVerb} the document "${envelope.title}".`,
+        emailMessage = envelope.documentMeta.message || '';
+
+        if (!emailMessage) {
+          const inviterName = user.name || user.email;
+
+          emailMessage = i18n._(
+            settings.includeSenderDetails
+              ? msg`${inviterName} on behalf of "${envelope.team.name}" has invited you to ${recipientActionVerb} the document "${envelope.title}".`
+              : msg`${envelope.team.name} has invited you to ${recipientActionVerb} the document "${envelope.title}".`,
           );
+        }
       }
 
       const customEmailTemplate = {
@@ -256,6 +263,7 @@ export const resendDocument = async ({ id, userId, recipients, teamId, requestMe
         selfSigner,
         organisationType,
         teamName: envelope.team?.name,
+        includeSenderDetails: settings.includeSenderDetails,
         reportUrl,
       });
 


### PR DESCRIPTION
## Summary

This fixes the document invite email copy when sender details are hidden for an organisation or team.

The email template already handled the heading and preview text, but the message body could still fall back to wording that showed the sender name. Reminder emails had the same issue because the resend path did not use the resolved `includeSenderDetails` setting.

## Changes

- Use team-only wording in the document invite message body when sender details are hidden.
- Use the resolved email settings when building reminder email copy.
- Pass `includeSenderDetails` into the resend email template.

Closes #3055.

## Testing

- `npx biome check packages/email/templates/document-invite.tsx packages/lib/server-only/document/resend-document.ts`
- `npx tsc -p packages/email/tsconfig.json --noEmit`

`npx tsc -p packages/lib/tsconfig.json --noEmit` still reports existing unrelated Prisma/schema type errors outside this change.