### PR TITLE
security: add required Expires field to security.txt (RFC 9116)

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -12,3 +12,6 @@ Contact: https://github.com/documenso/documenso/issues/new?assignees=&labels=bug
 
 Preferred-Languages: en
 Canonical: https://documenso.com/.well-known/security.txt
+
+# Required by RFC 9116 (section 2.5.5). Refresh before this date.
+Expires: 2027-07-13T00:00:00.000Z

--- a/apps/remix/public/.well-known/security.txt
+++ b/apps/remix/public/.well-known/security.txt
@@ -12,3 +12,6 @@ Contact: https://github.com/documenso/documenso/issues/new?assignees=&labels=bug
 
 Preferred-Languages: en
 Canonical: https://documenso.com/.well-known/security.txt
+
+# Required by RFC 9116 (section 2.5.5). Refresh before this date.
+Expires: 2027-07-13T00:00:00.000Z


### PR DESCRIPTION
### What

Add the required `Expires` field to `security.txt` (both copies — the root `.well-known/` one and the
served `apps/remix/public/.well-known/` one).

### Why

[RFC 9116 §2.5.5](https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5) makes `Expires` **mandatory**:

> The "Expires" field … MUST be present.

The current file (and the live one at `https://documenso.com/.well-known/security.txt`) has no
`Expires`, so RFC-9116 validators (e.g. securitytxt.org) flag it as invalid, and a researcher can't
tell whether the contact info is still current.

### What I did

Added `Expires: 2027-07-13T00:00:00.000Z` (one year out) to both copies. RFC 9116 recommends less than
a year, so **please set the date/cadence to whatever suits your refresh process** — I picked a
placeholder. No other content changed.

<sub>AI-assisted (I saw you use OpenCode!); I verified the RFC requirement and the live file myself, and I own this change.</sub>
