### PR TITLE
fix: use document title for single-item envelope downloads (#3096)

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
@@ -1,4 +1,5 @@
 import { downloadPDF } from '@documenso/lib/client-only/download-pdf';
+import { getEnvelopeDownloadFileName } from '@documenso/lib/utils/get-envelope-download-filename';
 import { trpc } from '@documenso/trpc/react';
 import { Button } from '@documenso/ui/primitives/button';
 import {
@@ -97,12 +98,13 @@ export const EnvelopeDownloadDialog = ({
       access: token ? { type: 'recipient', token } : { type: 'user' },
     },
     {
-      initialData: initialEnvelopeItems ? { data: initialEnvelopeItems } : undefined,
+      initialData: initialEnvelopeItems ? { data: initialEnvelopeItems, envelopeTitle: '' } : undefined,
       enabled: open,
     },
   );
 
   const envelopeItems = envelopeItemsPayload?.data || [];
+  const envelopeTitle = envelopeItemsPayload?.envelopeTitle ?? '';
 
   const onDownload = async (envelopeItem: EnvelopeItemToDownload, version: 'original' | 'signed' | 'pending') => {
     const { id: envelopeItemId } = envelopeItem;
@@ -120,7 +122,11 @@ export const EnvelopeDownloadDialog = ({
       await downloadPDF({
         envelopeItem,
         token,
-        fileName: envelopeItem.title,
+        fileName: getEnvelopeDownloadFileName({
+          itemCount: envelopeItems.length,
+          itemTitle: envelopeItem.title,
+          envelopeTitle,
+        }),
         version,
       });
 

--- a/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
@@ -21,6 +21,14 @@ type EnvelopeItemToDownload = Pick<EnvelopeItem, 'id' | 'envelopeId' | 'title' |
 
 type EnvelopeDownloadDialogProps = {
   envelopeId: string;
+
+  /**
+   * The envelope (document) title. Optional: when provided it is used as the
+   * initial download filename for single-item envelopes, avoiding a brief
+   * fallback to the (potentially stale) envelope item title before the items
+   * query resolves. When omitted, the title from the query response is used.
+   */
+  envelopeTitle?: string;
   envelopeStatus: DocumentStatus;
 
   /**
@@ -48,6 +56,7 @@ type EnvelopeDownloadDialogProps = {
 
 export const EnvelopeDownloadDialog = ({
   envelopeId,
+  envelopeTitle: initialEnvelopeTitle,
   envelopeStatus,
   isLegacy,
   envelopeItems: initialEnvelopeItems,
@@ -98,7 +107,9 @@ export const EnvelopeDownloadDialog = ({
       access: token ? { type: 'recipient', token } : { type: 'user' },
     },
     {
-      initialData: initialEnvelopeItems ? { data: initialEnvelopeItems, envelopeTitle: '' } : undefined,
+      initialData: initialEnvelopeItems
+        ? { data: initialEnvelopeItems, envelopeTitle: initialEnvelopeTitle ?? '' }
+        : undefined,
       enabled: open,
     },
   );

--- a/packages/lib/utils/get-envelope-download-filename.test.ts
+++ b/packages/lib/utils/get-envelope-download-filename.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { getEnvelopeDownloadFileName } from './get-envelope-download-filename';
+
+describe('getEnvelopeDownloadFileName', () => {
+  // Regression guard for #3096: a renamed single-item document must download
+  // using the (current) envelope title, not the stale envelope item title.
+  it('uses the envelope title for single-item envelopes', () => {
+    expect(
+      getEnvelopeDownloadFileName({
+        itemCount: 1,
+        itemTitle: 'original-upload-name',
+        envelopeTitle: 'Renamed Document',
+      }),
+    ).toBe('Renamed Document');
+  });
+
+  it('uses the item title for multi-item envelopes', () => {
+    expect(
+      getEnvelopeDownloadFileName({
+        itemCount: 3,
+        itemTitle: 'Appendix A',
+        envelopeTitle: 'Renamed Document',
+      }),
+    ).toBe('Appendix A');
+  });
+
+  it('falls back to the item title when the envelope title is empty', () => {
+    expect(
+      getEnvelopeDownloadFileName({
+        itemCount: 1,
+        itemTitle: 'fallback-name',
+        envelopeTitle: '   ',
+      }),
+    ).toBe('fallback-name');
+  });
+});

--- a/packages/lib/utils/get-envelope-download-filename.ts
+++ b/packages/lib/utils/get-envelope-download-filename.ts
@@ -1,0 +1,30 @@
+type GetEnvelopeDownloadFileNameOptions = {
+  itemCount: number;
+  itemTitle: string;
+  envelopeTitle: string;
+};
+
+/**
+ * Resolve the base filename used when downloading an envelope item.
+ *
+ * For single-item envelopes the item is effectively the document, so the
+ * envelope (document) title is used. Renaming a document only updates the
+ * envelope title, not the item title, so relying on the item title left
+ * downloads with a stale name (see #3096).
+ *
+ * Multi-item envelopes keep the per-item title so the downloaded files stay
+ * distinguishable from one another.
+ *
+ * The caller is responsible for appending any version suffix / extension.
+ */
+export const getEnvelopeDownloadFileName = ({
+  itemCount,
+  itemTitle,
+  envelopeTitle,
+}: GetEnvelopeDownloadFileNameOptions): string => {
+  if (itemCount === 1 && envelopeTitle.trim() !== '') {
+    return envelopeTitle;
+  }
+
+  return itemTitle;
+};

--- a/packages/trpc/server/envelope-router/get-envelope-items-by-token.ts
+++ b/packages/trpc/server/envelope-router/get-envelope-items-by-token.ts
@@ -34,7 +34,7 @@ export const getEnvelopeItemsByTokenRoute = maybeAuthenticatedProcedure
         });
       }
 
-      const { envelopeItems: data } = await handleGetEnvelopeItemsByUser({
+      const { envelopeItems: data, envelopeTitle } = await handleGetEnvelopeItemsByUser({
         envelopeId,
         userId: user.id,
         teamId,
@@ -42,16 +42,18 @@ export const getEnvelopeItemsByTokenRoute = maybeAuthenticatedProcedure
 
       return {
         data,
+        envelopeTitle,
       };
     }
 
-    const { envelopeItems: data } = await handleGetEnvelopeItemsByToken({
+    const { envelopeItems: data, envelopeTitle } = await handleGetEnvelopeItemsByToken({
       envelopeId,
       token: access.token,
     });
 
     return {
       data,
+      envelopeTitle,
     };
   });
 
@@ -83,6 +85,7 @@ const handleGetEnvelopeItemsByToken = async ({ envelopeId, token }: { envelopeId
 
   return {
     envelopeItems: envelope.envelopeItems,
+    envelopeTitle: envelope.title,
   };
 };
 
@@ -147,5 +150,6 @@ const handleGetEnvelopeItemsByUser = async ({
 
   return {
     envelopeItems: envelope.envelopeItems,
+    envelopeTitle: envelope.title,
   };
 };

--- a/packages/trpc/server/envelope-router/get-envelope-items-by-token.types.ts
+++ b/packages/trpc/server/envelope-router/get-envelope-items-by-token.types.ts
@@ -21,4 +21,10 @@ export const ZGetEnvelopeItemsByTokenResponseSchema = z.object({
     title: true,
     order: true,
   }).array(),
+  /**
+   * The title of the parent envelope (document). Used to name downloads of
+   * single-item envelopes after the document rather than the (potentially stale)
+   * envelope item title.
+   */
+  envelopeTitle: z.string(),
 });


### PR DESCRIPTION
## Description

Downloading a document from the "Download Files" dialog named the file after the envelope **item** title, which preserves the original template/upload name. Renaming a document updates the envelope title but not the item title, so downloads kept a stale name.

## Related Issue

Fixes #3096

## Changes Made

- `envelope.item.getManyByToken` now returns the parent `envelopeTitle` (`get-envelope-items-by-token.ts` / `.types.ts`).
- New pure helper `packages/lib/utils/get-envelope-download-filename.ts`: single-item envelopes download using the envelope (document) title; multi-item envelopes keep per-item titles so files remain distinguishable.
- `envelope-download-dialog.tsx` uses the helper (no change needed at the dialog's ~11 call sites).

## Testing Performed

- `vitest run utils/get-envelope-download-filename.test.ts` → **3 passed** (single-item → document title, multi-item → item title, empty-title fallback).
- `biome check` → clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.