### PR TITLE
Add "Apply Your License Key" self-hosting guide

### DIFF
--- a/apps/docs/content/docs/policies/enterprise-edition.mdx
+++ b/apps/docs/content/docs/policies/enterprise-edition.mdx
@@ -199,7 +199,7 @@ See [Support](/docs/policies/support) for complete support options.
     1. Sign the Enterprise license agreement
     2. Receive license key and access credentials
     3. Deploy using [self-hosting guides](/docs/self-hosting) or access Documenso Cloud
-    4. Configure Enterprise features with support assistance
+    4. Apply the key — see [Apply Your License Key](/docs/self-hosting/configuration/license) — and configure Enterprise features with support assistance
 
   </Step>
   <Step>

--- a/apps/docs/content/docs/policies/enterprise-edition.mdx
+++ b/apps/docs/content/docs/policies/enterprise-edition.mdx
@@ -76,6 +76,8 @@ The Enterprise Edition is required when you:
     4. Restart your Documenso instance
     5. Verify the license is active in the **Admin Panel** under the **Stats** section
 
+    See [Apply Your License Key](/docs/self-hosting/configuration/license) for the full walkthrough, including how to enable individual features once licensed.
+
   </Accordion>
 </Accordions>
 
@@ -238,6 +240,7 @@ See [Support](/docs/policies/support) for complete support options.
 
 ## Related
 
+- [Apply Your License Key](/docs/self-hosting/configuration/license) - Step-by-step license activation
 - [Community Edition](/docs/policies/community-edition) - AGPL-3.0 open-source license
 - [Licenses](/docs/policies/licenses) - Complete licensing overview and FAQ
 - [Support](/docs/policies/support) - Support channels and response times

--- a/apps/docs/content/docs/self-hosting/configuration/environment.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/environment.mdx
@@ -443,7 +443,7 @@ Telemetry collects only: app version, installation ID, and node ID. No personal 
 
 ## Enterprise Features
 
-These variables require an active [Enterprise Edition](/docs/policies/enterprise-edition) license. Obtain a license key from [license.documenso.com](https://license.documenso.com) and set it below to unlock enterprise features such as SSO, embed editor, and 21 CFR Part 11 compliance.
+These variables require an active [Enterprise Edition](/docs/policies/enterprise-edition) license. Obtain a license key from [license.documenso.com](https://license.documenso.com) and set it below to unlock enterprise features such as SSO, embed editor, and 21 CFR Part 11 compliance. See [Apply Your License Key](/docs/self-hosting/configuration/license) for step-by-step setup.
 
 | Variable                             | Description                                      |
 | ------------------------------------ | ------------------------------------------------ |

--- a/apps/docs/content/docs/self-hosting/configuration/environment.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/environment.mdx
@@ -447,7 +447,7 @@ These variables require an active [Enterprise Edition](/docs/policies/enterprise
 
 | Variable                             | Description                                      |
 | ------------------------------------ | ------------------------------------------------ |
-| `NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY` | License key for enterprise features              |
+| `NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY` | License key for enterprise features — see [Apply Your License Key](/docs/self-hosting/configuration/license) for how to apply it |
 | `NEXT_PRIVATE_STRIPE_API_KEY`        | Stripe API key for billing                       |
 | `NEXT_PRIVATE_STRIPE_WEBHOOK_SECRET` | Stripe webhook secret                            |
 | `NEXT_PRIVATE_SES_ACCESS_KEY_ID`     | AWS SES access key for email domain verification |

--- a/apps/docs/content/docs/self-hosting/configuration/license.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/license.mdx
@@ -5,7 +5,6 @@ description: Activate your Enterprise license key to unlock enterprise features 
 
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 import { Callout } from 'fumadocs-ui/components/callout';
-import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 A license key activates the Enterprise features available to your self-hosted instance, such as CSC signing, SSO, embed white-labelling, and 21 CFR Part 11 compliance.
@@ -19,9 +18,6 @@ A license key activates the Enterprise features available to your self-hosted in
 
 - An active Enterprise license key
 - A running self-hosted Documenso instance that you're able to restart
-- An **admin account** on your instance (needed for Steps 3 and 4). Every account created through
-  signup is a regular user with no admin panel access — you have to grant the admin role yourself.
-  See [Granting Admin Access](/docs/self-hosting/getting-started/quick-start#granting-admin-access).
 
 ## Step 1: Set the environment variable
 
@@ -76,72 +72,29 @@ docker compose restart documenso
 docker restart documenso
 ```
 
-On startup, Documenso sends the key to the Documenso license server and caches the result locally for future startups (so a brief license-server outage won't lock you out).
+On startup, Documenso validates the key against the Documenso license server and caches the result locally for future startups, so a brief license-server outage won't lock you out.
 
-## Step 3: Verify it's active
+## What the license enables
 
-Open **Admin Panel → Stats** in your instance. A **Documenso License** card shows a status badge (Active, Past Due, or Expired), the license name, expiry date, the masked license key, and which features it includes.
+A valid license doesn't turn every enterprise feature on everywhere — activation depends on the feature:
 
-If the card shows **Invalid License Key**, **No License Configured**, or a status other than **Active**, double check:
-
-- The key was set in the environment the running container/process actually uses (not just a local `.env` file that isn't mounted)
-- The instance was fully restarted, not just reloaded
-- The key wasn't truncated or has extra whitespace when copied in
-
-<Callout type="info">
-  There's also a resync button (the refresh icon in the top-right of the license card) in **Admin
-  Panel → Stats** that re-checks the license against the license server immediately, without a
-  restart.
-</Callout>
-
-## Step 4: Enable features
-
-A valid license doesn't automatically turn every enterprise feature on everywhere — how each feature is enabled differs:
-
-<Accordions type="multiple">
-  <Accordion title="CSC signing">
-    CSC signing is enabled instance-wide as soon as the license is active and CSC transport is
-    configured. See [CSC / QES Signing](/docs/self-hosting/configuration/signing-certificate/csc-qes)
-    for the full setup.
-  </Accordion>
-  <Accordion title="SSO, embed white-label, 21 CFR Part 11, and similar">
-    These are granted per-organisation rather than instance-wide. As an instance admin:
-
-    1. Go to **Admin Panel → Claims** and create (or edit) a subscription claim that enables the
-       features you need. Only enable features your license covers — enabling one it doesn't will
-       flag the instance as unauthorized (see the warning below).
-    2. Go to **Admin Panel → Organisations**, open the organisation, and assign that claim to it.
-    3. Organisation admins can then configure the feature under their organisation's settings — for
-       example, SSO is configured under **Organisation Settings → SSO**.
-
-  </Accordion>
-</Accordions>
-
-<Callout type="warn">
-  If an organisation is assigned a feature your license doesn't cover, the admin panel shows an
-  **Invalid License Type** banner ("Your Documenso instance is using features that are not part of
-  your license") until the enabled features are brought back in line with your license.
-</Callout>
+- **CSC signing** activates instance-wide automatically once the license is active and CSC transport is configured. See [CSC / QES Signing](/docs/self-hosting/configuration/signing-certificate/csc-qes) for the full setup.
+- **SSO, embed white-labelling, 21 CFR Part 11, and similar** are provisioned per organisation. Follow each feature's own guide to configure it once the license is active.
 
 ## Troubleshooting
 
 <Accordions type="multiple">
-  <Accordion title="License shows as invalid or not found">
+  <Accordion title="Enterprise features are still unavailable after applying the key">
     - Confirm the key is present in the environment the running process actually reads — `docker
       exec` into the container and check `env | grep LICENSE` if unsure.
-    - Confirm the instance was restarted after the variable was set, not just left running.
+    - Confirm the instance was fully restarted after the variable was set, not just reloaded.
     - Re-copy the key to rule out truncation or accidental whitespace.
   </Accordion>
-  <Accordion title="License is active, but a feature is still unavailable">
-    Instance-wide features (like CSC signing) only need an active license and correct
-    configuration. Per-organisation features (like SSO) also need the organisation's claim to
-    include that feature — see Step 4 above.
-  </Accordion>
-  <Accordion title="Admin panel shows an 'Invalid License Type' banner">
-    This means an organisation on your instance has an enterprise feature enabled that your license
-    doesn't cover. Disable the feature for that organisation under **Admin Panel → Organisations**,
-    or adjust the claim under **Admin Panel → Claims**, so the enabled features match what your
-    license includes.
+  <Accordion title="A specific feature still isn't working">
+    Instance-wide features (like CSC signing) also need their own configuration — an active license
+    alone isn't enough. Check that feature's guide to confirm the required settings are in place.
+    Per-organisation features additionally need to be provisioned for the organisation that's using
+    them.
   </Accordion>
 </Accordions>
 

--- a/apps/docs/content/docs/self-hosting/configuration/license.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/license.mdx
@@ -19,6 +19,9 @@ A license key activates the Enterprise features available to your self-hosted in
 
 - An active Enterprise license key
 - A running self-hosted Documenso instance that you're able to restart
+- An **admin account** on your instance (needed for Steps 3 and 4). Every account created through
+  signup is a regular user with no admin panel access — you have to grant the admin role yourself.
+  See [Granting Admin Access](/docs/self-hosting/getting-started/quick-start#granting-admin-access).
 
 ## Step 1: Set the environment variable
 

--- a/apps/docs/content/docs/self-hosting/configuration/license.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/license.mdx
@@ -16,7 +16,9 @@ A license key activates the Enterprise features available to your self-hosted in
 
 ## Prerequisites
 
-- An active Enterprise license key
+- An active Enterprise license key — contact [sales](https://documen.so/enterprise) to set up an
+  Enterprise subscription, then copy your key from [license.documenso.com](https://license.documenso.com).
+  See [Enterprise Edition](/docs/policies/enterprise-edition) for details.
 - A running self-hosted Documenso instance that you're able to restart
 
 ## Step 1: Set the environment variable

--- a/apps/docs/content/docs/self-hosting/configuration/license.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/license.mdx
@@ -1,0 +1,146 @@
+---
+title: Apply Your License Key
+description: Activate your Enterprise license key to unlock enterprise features on your self-hosted instance.
+---
+
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+A license key activates the Enterprise features available to your self-hosted instance, such as CSC signing, SSO, embed white-labelling, and 21 CFR Part 11 compliance.
+
+<Callout type="info">
+  The license key applies to your **whole instance**, not an individual user account. There's one
+  key per deployment.
+</Callout>
+
+## Prerequisites
+
+- An active Enterprise license key
+- A running self-hosted Documenso instance that you're able to restart
+
+## Step 1: Set the environment variable
+
+Set `NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY` to your license key.
+
+<Tabs items={['Docker Compose', 'docker run', '.env']}>
+<Tab value="Docker Compose">
+
+Add the variable to your `.env` file (or directly under `environment:` in `compose.yml`):
+
+```bash
+NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY=your-license-key-here
+```
+
+Then apply it:
+
+```bash
+docker compose up -d
+```
+
+</Tab>
+<Tab value="docker run">
+
+```bash
+docker run -d \
+  --name documenso \
+  -e NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY=your-license-key-here \
+  documenso/documenso:latest
+```
+
+</Tab>
+<Tab value=".env">
+
+If you're running Documenso directly (not in a container), add the variable to your `.env` file:
+
+```bash
+NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY=your-license-key-here
+```
+
+</Tab>
+</Tabs>
+
+## Step 2: Restart the instance
+
+The license key is only read once, at process startup. Setting the variable in a running container or shell has no effect until the process restarts.
+
+```bash
+# Docker Compose
+docker compose restart documenso
+
+# Docker
+docker restart documenso
+```
+
+On startup, Documenso sends the key to the Documenso license server and caches the result locally for future startups (so a brief license-server outage won't lock you out).
+
+## Step 3: Verify it's active
+
+Open **Admin Panel → Stats** in your instance. A license card shows the status (Active, Past Due, or Expired), license name, expiry date, and which features it includes.
+
+If the status doesn't say **Active**, double check:
+
+- The key was set in the environment the running container/process actually uses (not just a local `.env` file that isn't mounted)
+- The instance was fully restarted, not just reloaded
+- The key wasn't truncated or has extra whitespace when copied in
+
+<Callout type="info">
+  There's also a resync button on the license card in **Admin Panel → Stats** that re-checks the
+  license against the license server immediately, without a restart.
+</Callout>
+
+## Step 4: Enable features
+
+A valid license doesn't automatically turn every enterprise feature on everywhere — how each feature is enabled differs:
+
+<Accordions type="multiple">
+  <Accordion title="CSC signing">
+    CSC signing is enabled instance-wide as soon as the license is active and CSC transport is
+    configured. See [CSC / QES Signing](/docs/self-hosting/configuration/signing-certificate/csc-qes)
+    for the full setup.
+  </Accordion>
+  <Accordion title="SSO, embed white-label, 21 CFR Part 11, and similar">
+    These are granted per-organisation rather than instance-wide. As an instance admin:
+
+    1. Go to **Admin Panel → Claims** and create (or edit) a subscription claim with the features
+       you need enabled. Only features included in your license can be added.
+    2. Go to **Admin Panel → Organisations**, open the organisation, and assign that claim to it.
+    3. Organisation admins can then configure the feature under their organisation's settings — for
+       example, SSO is configured under **Organisation Settings → SSO**.
+
+  </Accordion>
+</Accordions>
+
+<Callout type="warn">
+  If an organisation's claim includes a feature your license doesn't cover, the license status
+  will show as unauthorized in the admin panel until the claim is brought back in line with your
+  license.
+</Callout>
+
+## Troubleshooting
+
+<Accordions type="multiple">
+  <Accordion title="License shows as invalid or not found">
+    - Confirm the key is present in the environment the running process actually reads — `docker
+      exec` into the container and check `env | grep LICENSE` if unsure.
+    - Confirm the instance was restarted after the variable was set, not just left running.
+    - Re-copy the key to rule out truncation or accidental whitespace.
+  </Accordion>
+  <Accordion title="License is active, but a feature is still unavailable">
+    Instance-wide features (like CSC signing) only need an active license and correct
+    configuration. Per-organisation features (like SSO) also need the organisation's claim to
+    include that feature — see Step 4 above.
+  </Accordion>
+  <Accordion title="Status shows Unauthorized">
+    This means an organisation on your instance has a feature enabled in its claim that your
+    license doesn't cover. Adjust the claim in **Admin Panel → Claims** so it matches what your
+    license includes.
+  </Accordion>
+</Accordions>
+
+## See Also
+
+- [Environment Variables](/docs/self-hosting/configuration/environment) - Complete configuration reference
+- [Enterprise Edition](/docs/policies/enterprise-edition) - What's included and how to purchase a license
+- [CSC / QES Signing](/docs/self-hosting/configuration/signing-certificate/csc-qes) - Enable CSC-based signing

--- a/apps/docs/content/docs/self-hosting/configuration/license.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/license.mdx
@@ -77,17 +77,18 @@ On startup, Documenso sends the key to the Documenso license server and caches t
 
 ## Step 3: Verify it's active
 
-Open **Admin Panel → Stats** in your instance. A license card shows the status (Active, Past Due, or Expired), license name, expiry date, and which features it includes.
+Open **Admin Panel → Stats** in your instance. A **Documenso License** card shows a status badge (Active, Past Due, or Expired), the license name, expiry date, the masked license key, and which features it includes.
 
-If the status doesn't say **Active**, double check:
+If the card shows **Invalid License Key**, **No License Configured**, or a status other than **Active**, double check:
 
 - The key was set in the environment the running container/process actually uses (not just a local `.env` file that isn't mounted)
 - The instance was fully restarted, not just reloaded
 - The key wasn't truncated or has extra whitespace when copied in
 
 <Callout type="info">
-  There's also a resync button on the license card in **Admin Panel → Stats** that re-checks the
-  license against the license server immediately, without a restart.
+  There's also a resync button (the refresh icon in the top-right of the license card) in **Admin
+  Panel → Stats** that re-checks the license against the license server immediately, without a
+  restart.
 </Callout>
 
 ## Step 4: Enable features
@@ -103,8 +104,9 @@ A valid license doesn't automatically turn every enterprise feature on everywher
   <Accordion title="SSO, embed white-label, 21 CFR Part 11, and similar">
     These are granted per-organisation rather than instance-wide. As an instance admin:
 
-    1. Go to **Admin Panel → Claims** and create (or edit) a subscription claim with the features
-       you need enabled. Only features included in your license can be added.
+    1. Go to **Admin Panel → Claims** and create (or edit) a subscription claim that enables the
+       features you need. Only enable features your license covers — enabling one it doesn't will
+       flag the instance as unauthorized (see the warning below).
     2. Go to **Admin Panel → Organisations**, open the organisation, and assign that claim to it.
     3. Organisation admins can then configure the feature under their organisation's settings — for
        example, SSO is configured under **Organisation Settings → SSO**.
@@ -113,9 +115,9 @@ A valid license doesn't automatically turn every enterprise feature on everywher
 </Accordions>
 
 <Callout type="warn">
-  If an organisation's claim includes a feature your license doesn't cover, the license status
-  will show as unauthorized in the admin panel until the claim is brought back in line with your
-  license.
+  If an organisation is assigned a feature your license doesn't cover, the admin panel shows an
+  **Invalid License Type** banner ("Your Documenso instance is using features that are not part of
+  your license") until the enabled features are brought back in line with your license.
 </Callout>
 
 ## Troubleshooting
@@ -132,9 +134,10 @@ A valid license doesn't automatically turn every enterprise feature on everywher
     configuration. Per-organisation features (like SSO) also need the organisation's claim to
     include that feature — see Step 4 above.
   </Accordion>
-  <Accordion title="Status shows Unauthorized">
-    This means an organisation on your instance has a feature enabled in its claim that your
-    license doesn't cover. Adjust the claim in **Admin Panel → Claims** so it matches what your
+  <Accordion title="Admin panel shows an 'Invalid License Type' banner">
+    This means an organisation on your instance has an enterprise feature enabled that your license
+    doesn't cover. Disable the feature for that organisation under **Admin Panel → Organisations**,
+    or adjust the claim under **Admin Panel → Claims**, so the enabled features match what your
     license includes.
   </Accordion>
 </Accordions>

--- a/apps/docs/content/docs/self-hosting/configuration/meta.json
+++ b/apps/docs/content/docs/self-hosting/configuration/meta.json
@@ -2,6 +2,7 @@
   "title": "Configuration",
   "pages": [
     "environment",
+    "license",
     "database",
     "email",
     "storage",

--- a/apps/docs/content/docs/self-hosting/configuration/signing-certificate/csc-qes.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/signing-certificate/csc-qes.mdx
@@ -49,7 +49,7 @@ The callback URL is fixed — Documenso derives it from `NEXT_PUBLIC_WEBAPP_URL`
 
 ### Enterprise Edition license
 
-CSC mode is gated by the `instanceCscSigning` license flag. Without a valid Enterprise license, the transport refuses to start (`CSC_UNLICENSED`).
+CSC mode is gated by the `instanceCscSigning` license flag. Without a valid Enterprise license, the transport refuses to start (`CSC_UNLICENSED`). See [Apply Your License Key](/docs/self-hosting/configuration/license) to activate one.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/self-hosting/index.mdx
+++ b/apps/docs/content/docs/self-hosting/index.mdx
@@ -141,7 +141,7 @@ See the [Quick Start guide](/docs/self-hosting/getting-started/quick-start) for 
 
 Self-hosted Documenso includes full core functionality under the AGPL-3.0 license. If you need enterprise features such as SSO, embed editor white label, or 21 CFR Part 11 compliance, you can activate them with a license key.
 
-See [Enterprise Edition](/docs/policies/enterprise-edition) for details and [Licenses](/docs/policies/licenses) for a comparison.
+See [Enterprise Edition](/docs/policies/enterprise-edition) for details and [Licenses](/docs/policies/licenses) for a comparison. Already have a key? See [Apply Your License Key](/docs/self-hosting/configuration/license).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31153,6 +31153,126 @@
         "react": "^18",
         "typescript": "5.6.2"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a dedicated self-hosting page documenting how to apply an Enterprise license key, and cross-links it from the related docs.

New page: self-hosting/configuration/license.mdx — "Apply Your License Key"
Set NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY (Docker Compose / docker run / .env tabs)