### PR TITLE
fix: render adjacent placeholders in custom email templates

### DIFF
--- a/packages/lib/utils/render-custom-email-template.test.ts
+++ b/packages/lib/utils/render-custom-email-template.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderCustomEmailTemplate } from './render-custom-email-template';
+
+describe('renderCustomEmailTemplate', () => {
+  const variables = {
+    first: 'John',
+    last: 'Doe',
+    'document.name': 'Contract',
+  };
+
+  it('replaces a single placeholder', () => {
+    expect(renderCustomEmailTemplate('Hello {first}', variables)).toBe('Hello John');
+  });
+
+  it('replaces placeholders separated by whitespace', () => {
+    expect(renderCustomEmailTemplate('{first} {last}', variables)).toBe('John Doe');
+  });
+
+  // Regression: a greedy "\S+" matched from the first "{" to the last "}",
+  // corrupting adjacent placeholders (or placeholders joined by a non-space char).
+  it('replaces adjacent placeholders individually', () => {
+    expect(renderCustomEmailTemplate('{first}{last}', variables)).toBe('JohnDoe');
+  });
+
+  it('replaces placeholders joined by a non-whitespace character', () => {
+    expect(renderCustomEmailTemplate('{first}-{last}', variables)).toBe('John-Doe');
+  });
+
+  it('keeps dotted keys working', () => {
+    expect(renderCustomEmailTemplate('Re: {document.name}', variables)).toBe('Re: Contract');
+  });
+
+  it('leaves unknown placeholders as their key', () => {
+    expect(renderCustomEmailTemplate('Hi {unknown}', variables)).toBe('Hi unknown');
+  });
+
+  it('returns the template unchanged when there are no placeholders', () => {
+    expect(renderCustomEmailTemplate('No placeholders here', variables)).toBe('No placeholders here');
+  });
+});

--- a/packages/lib/utils/render-custom-email-template.ts
+++ b/packages/lib/utils/render-custom-email-template.ts
@@ -1,5 +1,8 @@
 export const renderCustomEmailTemplate = <T extends Record<string, string>>(template: string, variables: T): string => {
-  return template.replace(/\{(\S+)\}/g, (_, key) => {
+  // Exclude braces (and whitespace) from the key so that adjacent placeholders
+  // like "{first}{last}" or "{a}-{b}" are matched individually. A greedy "\S+"
+  // would otherwise span from the first "{" to the last "}" and corrupt the output.
+  return template.replace(/\{([^{}\s]+)\}/g, (_, key) => {
     if (key in variables) {
       return variables[key];
     }


### PR DESCRIPTION
## Description

`renderCustomEmailTemplate` used a greedy `\S+` in its placeholder regex (`/\{(\S+)\}/g`), so a match spanned from the first `{` to the last `}`. Adjacent placeholders like `{first}{last}`, or placeholders joined by a non-space character such as `{a}-{b}`, were treated as a single malformed key and left uninterpolated — corrupting custom email subjects and messages.

This affects custom email subject/body rendering in the signing, completed, reminder and resend email flows.

## Changes Made

- `packages/lib/utils/render-custom-email-template.ts`: match the key with `[^{}\s]+` instead of `\S+`, so each placeholder is matched individually.
- Added `render-custom-email-template.test.ts` covering adjacent placeholders, non-space separators, dotted keys, unknown keys and no-placeholder input.

## Testing Performed

- `vitest run utils/render-custom-email-template.test.ts` → **7 passed** (the adjacent-placeholder cases fail before the fix).
- `biome check` → clean.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.