### PR TITLE
fix: keep previous table data during pagination to avoid skeleton flash

### DIFF
--- a/apps/remix/app/components/tables/admin-claims-table.tsx
+++ b/apps/remix/app/components/tables/admin-claims-table.tsx
@@ -38,11 +38,16 @@ export const AdminClaimsTable = ({ licenseFlags }: AdminClaimsTableProps) => {
 
   const parsedSearchParams = ZUrlSearchParamsSchema.parse(Object.fromEntries(searchParams ?? []));
 
-  const { data, isLoading, isLoadingError } = trpc.admin.claims.find.useQuery({
-    query: parsedSearchParams.query,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-  });
+  const { data, isLoading, isLoadingError } = trpc.admin.claims.find.useQuery(
+    {
+      query: parsedSearchParams.query,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/components/tables/admin-document-jobs-table.tsx
+++ b/apps/remix/app/components/tables/admin-document-jobs-table.tsx
@@ -19,11 +19,16 @@ export const AdminDocumentJobsTable = ({ envelopeId }: { envelopeId: string }) =
 
   const parsedSearchParams = ZUrlSearchParamsSchema.parse(Object.fromEntries(searchParams ?? []));
 
-  const { data, isLoading, isLoadingError, refetch, isFetching } = trpc.admin.document.findJobs.useQuery({
-    envelopeId: envelopeId,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-  });
+  const { data, isLoading, isLoadingError, refetch, isFetching } = trpc.admin.document.findJobs.useQuery(
+    {
+      envelopeId: envelopeId,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/components/tables/admin-email-transports-table.tsx
+++ b/apps/remix/app/components/tables/admin-email-transports-table.tsx
@@ -30,11 +30,16 @@ export const AdminEmailTransportsTable = () => {
 
   const parsedSearchParams = ZUrlSearchParamsSchema.parse(Object.fromEntries(searchParams ?? []));
 
-  const { data, isLoading, isLoadingError } = trpc.admin.emailTransport.find.useQuery({
-    query: parsedSearchParams.query,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-  });
+  const { data, isLoading, isLoadingError } = trpc.admin.emailTransport.find.useQuery(
+    {
+      query: parsedSearchParams.query,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/components/tables/admin-organisation-stats-table.tsx
+++ b/apps/remix/app/components/tables/admin-organisation-stats-table.tsx
@@ -77,15 +77,20 @@ export const AdminOrganisationStatsTable = ({ displayMode = 'usage' }: AdminOrga
   const orderByColumn = parseOrderByColumn(searchParams?.get('orderByColumn') ?? undefined);
   const orderByDirection = parseOrderByDirection(searchParams?.get('orderByDirection') ?? undefined);
 
-  const { data, isLoading, isLoadingError } = trpc.admin.organisation.stats.find.useQuery({
-    query: parsedSearchParams.query,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-    period,
-    claimId,
-    orderByColumn,
-    orderByDirection,
-  });
+  const { data, isLoading, isLoadingError } = trpc.admin.organisation.stats.find.useQuery(
+    {
+      query: parsedSearchParams.query,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+      period,
+      claimId,
+      orderByColumn,
+      orderByDirection,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/components/tables/admin-organisations-table.tsx
+++ b/apps/remix/app/components/tables/admin-organisations-table.tsx
@@ -55,13 +55,18 @@ export const AdminOrganisationsTable = ({
 
   const parsedSearchParams = ZUrlSearchParamsSchema.parse(Object.fromEntries(searchParams ?? []));
 
-  const { data, isLoading, isLoadingError } = trpc.admin.organisation.find.useQuery({
-    query: parsedSearchParams.query,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-    ownerUserId,
-    memberUserId,
-  });
+  const { data, isLoading, isLoadingError } = trpc.admin.organisation.find.useQuery(
+    {
+      query: parsedSearchParams.query,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+      ownerUserId,
+      memberUserId,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/components/tables/admin-user-teams-table.tsx
+++ b/apps/remix/app/components/tables/admin-user-teams-table.tsx
@@ -28,12 +28,17 @@ export const AdminUserTeamsTable = ({ userId }: AdminUserTeamsTableProps) => {
 
   const parsedSearchParams = ZUrlSearchParamsSchema.parse(Object.fromEntries(searchParams ?? []));
 
-  const { data, isLoading, isLoadingError } = trpc.admin.user.findTeams.useQuery({
-    userId,
-    query: parsedSearchParams.query,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-  });
+  const { data, isLoading, isLoadingError } = trpc.admin.user.findTeams.useQuery(
+    {
+      userId,
+      query: parsedSearchParams.query,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/components/tables/inbox-table.tsx
+++ b/apps/remix/app/components/tables/inbox-table.tsx
@@ -46,10 +46,15 @@ export const InboxTable = () => {
   const page = searchParams?.get?.('page') ? Number(searchParams.get('page')) : undefined;
   const perPage = searchParams?.get?.('perPage') ? Number(searchParams.get('perPage')) : undefined;
 
-  const { data, isLoading, isLoadingError } = trpc.document.inbox.find.useQuery({
-    page: page || 1,
-    perPage: perPage || 10,
-  });
+  const { data, isLoading, isLoadingError } = trpc.document.inbox.find.useQuery(
+    {
+      page: page || 1,
+      perPage: perPage || 10,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const columns = useMemo(() => {
     return [

--- a/apps/remix/app/components/tables/organisation-teams-table.tsx
+++ b/apps/remix/app/components/tables/organisation-teams-table.tsx
@@ -28,12 +28,17 @@ export const OrganisationTeamsTable = () => {
 
   const parsedSearchParams = ZUrlSearchParamsSchema.parse(Object.fromEntries(searchParams ?? []));
 
-  const { data, isLoading, isLoadingError } = trpc.team.find.useQuery({
-    organisationId: organisation.id,
-    query: parsedSearchParams.query,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-  });
+  const { data, isLoading, isLoadingError } = trpc.team.find.useQuery(
+    {
+      organisationId: organisation.id,
+      query: parsedSearchParams.query,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   const onPaginationChange = (page: number, perPage: number) => {
     updateSearchParams({

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/documents._index.tsx
@@ -91,6 +91,7 @@ export default function DocumentsPage() {
       folderId,
     },
     {
+      placeholderData: (previousData) => previousData,
       ...SKIP_QUERY_BATCH_META,
     },
   );

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks.$id._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.webhooks.$id._index.tsx
@@ -72,14 +72,19 @@ export default function WebhookPage({ params }: Route.ComponentProps) {
     data,
     isLoading: isLogsLoading,
     isLoadingError: isLogsLoadingError,
-  } = trpc.webhook.calls.find.useQuery({
-    webhookId: params.id,
-    page: parsedSearchParams.page,
-    perPage: parsedSearchParams.perPage,
-    status: parsedSearchParams.status,
-    events: parsedSearchParams.events,
-    query: parsedSearchParams.query,
-  });
+  } = trpc.webhook.calls.find.useQuery(
+    {
+      webhookId: params.id,
+      page: parsedSearchParams.page,
+      perPage: parsedSearchParams.perPage,
+      status: parsedSearchParams.status,
+      events: parsedSearchParams.events,
+      query: parsedSearchParams.query,
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    },
+  );
 
   /**
    * Handle debouncing the search query.

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/templates._index.tsx
@@ -66,6 +66,7 @@ export default function TemplatesPage() {
     },
     {
       enabled: !isOrgView,
+      placeholderData: (previousData) => previousData,
     },
   );
 
@@ -76,6 +77,7 @@ export default function TemplatesPage() {
     },
     {
       enabled: isOrgView,
+      placeholderData: (previousData) => previousData,
     },
   );
 


### PR DESCRIPTION
## Problem

Changing the page or rows-per-page on paginated tables caused the whole table to flash: the rows were replaced by the loading skeleton for a moment before the new page rendered.

This happens because page/perPage changes produce a new React Query cache key, so `data` becomes `undefined` and `isLoading` flips true until the response lands — unmounting the rows and rendering the skeleton on every pagination change.

## Fix

Add `placeholderData: (previousData) => previousData` to the affected queries, matching the convention already used by ~18 other tables in the codebase (admin documents, org members, document logs, etc.). The previous page's rows now stay visible while the next page fetches, and the skeleton only appears on true first load. Existing fetching indicators (e.g. the `useTransition` spinner overlay in `DocumentsTable`) still provide a loading cue during the transition.

## Affected tables

- Documents page (`document.findDocumentsInternal`)
- Templates page (`template.findTemplates`, `template.findOrganisationTemplates`)
- Inbox (`document.inbox.find`)
- Organisation teams (`team.find`)
- Webhook call logs (`webhook.calls.find`)
- Admin: claims, document jobs, email transports, organisation stats, organisations, user teams

## Verification

- `npx tsc --noEmit -p apps/remix` passes
- Biome format clean
