### PR TITLE
fix(ui): improve destructive button contrast in dark mode

### DIFF
--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -83,7 +83,7 @@
   --accent: hsl(0 0% 27.8431%);
   --accent-foreground: hsl(95.0847 71.0843% 67.451%);
   --destructive: hsl(0 86.5979% 61.9608%);
-  --destructive-foreground: hsl(0 87.6289% 19.0196%);
+  --destructive-foreground: hsl(0 0% 98.0392%);
   --border: hsl(0 0% 27.8431%);
   --input: hsl(0 0% 27.8431%);
   --ring: hsl(95.0847 71.0843% 67.451%);

--- a/packages/ui/styles/theme.css
+++ b/packages/ui/styles/theme.css
@@ -174,7 +174,7 @@
     --accent-foreground: 95.08 71.08% 67.45%;
 
     --destructive: 0 87% 62%;
-    --destructive-foreground: 0 87% 19%;
+    --destructive-foreground: 0 0% 98%;
 
     --ring: 95.08 71.08% 67.45%;
 


### PR DESCRIPTION
## Description

In dark mode, destructive buttons rendered very dark red text (`hsl(0 87% 19%)`) on a bright red background (`hsl(0 87% 62%)`), making labels like "Delete" and "Delete Account" hard to read.

This changes the dark mode `--destructive-foreground` token to near-white (`0 0% 98%`), matching what light mode already does (`210 40% 98%` on red). Since every destructive button, toast, and alert uses the `bg-destructive text-destructive-foreground` token pair, this single token change fixes all instances across the app. The same duplicated pair in the docs app is updated too.

`--destructive` itself is intentionally left unchanged, as it also backs `text-destructive` error text on dark backgrounds.

## Before

![before](https://gist.githubusercontent.com/ephraimduncan/10c192ff344bfed8e63b1be9e63086d3/raw/destructive-before.png)

## After

![after](https://gist.githubusercontent.com/ephraimduncan/10c192ff344bfed8e63b1be9e63086d3/raw/destructive-after.png)

## Changes

- `packages/ui/styles/theme.css`: dark mode `--destructive-foreground: 0 87% 19%` → `0 0% 98%`
- `apps/docs/src/app/global.css`: dark mode `--destructive-foreground: hsl(0 87.6289% 19.0196%)` → `hsl(0 0% 98.0392%)`
