### PR TITLE
chore(holostaff): embed copilot Dana

### DIFF
--- a/apps/remix/app/entry.client.tsx
+++ b/apps/remix/app/entry.client.tsx
@@ -9,6 +9,13 @@ import { HydratedRouter } from 'react-router/dom';
 
 import './utils/polyfills/promise-with-resolvers';
 
+import { holostaff } from '@holostaff/sdk';
+
+holostaff.init({
+  tenantId: 'workspace_urZYaISXD2Pcx2jCgTE57vyYCQu2',
+  sourceId: 'ks_mrp2mc59_f1kkq8',
+});
+
 function PosthogInit() {
   const postHogConfig = extractPostHogConfig();
 

--- a/apps/remix/package.json
+++ b/apps/remix/package.json
@@ -73,7 +73,9 @@
     "tailwindcss": "^3.4.18",
     "ts-pattern": "^5.9.0",
     "ua-parser-js": "^1.0.41",
-    "uqr": "^0.1.2"
+    "uqr": "^0.1.2",
+    "@holostaff/sdk": "^0.10.2",
+    "livekit-client": ">=2"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,6 +349,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "apps/docs/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "apps/docs/node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -420,6 +434,7 @@
         "@documenso/ui": "*",
         "@epic-web/remember": "^1.1.0",
         "@faker-js/faker": "^10.1.0",
+        "@holostaff/sdk": "^0.10.2",
         "@hono/node-server": "^1.19.11",
         "@hono/standard-validator": "^0.2.0",
         "@hono/trpc-server": "^0.4.0",
@@ -444,6 +459,7 @@
         "input-otp": "^1.4.2",
         "isbot": "^5.1.32",
         "konva": "^10.0.9",
+        "livekit-client": ">=2",
         "lucide-react": "^0.554.0",
         "luxon": "^3.7.2",
         "nanoid": "^5.1.6",
@@ -2531,9 +2547,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2551,9 +2564,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2571,9 +2581,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2591,9 +2598,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3840,6 +3844,30 @@
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
       "license": "MIT"
     },
+    "node_modules/@holostaff/sdk": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@holostaff/sdk/-/sdk-0.10.2.tgz",
+      "integrity": "sha512-7N+aPBXb5h6DLRdOMfGq3ED2qZyotlVJXDL3jXmFCp86jwHXiUPtpHH3etMzZka6rXol+1C5jFY4EEJRa5BSiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrweb": "^2.0.0-alpha.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@anam-ai/js-sdk": ">=3",
+        "livekit-client": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "@anam-ai/js-sdk": {
+          "optional": true
+        },
+        "livekit-client": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -5027,6 +5055,27 @@
       "peerDependencies": {
         "vite": "^3 || ^4 || ^5.0.9 || ^6 || ^7"
       }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.46.6",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.46.6.tgz",
+      "integrity": "sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/protocol/node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@marsidev/react-turnstile": {
       "version": "1.5.0",
@@ -12305,6 +12354,18 @@
         "win32"
       ]
     },
+    "node_modules/@rrweb/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-svOHkcuukP6rIjz2umwVsS7uYct+2h0N97+bg+8IJYKIUj5+YjwIvqx5y9NILFKPIu3yk+Mb+KDFfJ8RV+4JlA==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-hU7MT3TSdD+Do7FmMoHrBfPevFCheN5vo2mn97Y4vbXuwemopAmo8dqo5KJeMaA6oQQt7FinHJ0Xqb7k68Ci6Q==",
+      "license": "MIT"
+    },
     "node_modules/@rvf/set-get": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@rvf/set-get/-/set-get-7.0.2.tgz",
@@ -13907,6 +13968,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -14656,6 +14723,12 @@
       "integrity": "sha512-5BBJBmxJ1z/TzSuKE10stIX4dOsFN4tlMqj3WMPBSGM8euO1z5X/s2DaTSkXlTzznD5aWa4nV3t//zChFHruag==",
       "license": "MIT"
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -15167,6 +15240,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -22171,6 +22253,26 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.20.1.tgz",
+      "integrity": "sha512-JxooxLFMkdwqTo4XLer+DCij6S3//Z/GuHSjqdhlj94Vtbh1Eayd7Lyq47qkIE86+xVJhqxIdYnq53lg4oPH9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.46.6",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
@@ -22457,6 +22559,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long": {
@@ -23817,6 +23932,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -24246,9 +24367,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24264,9 +24382,6 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -24284,9 +24399,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24302,9 +24414,6 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -27517,6 +27626,40 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/rrdom": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.1.0.tgz",
+      "integrity": "sha512-d7oaIHzwffxI74UJMZDGq/f97/Yfm3QX4CcTIlQelt2HsLavItLjp8x8nQ0g9Pet5+5wG1RGr9yvsxb1gJlo8A==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.1.0"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.1.0.tgz",
+      "integrity": "sha512-gGGvd1eXWnOuJpQumH7+gPmBwTXzNrjmQyedWVePcEx0S5fe3VkQW4vw5f5ItY+vuigaaktte9cZKOg0OEvv+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.1.0",
+        "@rrweb/utils": "^2.1.0",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.1.0",
+        "rrweb-snapshot": "^2.1.0"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.1.0.tgz",
+      "integrity": "sha512-CFjUKWlO+Dl72gk8qwcDcNE/Pj9yr6IvGRAiRAx12pmJaSWaOKFoFgpQQ1j/mW0WKwEZXbHnMJL8M92gIsdwUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -27628,6 +27771,21 @@
       "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/secure-json-parse": {
@@ -29495,6 +29653,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -30791,6 +30958,19 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/rig/README.md
+++ b/rig/README.md
@@ -1,0 +1,28 @@
+# Holostaff deployment rig
+
+This fork is a Tier-2 target of the Holostaff deployment test rig
+(holostaff-agent `documents/prd-test-rig.md`, P2). The rig force-resets
+`main` to a pinned baseline before every run, opens real Holostaff
+deploy + embed PRs against it, merges them, builds this compose stack
+from the merged source, and drives simulated users at the running app.
+
+`compose.yml` is the rig's serving stack (Postgres + Mailpit + the app
+built from this checkout). Manual bring-up:
+
+```sh
+# one-time: self-signed signing cert (document signing needs a p12)
+openssl genrsa -out /tmp/rig-doc.key 2048
+openssl req -new -x509 -key /tmp/rig-doc.key -out /tmp/rig-doc.crt -days 365 \
+  -subj "/CN=Holostaff Rig"
+openssl pkcs12 -export -out "$HOME/.holostaff-rig/documenso-cert.p12" \
+  -inkey /tmp/rig-doc.key -in /tmp/rig-doc.crt -passout pass:
+
+RIG_APP_PORT=4180 \
+RIG_PUBLIC_ORIGIN=http://localhost:4180 \
+RIG_CERT_PATH="$HOME/.holostaff-rig/documenso-cert.p12" \
+docker compose -f rig/compose.yml up -d --build
+```
+
+Seeding: the rig creates its user through the app's own signup endpoint
+and then marks the email verified directly in Postgres (login requires a
+verified email; SMTP lands in Mailpit at `127.0.0.1:8026`).

--- a/rig/compose.yml
+++ b/rig/compose.yml
@@ -1,0 +1,70 @@
+# Holostaff deployment-rig stack for the documenso target
+# (holostaff-agent documents/prd-test-rig.md P2).
+#
+# Minimal production-shaped stack: Postgres + Mailpit + the app built
+# from THIS checkout (so merged Holostaff PRs are exercised). Jobs use
+# the default local provider (no Redis); uploads use the database
+# transport (no MinIO); only PDF uploads are exercised (no Gotenberg).
+#
+# The rig runner invokes:
+#   docker compose -f rig/compose.yml down -v   # fresh DB every run
+#   docker compose -f rig/compose.yml up -d --build
+# with RIG_APP_PORT, RIG_PUBLIC_ORIGIN and RIG_CERT_PATH in the
+# environment. RIG_CERT_PATH must point at a host-side self-signed
+# cert.p12 (the runner generates one; see rig/README.md for manual use).
+#
+# All credentials below are rig-local throwaways for an ephemeral test
+# database that never holds real data.
+
+name: rig-documenso
+
+services:
+  database:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=documenso
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=documenso
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U documenso']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mailpit:
+    image: axllent/mailpit:v1.24
+    # SMTP :1025 / web UI + API :8025, internal to the compose network.
+    # Exposed on the host for debugging verification mails if needed.
+    ports:
+      - '127.0.0.1:8026:8025'
+
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      database:
+        condition: service_healthy
+    environment:
+      - PORT=${RIG_APP_PORT:-4180}
+      - NEXTAUTH_SECRET=rig-local-nextauth-secret-2f8a1c
+      - NEXT_PRIVATE_ENCRYPTION_KEY=rig-local-encryption-key-77aa
+      - NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY=rig-local-secondary-key-88bb
+      - NEXT_PUBLIC_WEBAPP_URL=${RIG_PUBLIC_ORIGIN:-http://localhost:4180}
+      - NEXT_PRIVATE_INTERNAL_WEBAPP_URL=http://localhost:${RIG_APP_PORT:-4180}
+      - NEXT_PRIVATE_DATABASE_URL=postgresql://documenso:password@database:5432/documenso
+      - NEXT_PRIVATE_DIRECT_DATABASE_URL=postgresql://documenso:password@database:5432/documenso
+      - NEXT_PUBLIC_UPLOAD_TRANSPORT=database
+      - NEXT_PRIVATE_SMTP_TRANSPORT=smtp-auth
+      - NEXT_PRIVATE_SMTP_HOST=mailpit
+      - NEXT_PRIVATE_SMTP_PORT=1025
+      - NEXT_PRIVATE_SMTP_SECURE=false
+      - NEXT_PRIVATE_SMTP_UNSAFE_IGNORE_TLS=true
+      - NEXT_PRIVATE_SMTP_FROM_NAME=Documenso Rig
+      - NEXT_PRIVATE_SMTP_FROM_ADDRESS=noreply@rig.holostaff.ai
+      - NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=/opt/documenso/cert.p12
+      - NEXT_PRIVATE_SIGNING_PASSPHRASE=
+    ports:
+      - '${RIG_APP_PORT:-4180}:${RIG_APP_PORT:-4180}'
+    volumes:
+      - '${RIG_CERT_PATH:?set RIG_CERT_PATH to a host-side self-signed cert.p12}:/opt/documenso/cert.p12:ro'


### PR DESCRIPTION
Generated by `holostaff embed` (headless).

Wires the Holostaff widget for **Dana** into this app.
Visitors will see this copilot once the branch merges and the build deploys.

**Files changed (3):**
- `apps/remix/package.json`
- `apps/remix/app/entry.client.tsx`
- `package-lock.json`

**Install before building:** `@holostaff/sdk`, `livekit-client`