### PR TITLE
fix: use Promise.allSettled for completion emails to prevent total fa…

### DIFF
--- a/packages/lib/jobs/definitions/emails/send-document-completed-emails.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-completed-emails.handler.ts
@@ -177,7 +177,7 @@ export const run = async ({ payload, io }: { payload: TSendDocumentCompletedEmai
 
   const recipientsToNotify = envelope.recipients.filter((recipient) => isRecipientEmailValidForSending(recipient));
 
-  await Promise.all(
+  const results = await Promise.allSettled(
     recipientsToNotify.map(async (recipient) => {
       // A CC recipient never asked to be part of this document, so their completion
       // email is effectively unsolicited. Meter it against the organisation email
@@ -271,4 +271,20 @@ export const run = async ({ payload, io }: { payload: TSendDocumentCompletedEmai
       });
     }),
   );
+
+  const failedSends = results.filter((result) => result.status === 'rejected') as PromiseRejectedResult[];
+
+  if (failedSends.length > 0) {
+    if (failedSends.length === recipientsToNotify.length) {
+      throw new Error(`Failed to send completion emails to all recipients: ${failedSends[0].reason}`);
+    } else {
+      failedSends.forEach((failure) => {
+        io.logger.error({
+          msg: 'Failed to send completion email to a recipient',
+          error: failure.reason,
+          envelopeId: envelope.id,
+        });
+      });
+    }
+  }
 };


### PR DESCRIPTION
…ilure on single error (#3038)

<!--
  We are no longer accepting external pull requests.

  Aside from a small group of trusted contributors we reach out to directly,
  new external PRs will usually be closed with a request to open an issue instead.
  This is a security decision. See https://documenso.com/blog/why-we-re-pausing-external-pull-requests

  If you're a trusted contributor or maintainer, continue below.
  Otherwise, please open a detailed issue: https://github.com/documenso/documenso/issues/new/choose
-->

## Description

<!--- Describe the changes introduced by this pull request. -->
<!--- Explain what problem it solves or what feature/fix it adds. -->

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Change 1
- Change 2
- ...

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- Tested feature X in scenario Y.
- Ran unit tests for component Z.
- Tested on browsers A, B, and C.
- ...

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
