### PR TITLE
fix: match region-qualified locales in Accept-Language negotiation (#3090)

### DIFF
--- a/packages/lib/utils/i18n.test.ts
+++ b/packages/lib/utils/i18n.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractLocaleData, extractLocaleDataFromHeaders } from './i18n';
+
+const headersWith = (acceptLanguage: string) => new Headers({ 'accept-language': acceptLanguage });
+
+describe('extractLocaleData', () => {
+  // Regression guard for #3090 (Accept-Language can never match pt-BR): a
+  // region-qualified supported language must be matched instead of falling back.
+  it('matches a region-qualified supported language (pt-BR)', () => {
+    expect(extractLocaleData({ headers: headersWith('pt-BR') }).lang).toBe('pt-BR');
+  });
+
+  it('matches pt-BR even with a quality value and lower-priority locales', () => {
+    expect(extractLocaleData({ headers: headersWith('pt-BR;q=0.9,en;q=0.8') }).lang).toBe('pt-BR');
+  });
+
+  it('matches a region-qualified locale case-insensitively', () => {
+    expect(extractLocaleData({ headers: headersWith('pt-br') }).lang).toBe('pt-BR');
+  });
+
+  it('still falls back to the base language for region locales (en-US -> en)', () => {
+    expect(extractLocaleData({ headers: headersWith('en-US') }).lang).toBe('en');
+  });
+
+  it('matches a plain supported language', () => {
+    expect(extractLocaleData({ headers: headersWith('de') }).lang).toBe('de');
+  });
+
+  it('falls back to the source language for unsupported locales', () => {
+    expect(extractLocaleData({ headers: headersWith('xx-YY') }).lang).toBe('en');
+  });
+
+  it('falls back to the source language when no accept-language is present', () => {
+    expect(extractLocaleData({ headers: new Headers() }).lang).toBe('en');
+  });
+});
+
+describe('extractLocaleDataFromHeaders', () => {
+  it('matches a region-qualified supported language (pt-BR)', () => {
+    expect(extractLocaleDataFromHeaders(headersWith('pt-BR,en;q=0.9')).lang).toBe('pt-BR');
+  });
+
+  it('returns null for an unsupported locale', () => {
+    expect(extractLocaleDataFromHeaders(headersWith('xx-YY')).lang).toBeNull();
+  });
+});

--- a/packages/lib/utils/i18n.ts
+++ b/packages/lib/utils/i18n.ts
@@ -21,17 +21,32 @@ export async function dynamicActivate(locale: string) {
 }
 
 const parseLanguageFromLocale = (locale: string): SupportedLanguageCodes | null => {
-  const [language, _country] = locale.split('-');
+  // Accept-Language entries may carry a quality value (e.g. "pt-BR;q=0.9").
+  const normalizedLocale = locale.split(';')[0].trim().toLowerCase();
 
-  const foundSupportedLanguage = APP_I18N_OPTIONS.supportedLangs.find(
-    (lang): lang is SupportedLanguageCodes => lang === language,
-  );
-
-  if (!foundSupportedLanguage) {
+  if (!normalizedLocale) {
     return null;
   }
 
-  return foundSupportedLanguage;
+  const [language] = normalizedLocale.split('-');
+
+  // Prefer an exact match on the full locale so region-qualified supported
+  // languages (e.g. "pt-BR") are matched, then fall back to the base language
+  // (e.g. "en-US" -> "en"). Accept-Language casing is not guaranteed, so we
+  // compare case-insensitively while returning the canonical supported code.
+  const exactMatch = APP_I18N_OPTIONS.supportedLangs.find(
+    (lang): lang is SupportedLanguageCodes => lang.toLowerCase() === normalizedLocale,
+  );
+
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const languageMatch = APP_I18N_OPTIONS.supportedLangs.find(
+    (lang): lang is SupportedLanguageCodes => lang.toLowerCase() === language,
+  );
+
+  return languageMatch ?? null;
 };
 
 /**


### PR DESCRIPTION
## Description

`parseLanguageFromLocale` split the incoming locale on `-` and compared only the base language against the supported languages. Since `pt-BR` is the only region-qualified entry in `SUPPORTED_LANGUAGE_CODES`, an `Accept-Language: pt-BR` header was reduced to `pt`, which is not in the list — so Brazilian Portuguese users always fell back to English.

## Related Issue

Fixes #3090

## Changes Made

- `packages/lib/utils/i18n.ts`: match the full locale first (case-insensitively, ignoring any `;q=` quality value), then fall back to the base language. Region-qualified supported languages like `pt-BR` now match, while base-language behaviour (`en-US` → `en`) is preserved.
- Added `packages/lib/utils/i18n.test.ts` with unit tests for `extractLocaleData` / `extractLocaleDataFromHeaders`.

## Testing Performed

- `vitest run utils/i18n.test.ts` → **9 passed** (pt-BR match, quality value, case-insensitive, `en-US`→`en` regression, unsupported→fallback, empty header).
- `biome check` → clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.