### PR TITLE
fix: use envelope title for single-item document download filename

### DIFF
--- a/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelope-download-dialog.tsx
@@ -104,6 +104,19 @@ export const EnvelopeDownloadDialog = ({
 
   const envelopeItems = envelopeItemsPayload?.data || [];
 
+  // Item titles are captured when the item is created and are never updated
+  // afterwards: renaming a document only updates the envelope title, and a
+  // document generated from a template inherits the template's item title. For a
+  // single-item envelope the item *is* the document, so use the envelope's current
+  // title for both the download filename and the displayed name so they match the
+  // document title — consistent with the audit log / signing certificate / bulk
+  // document downloads. Multi-item envelopes keep their per-item titles so the
+  // downloaded files stay distinct.
+  const envelopeTitle = envelopeItemsPayload?.envelopeTitle;
+
+  const resolveItemTitle = (item: EnvelopeItemToDownload) =>
+    envelopeItems.length === 1 && envelopeTitle ? envelopeTitle : item.title;
+
   const onDownload = async (envelopeItem: EnvelopeItemToDownload, version: 'original' | 'signed' | 'pending') => {
     const { id: envelopeItemId } = envelopeItem;
 
@@ -120,7 +133,7 @@ export const EnvelopeDownloadDialog = ({
       await downloadPDF({
         envelopeItem,
         token,
-        fileName: envelopeItem.title,
+        fileName: resolveItemTitle(envelopeItem),
         version,
       });
 
@@ -186,8 +199,8 @@ export const EnvelopeDownloadDialog = ({
 
                   <div className="min-w-0 flex-1">
                     {/* Todo: Envelopes - Fix overflow */}
-                    <h4 className="truncate font-medium text-foreground text-sm" title={item.title}>
-                      {item.title}
+                    <h4 className="truncate font-medium text-foreground text-sm" title={resolveItemTitle(item)}>
+                      {resolveItemTitle(item)}
                     </h4>
                     <p className="mt-0.5 text-muted-foreground text-xs">
                       <Trans>PDF Document</Trans>

--- a/packages/trpc/server/envelope-router/get-envelope-items-by-token.ts
+++ b/packages/trpc/server/envelope-router/get-envelope-items-by-token.ts
@@ -34,7 +34,7 @@ export const getEnvelopeItemsByTokenRoute = maybeAuthenticatedProcedure
         });
       }
 
-      const { envelopeItems: data } = await handleGetEnvelopeItemsByUser({
+      const { envelopeItems: data, envelopeTitle } = await handleGetEnvelopeItemsByUser({
         envelopeId,
         userId: user.id,
         teamId,
@@ -42,16 +42,18 @@ export const getEnvelopeItemsByTokenRoute = maybeAuthenticatedProcedure
 
       return {
         data,
+        envelopeTitle,
       };
     }
 
-    const { envelopeItems: data } = await handleGetEnvelopeItemsByToken({
+    const { envelopeItems: data, envelopeTitle } = await handleGetEnvelopeItemsByToken({
       envelopeId,
       token: access.token,
     });
 
     return {
       data,
+      envelopeTitle,
     };
   });
 
@@ -83,6 +85,7 @@ const handleGetEnvelopeItemsByToken = async ({ envelopeId, token }: { envelopeId
 
   return {
     envelopeItems: envelope.envelopeItems,
+    envelopeTitle: envelope.title,
   };
 };
 
@@ -147,5 +150,6 @@ const handleGetEnvelopeItemsByUser = async ({
 
   return {
     envelopeItems: envelope.envelopeItems,
+    envelopeTitle: envelope.title,
   };
 };

--- a/packages/trpc/server/envelope-router/get-envelope-items-by-token.types.ts
+++ b/packages/trpc/server/envelope-router/get-envelope-items-by-token.types.ts
@@ -21,4 +21,16 @@ export const ZGetEnvelopeItemsByTokenResponseSchema = z.object({
     title: true,
     order: true,
   }).array(),
+
+  /**
+   * The current title of the parent envelope (document).
+   *
+   * For a single-item envelope the item *is* the document, so the client uses this
+   * as the download filename and displayed name. Item titles are frozen at creation
+   * time and can go stale after a rename or when a document is generated from a
+   * template, whereas the envelope title always reflects the current document title.
+   *
+   * Optional so cached / initial data that predates this field still satisfies the type.
+   */
+  envelopeTitle: z.string().optional(),
 });


### PR DESCRIPTION
## Description

Downloading a document from the **Download Files** dialog names the saved file after the **envelope item** title, not the document (envelope) title. The item title is set when the item is created and is **never updated afterwards**, so:

- Renaming a document updates `envelope.title` only — item titles are left untouched.
- A document generated from a template inherits the **template's** item title.

Any renamed document — and in particular a template-generated document given a custom title — therefore downloads with a filename that no longer matches the document's title (for template-generated documents this surfaces as "the download is named after the template"). This is inconsistent with every other document-level download (bulk document PDF, audit log, signing certificate), which all use `envelope.title`.

## Related Issue

Fixes #3096

## Root cause

- `apps/remix/app/components/dialogs/envelope-download-dialog.tsx` passed `fileName: envelopeItem.title` into `downloadPDF`, and `downloadFile` builds an `<a download="...">` whose value takes precedence over the server's `Content-Disposition`. So the stale item title is what names the saved file, and the dialog's file list also shows that stale title.
- The item title diverges from the document title because renames (`update-envelope.ts`) and template instantiation (`create-document-from-template.ts`) don't keep item titles in sync with the envelope title.

## Changes Made

For a **single-item** envelope the item *is* the document, so its download filename and displayed name can use the envelope's current title, while **multi-item** envelopes keep their per-item titles so the files stay distinct.

- `get-envelope-items-by-token` tRPC route (which already loads the envelope) now also returns `envelopeTitle`. Added as an **optional** field on the response schema so existing cached / `initialData` payloads still satisfy the type.
- `EnvelopeDownloadDialog` resolves the title via a small `resolveItemTitle` helper: envelope title when there's exactly one item and it's available, otherwise the per-item title. This is used for both the download filename and the displayed name.

This mirrors the audit-log / certificate / bulk-document downloads, which already derive their filename from `envelope.title`.

## Testing Performed

- Traced the full download path (dialog → `downloadPDF` → `downloadFile`) to confirm the client-supplied `download` attribute is what names the saved file, so fixing the dialog's `fileName` resolves both the reported filename and the displayed-name symptoms.
- Verified the route already loads the envelope in both the user and recipient-token code paths, so `envelopeTitle` is available with no extra query; the `.output()` schema change is backwards-compatible (new field is optional).
- Confirmed multi-item envelopes are unaffected (`resolveItemTitle` falls back to per-item titles when `envelopeItems.length !== 1`) and that `initialData` without `envelopeTitle` still type-checks and degrades gracefully to the item title until the query resolves.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)