### PR TITLE
fix: replace tailwind class typos

### DIFF
--- a/apps/remix/app/components/dialogs/folder-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/folder-delete-dialog.tsx
@@ -122,7 +122,7 @@ export const FolderDeleteDialog = ({ folder, isOpen, onOpenChange }: FolderDelet
                     <FormLabel>
                       <Trans>
                         Confirm by typing:{' '}
-                        <span className="font-semibold font-sm text-destructive">{deleteMessage}</span>
+                        <span className="font-semibold text-destructive text-sm">{deleteMessage}</span>
                       </Trans>
                     </FormLabel>
                     <FormControl>

--- a/apps/remix/app/components/dialogs/organisation-create-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-create-dialog.tsx
@@ -336,7 +336,7 @@ const BillingPlanForm = ({ value, onChange, plans, canCreateFreeOrganisation }: 
         >
           <div className="w-full text-left">
             <div className="flex items-center justify-between">
-              <p className="text-medium">
+              <p className="font-medium">
                 <Trans context="Plan price">Free</Trans>
               </p>
 

--- a/apps/remix/app/components/dialogs/organisation-email-domain-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-email-domain-delete-dialog.tsx
@@ -115,7 +115,7 @@ export const OrganisationEmailDomainDeleteDialog = ({
                     <FormLabel>
                       <Trans>
                         Confirm by typing{' '}
-                        <span className="font-semibold font-sm text-destructive">{deleteMessage}</span>
+                        <span className="font-semibold text-destructive text-sm">{deleteMessage}</span>
                       </Trans>
                     </FormLabel>
                     <FormControl>

--- a/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
+++ b/apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
@@ -370,7 +370,7 @@ export const OrganisationMemberInviteDialog = ({ trigger, ...props }: Organisati
                           <button
                             type="button"
                             className={cn(
-                              'justify-left inline-flex h-10 w-10 items-center text-slate-500 hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50',
+                              'inline-flex h-10 w-10 items-center justify-start text-slate-500 hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50',
                               index === 0 ? 'mt-8' : 'mt-0',
                             )}
                             disabled={organisationMemberInvites.length === 1}

--- a/apps/remix/app/components/dialogs/token-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/token-delete-dialog.tsx
@@ -126,7 +126,7 @@ export default function TokenDeleteDialog({ token, onDelete, children }: TokenDe
                     <FormLabel>
                       <Trans>
                         Confirm by typing:{' '}
-                        <span className="font-semibold font-sm text-destructive">{deleteMessage}</span>
+                        <span className="font-semibold text-destructive text-sm">{deleteMessage}</span>
                       </Trans>
                     </FormLabel>
 

--- a/apps/remix/app/components/dialogs/webhook-delete-dialog.tsx
+++ b/apps/remix/app/components/dialogs/webhook-delete-dialog.tsx
@@ -117,7 +117,7 @@ export const WebhookDeleteDialog = ({ webhook, children }: WebhookDeleteDialogPr
                     <FormLabel>
                       <Trans>
                         Confirm by typing:{' '}
-                        <span className="font-semibold font-sm text-destructive">{deleteMessage}</span>
+                        <span className="font-semibold text-destructive text-sm">{deleteMessage}</span>
                       </Trans>
                     </FormLabel>
                     <FormControl>

--- a/apps/remix/app/components/embed/authoring/configure-fields-view.tsx
+++ b/apps/remix/app/components/embed/authoring/configure-fields-view.tsx
@@ -503,7 +503,7 @@ export const ConfigureFieldsView = ({
             {selectedField && (
               <div
                 className={cn(
-                  'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center bg-white text-muted-foreground transition duration-200 [container-type:size] dark:text-muted-background',
+                  'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center bg-white text-muted-foreground transition duration-200 [container-type:size] dark:text-muted',
                   selectedRecipientStyles.base,
                   {
                     '-rotate-6 scale-90 opacity-50 dark:bg-black/20': !isFieldWithinBounds,

--- a/apps/remix/app/components/general/admin-license-card.tsx
+++ b/apps/remix/app/components/general/admin-license-card.tsx
@@ -87,7 +87,7 @@ export const AdminLicenseCard = ({ licenseData }: AdminLicenseCardProps) => {
           <KeyRoundIcon className="h-4 w-4 text-muted-foreground" />
         </div>
 
-        <h3 className="mb-2 flex items-end font-medium text-primary-forground text-sm leading-tight">
+        <h3 className="mb-2 flex items-end font-medium text-foreground text-sm leading-tight">
           <Trans>Documenso License</Trans>
         </h3>
 

--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-drag-drop.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-drag-drop.tsx
@@ -270,7 +270,7 @@ export const EnvelopeEditorFieldDragDrop = ({
       {selectedField && (
         <div
           className={cn(
-            'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center rounded-[2px] bg-white font-noto text-muted-foreground ring-2 transition duration-200 [container-type:size] dark:text-muted-background',
+            'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center rounded-[2px] bg-white font-noto text-muted-foreground ring-2 transition duration-200 [container-type:size] dark:text-muted',
             selectedRecipientStyles.base,
             selectedField === FieldType.SIGNATURE && 'font-signature',
             {

--- a/apps/remix/app/components/general/envelope/envelope-drop-zone-wrapper.tsx
+++ b/apps/remix/app/components/general/envelope/envelope-drop-zone-wrapper.tsx
@@ -174,7 +174,7 @@ export const EnvelopeDropZoneWrapper = ({ children, type, className }: EnvelopeD
               {type === EnvelopeType.DOCUMENT ? <Trans>Upload Document</Trans> : <Trans>Upload Template</Trans>}
             </h2>
 
-            <p className="mt-4 text-md text-muted-foreground">
+            <p className="mt-4 text-base text-muted-foreground">
               <Trans>Drag and drop your document here</Trans>
             </p>
 

--- a/apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
+++ b/apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
@@ -82,7 +82,7 @@ export default function WaitingForTurnToSignPage({ loaderData }: Route.Component
       <RecipientBranding branding={branding} cspNonce={cspNonce} />
       <div className="relative flex flex-col items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
         <div className="w-full max-w-md text-center">
-          <h2 className="font-bold text-3xl tracking-tigh">
+          <h2 className="font-bold text-3xl tracking-tight">
             <Trans>Waiting for Your Turn</Trans>
           </h2>
 

--- a/packages/email/template-components/template-document-invite.tsx
+++ b/packages/email/template-components/template-document-invite.tsx
@@ -87,7 +87,7 @@ export const TemplateDocumentInvite = ({
 
         <Section className="mt-8 mb-6 text-center">
           <Button
-            className="inline-flex items-center justify-center rounded-lg bg-primary px-6 py-3 text-center font-medium text-primary-foreground text-sbase no-underline"
+            className="inline-flex items-center justify-center rounded-lg bg-primary px-6 py-3 text-center font-medium text-base text-primary-foreground no-underline"
             href={signDocumentLink}
           >
             {match(role)

--- a/packages/ui/primitives/command.tsx
+++ b/packages/ui/primitives/command.tsx
@@ -62,7 +62,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-foreground-muted disabled:cursor-not-allowed disabled:opacity-50',
+        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -577,7 +577,7 @@ export const AddFieldsFormPartial = ({
               {selectedField && (
                 <div
                   className={cn(
-                    'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center rounded-[2px] bg-white text-muted-foreground ring-2 transition duration-200 [container-type:size] dark:text-muted-background',
+                    'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center rounded-[2px] bg-white text-muted-foreground ring-2 transition duration-200 [container-type:size] dark:text-muted',
                     selectedSignerStyles?.base,
                     {
                       '-rotate-6 scale-90 opacity-50 dark:bg-black/20': !isFieldWithinBounds,

--- a/packages/ui/primitives/document-flow/field-items-advanced-settings/dropdown-field.tsx
+++ b/packages/ui/primitives/document-flow/field-items-advanced-settings/dropdown-field.tsx
@@ -89,7 +89,7 @@ export const DropdownFieldAdvancedSettings = ({
   }, [fieldState.defaultValue]);
 
   return (
-    <div className="flex flex-col gap-4 text-dark">
+    <div className="flex flex-col gap-4">
       <div>
         <Label>
           <Trans>Select default option</Trans>

--- a/packages/ui/primitives/template-flow/add-template-fields.tsx
+++ b/packages/ui/primitives/template-flow/add-template-fields.tsx
@@ -520,7 +520,7 @@ export const AddTemplateFieldsFormPartial = ({
               {selectedField && (
                 <div
                   className={cn(
-                    'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center rounded-[2px] bg-white text-muted-foreground ring-2 transition duration-200 [container-type:size] dark:text-muted-background',
+                    'pointer-events-none fixed z-50 flex cursor-pointer flex-col items-center justify-center rounded-[2px] bg-white text-muted-foreground ring-2 transition duration-200 [container-type:size] dark:text-muted',
                     selectedSignerStyles?.base,
                     {
                       '-rotate-6 scale-90 opacity-50 dark:bg-black/20': !isFieldWithinBounds,
@@ -603,9 +603,7 @@ export const AddTemplateFieldsFormPartial = ({
                       <span className="flex-1 truncate text-left">{selectedSigner?.name}</span>
                     )}
 
-                    {!selectedSigner?.email && (
-                      <span className="gradie flex-1 truncate text-left">No recipient selected</span>
-                    )}
+                    {!selectedSigner?.email && <span className="flex-1 truncate text-left">No recipient selected</span>}
 
                     <ChevronsUpDown className="ml-2 h-4 w-4" />
                   </Button>


### PR DESCRIPTION
## Description

While looking into a `text-sbase` typo in the document invite email, I audited every `className` token in the repo by compiling them through `packages/tailwind-config` and diffing the generated selectors against usage. This surfaced 10 distinct dead tokens (16 occurrences) that silently generate no CSS.

| Dead token | Replaced with | Location |
|---|---|---|
| `text-sbase` | `text-base` | `template-document-invite.tsx` — introduced in #2030 as a botched `sm`→`base` edit; CTA text size now applies |
| `text-primary-forground` | `text-foreground` | `admin-license-card.tsx` — see note below |
| `tracking-tigh` | `tracking-tight` | `sign.$token/waiting.tsx` heading |
| `font-sm` (×4) | `text-sm` | folder/token/webhook/email-domain delete dialogs |
| `dark:text-muted-background` (×4) | `dark:text-muted` | field drag ghost in document/template/envelope-editor/embed-authoring flows |
| `placeholder:text-foreground-muted` | `placeholder:text-muted-foreground` | `ui/primitives/command.tsx` |
| `text-medium` | `font-medium` | org create dialog "Free" plan (matches paid plan cards) |
| `text-md` | `text-base` | envelope drop zone hint text |
| `justify-left` | `justify-start` | member invite remove button (no-op, flex default) |
| `gradie`, `text-dark` | removed | stray fragment in `add-template-fields.tsx`; no `dark` colour exists in the palette |

**Two judgment calls:**
- `text-primary-forground`: the literal spelling fix (`text-primary-foreground`) would put 10%-lightness text on the dark-mode card (14.9%) — near invisible. Since the dead class always rendered with inherited `foreground`, I kept that intent explicit instead.
- `dark:text-muted-background`: #1242 intended dark readable text on the white drag ghost in dark mode. `--muted` in dark mode is 23.4% lightness, matching that intent; `muted-foreground` (85%, light) would re-break it.

## Testing

- Recompiled all replacement tokens through the shared Tailwind config — every one now generates CSS.
- Repo-wide grep confirms no occurrences of the dead tokens remain.

Not touched (dead but look like intent/version drift, separate pass if wanted): `max-w-screen`/`min-w-screen`, `h-42`, `z-100`, `bg-destructive/2`, `origin-top-center`, `supports-backdrop-blur:`, and v4-style `has-*:` variants in `multiselect.tsx`.