### PR TITLE
fix(auth): invalidate active user sessions upon OAuth revocation (#2190)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32418,6 +32418,7 @@
         "@simplewebauthn/server": "^13.2.2",
         "arctic": "^3.7.0",
         "hono": "^4.12.14",
+        "jose": "^6.1.2",
         "luxon": "^3.7.2",
         "nanoid": "^5.1.6",
         "ts-pattern": "^5.9.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,6 +5,7 @@
   "types": "./index.ts",
   "license": "MIT",
   "scripts": {
+    "test": "vitest run",
     "clean": "rimraf node_modules"
   },
   "dependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,6 +16,7 @@
     "@simplewebauthn/server": "^13.2.2",
     "arctic": "^3.7.0",
     "hono": "^4.12.14",
+    "jose": "^6.1.2",
     "luxon": "^3.7.2",
     "nanoid": "^5.1.6",
     "ts-pattern": "^5.9.0",

--- a/packages/auth/server/lib/session/session.ts
+++ b/packages/auth/server/lib/session/session.ts
@@ -3,7 +3,7 @@ import type { RequestMetadata } from '@documenso/lib/universal/extract-request-m
 import { prisma } from '@documenso/prisma';
 import { sha256 } from '@oslojs/crypto/sha2';
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
-import { type Session, type User, UserSecurityAuditLogType } from '@prisma/client';
+import { type Prisma, type Session, type User, UserSecurityAuditLogType } from '@prisma/client';
 
 import { AUTH_SESSION_LIFETIME } from '../../config';
 
@@ -159,4 +159,50 @@ export const invalidateSessions = async ({
       })),
     });
   });
+};
+
+type InvalidateAllUserSessionsOptions = {
+  userId: number;
+  metadata?: RequestMetadata;
+  isRevoke?: boolean;
+  tx?: Prisma.TransactionClient;
+};
+
+export const invalidateAllUserSessions = async ({
+  userId,
+  metadata = {},
+  isRevoke = true,
+  tx,
+}: InvalidateAllUserSessionsOptions): Promise<void> => {
+  const execute = async (client: Prisma.TransactionClient | typeof prisma) => {
+    const userSessions = await client.session.findMany({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (userSessions.length === 0) {
+      return;
+    }
+
+    await client.session.deleteMany({
+      where: { userId },
+    });
+
+    await client.userSecurityAuditLog.createMany({
+      data: userSessions.map(() => ({
+        userId,
+        ipAddress: metadata.ipAddress ?? null,
+        userAgent: metadata.userAgent ?? null,
+        type: isRevoke ? UserSecurityAuditLogType.SESSION_REVOKED : UserSecurityAuditLogType.SIGN_OUT,
+      })),
+    });
+  };
+
+  if (tx) {
+    await execute(tx);
+  } else {
+    await prisma.$transaction(async (t) => {
+      await execute(t);
+    });
+  }
 };

--- a/packages/auth/server/lib/utils/handle-oauth-revocation.test.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-revocation.test.ts
@@ -1,0 +1,230 @@
+import { AppError } from '@documenso/lib/errors/app-error';
+import { prisma } from '@documenso/prisma';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleOAuthRevocation } from './handle-oauth-revocation';
+
+vi.mock('@prisma/client', () => ({
+  UserSecurityAuditLogType: {
+    SESSION_REVOKED: 'SESSION_REVOKED',
+    SIGN_OUT: 'SIGN_OUT',
+    ACCOUNT_SSO_UNLINK: 'ACCOUNT_SSO_UNLINK',
+  },
+}));
+
+vi.mock('jose', () => ({
+  decodeJwt: vi.fn((token: string) => {
+    if (token.includes('invalid') || token.includes('throws_error')) {
+      throw new Error('Invalid JWT signature or payload');
+    }
+    const parts = token.split('.');
+    if (parts.length < 2) {
+      return {};
+    }
+    const base64Url = parts[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = Buffer.from(base64, 'base64').toString('utf8');
+    return JSON.parse(jsonPayload);
+  }),
+  jwtVerify: vi.fn().mockResolvedValue({}),
+  createRemoteJWKSet: vi.fn().mockReturnValue(() => ({})),
+}));
+
+vi.mock('./open-id', () => ({
+  getOpenIdConfiguration: vi.fn().mockResolvedValue({
+    jwks_uri: 'https://example.com/jwks',
+  }),
+}));
+
+vi.mock('@documenso/prisma', () => {
+  const mockPrisma = {
+    account: {
+      findFirst: vi.fn(),
+      delete: vi.fn(),
+    },
+    session: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    userSecurityAuditLog: {
+      createMany: vi.fn(),
+      create: vi.fn(),
+    },
+    $transaction: vi.fn().mockImplementation((cb: any) => cb(mockPrisma)),
+  };
+
+  return {
+    prisma: mockPrisma,
+    UserSecurityAuditLogType: {
+      SESSION_REVOKED: 'SESSION_REVOKED',
+      SIGN_OUT: 'SIGN_OUT',
+      ACCOUNT_SSO_UNLINK: 'ACCOUNT_SSO_UNLINK',
+    },
+  };
+});
+
+describe('OAuth Access Revocation & Session Invalidation Handler', () => {
+  const mockContext = {
+    get: vi.fn().mockReturnValue({ ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent' }),
+    json: vi.fn().mockImplementation((data, status) => ({ data, status })),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('1. should invalidate active sessions and remove account link when providerAccountId is supplied', async () => {
+    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce({
+      id: 'acc_123',
+      userId: 42,
+      provider: 'google',
+    } as any);
+    vi.mocked(prisma.session.findMany).mockResolvedValueOnce([{ id: 'sess_1' }, { id: 'sess_2' }] as any);
+    vi.mocked(prisma.session.deleteMany).mockResolvedValueOnce({ count: 2 } as any);
+    vi.mocked(prisma.userSecurityAuditLog.createMany).mockResolvedValueOnce({ count: 2 } as any);
+    vi.mocked(prisma.userSecurityAuditLog.create).mockResolvedValueOnce({} as any);
+    vi.mocked(prisma.account.delete).mockResolvedValueOnce({} as any);
+
+    const res = await handleOAuthRevocation({
+      c: mockContext as any,
+      providerAccountId: 'google_user_sub_99',
+      provider: 'google',
+    });
+
+    expect(prisma.account.findFirst).toHaveBeenCalledWith({
+      where: { providerAccountId: 'google_user_sub_99', provider: 'google' },
+      select: { id: true, userId: true, provider: true },
+    });
+    expect(prisma.session.deleteMany).toHaveBeenCalledWith({ where: { userId: 42 } });
+    expect(prisma.userSecurityAuditLog.createMany).toHaveBeenCalledWith({
+      data: [
+        { userId: 42, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'SESSION_REVOKED' },
+        { userId: 42, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'SESSION_REVOKED' },
+      ],
+    });
+    expect(prisma.account.delete).toHaveBeenCalledWith({ where: { id: 'acc_123' } });
+    expect(prisma.userSecurityAuditLog.create).toHaveBeenCalledWith({
+      data: { userId: 42, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'ACCOUNT_SSO_UNLINK' },
+    });
+    expect(res).toEqual({
+      data: { success: true, message: 'OAuth access revoked and sessions terminated' },
+      status: 200,
+    });
+  });
+
+  it('2. should handle non-existent user/account gracefully (idempotent HTTP 200)', async () => {
+    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce(null);
+
+    const res = await handleOAuthRevocation({
+      c: mockContext as any,
+      providerAccountId: 'non_existent_sub_000',
+    });
+
+    expect(prisma.account.findFirst).toHaveBeenCalledWith({
+      where: { providerAccountId: 'non_existent_sub_000' },
+      select: { id: true, userId: true, provider: true },
+    });
+    expect(prisma.session.findMany).not.toHaveBeenCalled();
+    expect(prisma.account.delete).not.toHaveBeenCalled();
+    expect(res).toEqual({
+      data: { success: true, message: 'No associated account found' },
+      status: 200,
+    });
+  });
+
+  it('3. should throw INVALID_REQUEST when neither logoutToken nor providerAccountId is provided', async () => {
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+      }),
+    ).rejects.toThrowError(AppError);
+  });
+
+  it('4. should throw INVALID_REQUEST when logout_token is malformed/invalid JWT', async () => {
+    const malformedJwt = 'header.invalid_base64_json_%%%!!!.signature';
+
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken: malformedJwt,
+      }),
+    ).rejects.toThrowError(AppError);
+  });
+
+  it('5. should parse valid logout_token JWT with sub claim, infer provider, and perform back-channel logout', async () => {
+    // Payload: {"iss":"https://accounts.google.com","sub":"backchannel_sub_456","events":{"http://schemas.openid.net/event/backchannel-logout":{} }}
+    const validLogoutToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiJiYWNrY2hhbm5lbF9zdWJfNDU2IiwiZXZlbnRzIjp7Imh0dHA6Ly9zY2hlbWFzLm9wZW5pZC5uZXQvZXZlbnQvYmFja2NoYW5uZWwtbG9nb3V0Ijp7fX19.sig';
+
+    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce({
+      id: 'acc_456',
+      userId: 88,
+      provider: 'google',
+    } as any);
+    vi.mocked(prisma.session.findMany).mockResolvedValueOnce([{ id: 'sess_bc' }] as any);
+    vi.mocked(prisma.session.deleteMany).mockResolvedValueOnce({ count: 1 } as any);
+    vi.mocked(prisma.userSecurityAuditLog.createMany).mockResolvedValueOnce({ count: 1 } as any);
+    vi.mocked(prisma.userSecurityAuditLog.create).mockResolvedValueOnce({} as any);
+    vi.mocked(prisma.account.delete).mockResolvedValueOnce({} as any);
+
+    const res = await handleOAuthRevocation({
+      c: mockContext as any,
+      logoutToken: validLogoutToken,
+    });
+
+    expect(prisma.account.findFirst).toHaveBeenCalledWith({
+      where: { providerAccountId: 'backchannel_sub_456', provider: 'google' },
+      select: { id: true, userId: true, provider: true },
+    });
+    expect(prisma.session.deleteMany).toHaveBeenCalledWith({ where: { userId: 88 } });
+    expect(prisma.account.delete).toHaveBeenCalledWith({ where: { id: 'acc_456' } });
+    expect(prisma.userSecurityAuditLog.create).toHaveBeenCalledWith({
+      data: { userId: 88, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'ACCOUNT_SSO_UNLINK' },
+    });
+    expect(res).toEqual({
+      data: { success: true, message: 'OAuth access revoked and sessions terminated' },
+      status: 200,
+    });
+  });
+
+  it('6. should throw INVALID_REQUEST when logout_token JWT lacks a sub claim', async () => {
+    // Payload: {"iss":"https://accounts.google.com","events":{"http://schemas.openid.net/event/backchannel-logout":{} }}
+    const logoutTokenNoSub =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJldmVudHMiOnsiaHR0cDovL3NjaGVtYXMub3BlbmlkLm5ldC9ldmVudC9iYWNrY2hhbm5lbC1sb2dvdXQiOnt9fX0.sig';
+
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken: logoutTokenNoSub,
+      }),
+    ).rejects.toThrowError('Missing provider account ID (sub) for revocation');
+  });
+
+  it('7. should process revocation cleanly when user has 0 active sessions', async () => {
+    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce({
+      id: 'acc_789',
+      userId: 99,
+      provider: 'microsoft',
+    } as any);
+    vi.mocked(prisma.session.findMany).mockResolvedValueOnce([]);
+    vi.mocked(prisma.account.delete).mockResolvedValueOnce({} as any);
+    vi.mocked(prisma.userSecurityAuditLog.create).mockResolvedValueOnce({} as any);
+
+    const res = await handleOAuthRevocation({
+      c: mockContext as any,
+      providerAccountId: 'ms_sub_789',
+      provider: 'microsoft',
+    });
+
+    expect(prisma.session.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.userSecurityAuditLog.createMany).not.toHaveBeenCalled();
+    expect(prisma.account.delete).toHaveBeenCalledWith({ where: { id: 'acc_789' } });
+    expect(prisma.userSecurityAuditLog.create).toHaveBeenCalledWith({
+      data: { userId: 99, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'ACCOUNT_SSO_UNLINK' },
+    });
+    expect(res).toEqual({
+      data: { success: true, message: 'OAuth access revoked and sessions terminated' },
+      status: 200,
+    });
+  });
+});

--- a/packages/auth/server/lib/utils/handle-oauth-revocation.test.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-revocation.test.ts
@@ -1,8 +1,55 @@
 import { AppError } from '@documenso/lib/errors/app-error';
 import { prisma } from '@documenso/prisma';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { handleOAuthRevocation } from './handle-oauth-revocation';
+
+const BACKCHANNEL_LOGOUT_EVENT = 'http://schemas.openid.net/event/backchannel-logout';
+
+const hoisted = vi.hoisted(() => ({
+  issuer: 'https://accounts.google.com',
+  audience: 'test-google-client-id',
+  publicJwk: null as any,
+}));
+
+vi.mock('jose', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('jose')>();
+
+  return {
+    ...actual,
+    createRemoteJWKSet: vi.fn(() =>
+      hoisted.publicJwk
+        ? actual.createLocalJWKSet({ keys: [hoisted.publicJwk] })
+        : actual.createRemoteJWKSet(new URL('https://example.com/jwks')),
+    ),
+  };
+});
+
+vi.mock('../../config', () => ({
+  GoogleAuthOptions: {
+    id: 'google',
+    clientId: hoisted.audience,
+    wellKnownUrl: 'https://accounts.google.com/.well-known/openid-configuration',
+  },
+  MicrosoftAuthOptions: {
+    id: 'microsoft',
+    clientId: 'test-microsoft-client-id',
+    wellKnownUrl: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
+  },
+  OidcAuthOptions: {
+    id: 'oidc',
+    clientId: '',
+    wellKnownUrl: '',
+  },
+}));
+
+vi.mock('./open-id', () => ({
+  getOpenIdConfiguration: vi.fn().mockResolvedValue({
+    issuer: hoisted.issuer,
+    jwks_uri: 'https://example.com/jwks',
+  }),
+}));
 
 vi.mock('@prisma/client', () => ({
   UserSecurityAuditLogType: {
@@ -10,30 +57,6 @@ vi.mock('@prisma/client', () => ({
     SIGN_OUT: 'SIGN_OUT',
     ACCOUNT_SSO_UNLINK: 'ACCOUNT_SSO_UNLINK',
   },
-}));
-
-vi.mock('jose', () => ({
-  decodeJwt: vi.fn((token: string) => {
-    if (token.includes('invalid') || token.includes('throws_error')) {
-      throw new Error('Invalid JWT signature or payload');
-    }
-    const parts = token.split('.');
-    if (parts.length < 2) {
-      return {};
-    }
-    const base64Url = parts[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const jsonPayload = Buffer.from(base64, 'base64').toString('utf8');
-    return JSON.parse(jsonPayload);
-  }),
-  jwtVerify: vi.fn().mockResolvedValue({}),
-  createRemoteJWKSet: vi.fn().mockReturnValue(() => ({})),
-}));
-
-vi.mock('./open-id', () => ({
-  getOpenIdConfiguration: vi.fn().mockResolvedValue({
-    jwks_uri: 'https://example.com/jwks',
-  }),
 }));
 
 vi.mock('@documenso/prisma', () => {
@@ -69,92 +92,58 @@ describe('OAuth Access Revocation & Session Invalidation Handler', () => {
     json: vi.fn().mockImplementation((data, status) => ({ data, status })),
   };
 
+  let privateKey: any;
+
+  const signLogoutToken = async (
+    overrides: {
+      iss?: string;
+      sub?: string;
+      nonce?: string;
+      events?: Record<string, unknown>;
+      signature?: string;
+    } = {},
+  ): Promise<string> => {
+    const jwt = new SignJWT({
+      events: overrides.events !== undefined ? overrides.events : { [BACKCHANNEL_LOGOUT_EVENT]: {} },
+      ...(overrides.nonce !== undefined ? { nonce: overrides.nonce } : {}),
+    })
+      .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
+      .setIssuer(overrides.iss ?? hoisted.issuer)
+      .setAudience(hoisted.audience)
+      .setIssuedAt()
+      .setExpirationTime('10m');
+
+    if (overrides.sub !== undefined) {
+      jwt.setSubject(overrides.sub);
+    }
+
+    const signed = await jwt.sign(privateKey);
+
+    if (overrides.signature !== undefined) {
+      const [header, payload] = signed.split('.');
+      return `${header}.${payload}.${overrides.signature}`;
+    }
+
+    return signed;
+  };
+
+  beforeAll(async () => {
+    const { publicKey, privateKey: signingKey } = await generateKeyPair('RS256');
+    const publicJwk = await exportJWK(publicKey);
+
+    publicJwk.alg = 'RS256';
+    publicJwk.use = 'sig';
+
+    hoisted.publicJwk = publicJwk;
+    privateKey = signingKey;
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('1. should invalidate active sessions and remove account link when providerAccountId is supplied', async () => {
-    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce({
-      id: 'acc_123',
-      userId: 42,
-      provider: 'google',
-    } as any);
-    vi.mocked(prisma.session.findMany).mockResolvedValueOnce([{ id: 'sess_1' }, { id: 'sess_2' }] as any);
-    vi.mocked(prisma.session.deleteMany).mockResolvedValueOnce({ count: 2 } as any);
-    vi.mocked(prisma.userSecurityAuditLog.createMany).mockResolvedValueOnce({ count: 2 } as any);
-    vi.mocked(prisma.userSecurityAuditLog.create).mockResolvedValueOnce({} as any);
-    vi.mocked(prisma.account.delete).mockResolvedValueOnce({} as any);
-
-    const res = await handleOAuthRevocation({
-      c: mockContext as any,
-      providerAccountId: 'google_user_sub_99',
-      provider: 'google',
-    });
-
-    expect(prisma.account.findFirst).toHaveBeenCalledWith({
-      where: { providerAccountId: 'google_user_sub_99', provider: 'google' },
-      select: { id: true, userId: true, provider: true },
-    });
-    expect(prisma.session.deleteMany).toHaveBeenCalledWith({ where: { userId: 42 } });
-    expect(prisma.userSecurityAuditLog.createMany).toHaveBeenCalledWith({
-      data: [
-        { userId: 42, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'SESSION_REVOKED' },
-        { userId: 42, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'SESSION_REVOKED' },
-      ],
-    });
-    expect(prisma.account.delete).toHaveBeenCalledWith({ where: { id: 'acc_123' } });
-    expect(prisma.userSecurityAuditLog.create).toHaveBeenCalledWith({
-      data: { userId: 42, ipAddress: '127.0.0.1', userAgent: 'Vitest-Agent', type: 'ACCOUNT_SSO_UNLINK' },
-    });
-    expect(res).toEqual({
-      data: { success: true, message: 'OAuth access revoked and sessions terminated' },
-      status: 200,
-    });
-  });
-
-  it('2. should handle non-existent user/account gracefully (idempotent HTTP 200)', async () => {
-    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce(null);
-
-    const res = await handleOAuthRevocation({
-      c: mockContext as any,
-      providerAccountId: 'non_existent_sub_000',
-    });
-
-    expect(prisma.account.findFirst).toHaveBeenCalledWith({
-      where: { providerAccountId: 'non_existent_sub_000' },
-      select: { id: true, userId: true, provider: true },
-    });
-    expect(prisma.session.findMany).not.toHaveBeenCalled();
-    expect(prisma.account.delete).not.toHaveBeenCalled();
-    expect(res).toEqual({
-      data: { success: true, message: 'No associated account found' },
-      status: 200,
-    });
-  });
-
-  it('3. should throw INVALID_REQUEST when neither logoutToken nor providerAccountId is provided', async () => {
-    await expect(
-      handleOAuthRevocation({
-        c: mockContext as any,
-      }),
-    ).rejects.toThrowError(AppError);
-  });
-
-  it('4. should throw INVALID_REQUEST when logout_token is malformed/invalid JWT', async () => {
-    const malformedJwt = 'header.invalid_base64_json_%%%!!!.signature';
-
-    await expect(
-      handleOAuthRevocation({
-        c: mockContext as any,
-        logoutToken: malformedJwt,
-      }),
-    ).rejects.toThrowError(AppError);
-  });
-
-  it('5. should parse valid logout_token JWT with sub claim, infer provider, and perform back-channel logout', async () => {
-    // Payload: {"iss":"https://accounts.google.com","sub":"backchannel_sub_456","events":{"http://schemas.openid.net/event/backchannel-logout":{} }}
-    const validLogoutToken =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiJiYWNrY2hhbm5lbF9zdWJfNDU2IiwiZXZlbnRzIjp7Imh0dHA6Ly9zY2hlbWFzLm9wZW5pZC5uZXQvZXZlbnQvYmFja2NoYW5uZWwtbG9nb3V0Ijp7fX19.sig';
+  it('1. verifies a real signed logout token, invalidates sessions and unlinks the account', async () => {
+    const logoutToken = await signLogoutToken({ sub: 'backchannel_sub_456' });
 
     vi.mocked(prisma.account.findFirst).mockResolvedValueOnce({
       id: 'acc_456',
@@ -169,7 +158,7 @@ describe('OAuth Access Revocation & Session Invalidation Handler', () => {
 
     const res = await handleOAuthRevocation({
       c: mockContext as any,
-      logoutToken: validLogoutToken,
+      logoutToken,
     });
 
     expect(prisma.account.findFirst).toHaveBeenCalledWith({
@@ -187,24 +176,98 @@ describe('OAuth Access Revocation & Session Invalidation Handler', () => {
     });
   });
 
-  it('6. should throw INVALID_REQUEST when logout_token JWT lacks a sub claim', async () => {
-    // Payload: {"iss":"https://accounts.google.com","events":{"http://schemas.openid.net/event/backchannel-logout":{} }}
-    const logoutTokenNoSub =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJldmVudHMiOnsiaHR0cDovL3NjaGVtYXMub3BlbmlkLm5ldC9ldmVudC9iYWNrY2hhbm5lbC1sb2dvdXQiOnt9fX0.sig';
+  it('2. returns idempotent 200 when the account no longer exists', async () => {
+    vi.mocked(prisma.account.findFirst).mockResolvedValueOnce(null);
+
+    const res = await handleOAuthRevocation({
+      c: mockContext as any,
+      logoutToken: await signLogoutToken({ sub: 'non_existent_sub_000' }),
+    });
+
+    expect(prisma.session.findMany).not.toHaveBeenCalled();
+    expect(prisma.account.delete).not.toHaveBeenCalled();
+    expect(res).toEqual({
+      data: { success: true, message: 'No associated account found' },
+      status: 200,
+    });
+  });
+
+  it('3. throws INVALID_REQUEST when no logout token is provided', async () => {
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+      }),
+    ).rejects.toThrowError(AppError);
+  });
+
+  it('4. throws INVALID_REQUEST for a malformed JWT', async () => {
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken: 'header.invalid_payload.signature',
+      }),
+    ).rejects.toThrowError(AppError);
+  });
+
+  it('5. rejects a token with a tampered signature before touching the database', async () => {
+    const logoutToken = await signLogoutToken({
+      sub: 'backchannel_sub_456',
+      signature: 'tampered_signature',
+    });
 
     await expect(
       handleOAuthRevocation({
         c: mockContext as any,
-        logoutToken: logoutTokenNoSub,
+        logoutToken,
       }),
-    ).rejects.toThrowError('Missing provider account ID (sub) for revocation');
+    ).rejects.toThrowError(AppError);
+
+    expect(prisma.account.findFirst).not.toHaveBeenCalled();
   });
 
-  it('7. should process revocation cleanly when user has 0 active sessions', async () => {
+  it('6. rejects a token whose issuer does not match the pinned provider issuer', async () => {
+    const logoutToken = await signLogoutToken({
+      iss: 'https://accounts.google.com.evil.com',
+      sub: 'backchannel_sub_456',
+    });
+
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken,
+      }),
+    ).rejects.toThrowError(AppError);
+
+    expect(prisma.account.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('7. rejects a validly signed token without a subject (sub) claim', async () => {
+    const logoutToken = await signLogoutToken({});
+
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken,
+      }),
+    ).rejects.toThrowError('Logout token is missing the subject (sub) claim');
+  });
+
+  it('8. rejects a logout token containing a nonce', async () => {
+    const logoutToken = await signLogoutToken({ sub: 'backchannel_sub_456', nonce: 'unexpected' });
+
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken,
+      }),
+    ).rejects.toThrowError('Logout token must not contain a nonce');
+  });
+
+  it('9. unlinks the account and logs even when the user has no active sessions', async () => {
     vi.mocked(prisma.account.findFirst).mockResolvedValueOnce({
       id: 'acc_789',
       userId: 99,
-      provider: 'microsoft',
+      provider: 'google',
     } as any);
     vi.mocked(prisma.session.findMany).mockResolvedValueOnce([]);
     vi.mocked(prisma.account.delete).mockResolvedValueOnce({} as any);
@@ -212,8 +275,7 @@ describe('OAuth Access Revocation & Session Invalidation Handler', () => {
 
     const res = await handleOAuthRevocation({
       c: mockContext as any,
-      providerAccountId: 'ms_sub_789',
-      provider: 'microsoft',
+      logoutToken: await signLogoutToken({ sub: 'ms_sub_789' }),
     });
 
     expect(prisma.session.deleteMany).not.toHaveBeenCalled();
@@ -226,5 +288,18 @@ describe('OAuth Access Revocation & Session Invalidation Handler', () => {
       data: { success: true, message: 'OAuth access revoked and sessions terminated' },
       status: 200,
     });
+  });
+
+  it('10. rejects a validly signed token without the back-channel logout event', async () => {
+    const logoutToken = await signLogoutToken({ sub: 'backchannel_sub_456', events: {} });
+
+    await expect(
+      handleOAuthRevocation({
+        c: mockContext as any,
+        logoutToken,
+      }),
+    ).rejects.toThrowError('Missing back-channel logout event claim');
+
+    expect(prisma.account.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth/server/lib/utils/handle-oauth-revocation.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-revocation.ts
@@ -11,99 +11,119 @@ import { getOpenIdConfiguration } from './open-id';
 type HandleOAuthRevocationOptions = {
   c: Context;
   logoutToken?: string;
-  providerAccountId?: string;
-  provider?: string;
 };
 
-export const handleOAuthRevocation = async (options: HandleOAuthRevocationOptions) => {
-  const { c, logoutToken, providerAccountId, provider } = options;
+type ResolvedClientOptions = {
+  clientOptions: typeof GoogleAuthOptions;
+  provider: string;
+};
 
-  const requestMeta = c.get('requestMetadata') ?? {};
-  let targetSub = providerAccountId;
-  let detectedProvider = provider;
+const BACKCHANNEL_LOGOUT_EVENT = 'http://schemas.openid.net/event/backchannel-logout';
 
-  if (logoutToken) {
-    try {
-      // Decode JWT without verification to read the issuer (iss)
-      const decoded = decodeJwt(logoutToken);
-      const iss = decoded.iss;
-
-      if (typeof iss !== 'string') {
-        throw new Error('Missing issuer (iss) claim');
-      }
-
-      // Match OIDC provider client configuration and provider name based on issuer
-      let clientOptions: typeof GoogleAuthOptions;
-      if (iss.includes('accounts.google.com')) {
-        clientOptions = GoogleAuthOptions;
-        detectedProvider = detectedProvider ?? 'google';
-      } else if (iss.includes('login.microsoftonline.com')) {
-        clientOptions = MicrosoftAuthOptions;
-        detectedProvider = detectedProvider ?? 'microsoft';
-      } else if (OidcAuthOptions.wellKnownUrl) {
-        clientOptions = OidcAuthOptions;
-        detectedProvider = detectedProvider ?? 'oidc';
-      } else {
-        throw new Error(`Unsupported issuer: ${iss}`);
-      }
-
-      // Retrieve public keys (JWKS) via OIDC discovery
-      const oidcConfig = await getOpenIdConfiguration(clientOptions.wellKnownUrl);
-      const jwksUri = oidcConfig.jwks_uri;
-      if (!jwksUri) {
-        throw new Error('OIDC provider configuration lacks jwks_uri');
-      }
-
-      // Verify signature and claims (iss, aud, exp) cryptographically
-      const JWKS = createRemoteJWKSet(new URL(jwksUri));
-      await jwtVerify(logoutToken, JWKS, {
-        issuer: iss,
-        audience: clientOptions.clientId,
-      });
-
-      // Assert OIDC Back-Channel Logout specific requirements
-      const events = decoded.events as Record<string, unknown> | undefined;
-      if (!events || !events['http://schemas.openid.net/event/backchannel-logout']) {
-        throw new Error('Missing back-channel logout event claim');
-      }
-
-      if (decoded.nonce) {
-        throw new Error('Logout token must not contain a nonce');
-      }
-
-      if (decoded.sub && typeof decoded.sub === 'string') {
-        targetSub = decoded.sub;
-      } else if (decoded.sid && typeof decoded.sid === 'string') {
-        targetSub = decoded.sid;
-      }
-    } catch (err) {
-      if (err instanceof Error) {
-        console.error('OAuth revocation JWT error:', err.message);
-      }
-      throw new AppError(AppErrorCode.INVALID_REQUEST, {
-        message: err instanceof Error ? err.message : 'Invalid logout_token signature or claims',
-      });
-    }
+const resolveClientOptions = (iss: string): ResolvedClientOptions => {
+  if (iss.includes('accounts.google.com')) {
+    return { clientOptions: GoogleAuthOptions, provider: 'google' };
   }
 
-  if (!targetSub) {
+  if (iss.includes('login.microsoftonline.com')) {
+    return { clientOptions: MicrosoftAuthOptions, provider: 'microsoft' };
+  }
+
+  if (OidcAuthOptions.wellKnownUrl) {
+    return { clientOptions: OidcAuthOptions, provider: 'oidc' };
+  }
+
+  throw new Error(`Unsupported issuer: ${iss}`);
+};
+
+type VerifyLogoutTokenResult = {
+  sub: string;
+  provider: string;
+};
+
+const verifyLogoutToken = async (logoutToken: string): Promise<VerifyLogoutTokenResult> => {
+  // Decode JWT without verification to read the issuer (iss).
+  const decoded = decodeJwt(logoutToken);
+  const iss = decoded.iss;
+
+  if (typeof iss !== 'string') {
+    throw new Error('Missing issuer (iss) claim');
+  }
+
+  const { clientOptions, provider } = resolveClientOptions(iss);
+
+  // Retrieve provider metadata (issuer + JWKS) via OIDC discovery.
+  const oidcConfig = await getOpenIdConfiguration(clientOptions.wellKnownUrl);
+  const jwksUri = oidcConfig.jwks_uri;
+
+  if (!jwksUri) {
+    throw new Error('OIDC provider configuration lacks jwks_uri');
+  }
+
+  // Pin the issuer to the value advertised by the provider discovery document.
+  // Multi-tenant providers (e.g. Microsoft "common") expose a `{tenantid}`
+  // placeholder, so they fall back to the token's own issuer.
+  const discoveredIssuer = oidcConfig.issuer;
+  const expectedIssuer = discoveredIssuer && !discoveredIssuer.includes('{tenantid}') ? discoveredIssuer : iss;
+
+  // Verify signature and claims (iss, aud, exp) cryptographically.
+  const JWKS = createRemoteJWKSet(new URL(jwksUri));
+
+  const { payload } = await jwtVerify(logoutToken, JWKS, {
+    issuer: expectedIssuer,
+    audience: clientOptions.clientId,
+  });
+
+  // Assert OIDC Back-Channel Logout specific requirements on the verified payload.
+  const events = payload.events as Record<string, unknown> | undefined;
+
+  if (!events || !events[BACKCHANNEL_LOGOUT_EVENT]) {
+    throw new Error('Missing back-channel logout event claim');
+  }
+
+  if (payload.nonce) {
+    throw new Error('Logout token must not contain a nonce');
+  }
+
+  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+    throw new Error('Logout token is missing the subject (sub) claim');
+  }
+
+  return { sub: payload.sub, provider };
+};
+
+export const handleOAuthRevocation = async ({ c, logoutToken }: HandleOAuthRevocationOptions) => {
+  const requestMeta = c.get('requestMetadata') ?? {};
+
+  if (!logoutToken) {
     throw new AppError(AppErrorCode.INVALID_REQUEST, {
-      message: 'Missing provider account ID (sub) for revocation',
+      message: 'Missing logout_token for revocation',
     });
   }
 
-  const whereCondition: { providerAccountId: string; provider?: string } = {
-    providerAccountId: targetSub,
-  };
+  let targetSub: string;
+  let detectedProvider: string;
 
-  if (detectedProvider) {
-    whereCondition.provider = detectedProvider;
+  try {
+    ({ sub: targetSub, provider: detectedProvider } = await verifyLogoutToken(logoutToken));
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error('OAuth revocation JWT error:', err.message);
+    }
+
+    throw new AppError(AppErrorCode.INVALID_REQUEST, {
+      message: err instanceof Error ? err.message : 'Invalid logout_token signature or claims',
+    });
   }
 
-  // Execute database query, session invalidation, audit logging, and account deletion inside an atomic transaction
+  // Execute database query, session invalidation, audit logging, and account
+  // deletion inside an atomic transaction.
   return await prisma.$transaction(async (tx) => {
     const existingAccount = await tx.account.findFirst({
-      where: whereCondition,
+      where: {
+        providerAccountId: targetSub,
+        provider: detectedProvider,
+      },
       select: {
         id: true,
         userId: true,

--- a/packages/auth/server/lib/utils/handle-oauth-revocation.ts
+++ b/packages/auth/server/lib/utils/handle-oauth-revocation.ts
@@ -1,0 +1,145 @@
+import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { prisma } from '@documenso/prisma';
+import { UserSecurityAuditLogType } from '@prisma/client';
+import type { Context } from 'hono';
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
+
+import { GoogleAuthOptions, MicrosoftAuthOptions, OidcAuthOptions } from '../../config';
+import { invalidateAllUserSessions } from '../session/session';
+import { getOpenIdConfiguration } from './open-id';
+
+type HandleOAuthRevocationOptions = {
+  c: Context;
+  logoutToken?: string;
+  providerAccountId?: string;
+  provider?: string;
+};
+
+export const handleOAuthRevocation = async (options: HandleOAuthRevocationOptions) => {
+  const { c, logoutToken, providerAccountId, provider } = options;
+
+  const requestMeta = c.get('requestMetadata') ?? {};
+  let targetSub = providerAccountId;
+  let detectedProvider = provider;
+
+  if (logoutToken) {
+    try {
+      // Decode JWT without verification to read the issuer (iss)
+      const decoded = decodeJwt(logoutToken);
+      const iss = decoded.iss;
+
+      if (typeof iss !== 'string') {
+        throw new Error('Missing issuer (iss) claim');
+      }
+
+      // Match OIDC provider client configuration and provider name based on issuer
+      let clientOptions: typeof GoogleAuthOptions;
+      if (iss.includes('accounts.google.com')) {
+        clientOptions = GoogleAuthOptions;
+        detectedProvider = detectedProvider ?? 'google';
+      } else if (iss.includes('login.microsoftonline.com')) {
+        clientOptions = MicrosoftAuthOptions;
+        detectedProvider = detectedProvider ?? 'microsoft';
+      } else if (OidcAuthOptions.wellKnownUrl) {
+        clientOptions = OidcAuthOptions;
+        detectedProvider = detectedProvider ?? 'oidc';
+      } else {
+        throw new Error(`Unsupported issuer: ${iss}`);
+      }
+
+      // Retrieve public keys (JWKS) via OIDC discovery
+      const oidcConfig = await getOpenIdConfiguration(clientOptions.wellKnownUrl);
+      const jwksUri = oidcConfig.jwks_uri;
+      if (!jwksUri) {
+        throw new Error('OIDC provider configuration lacks jwks_uri');
+      }
+
+      // Verify signature and claims (iss, aud, exp) cryptographically
+      const JWKS = createRemoteJWKSet(new URL(jwksUri));
+      await jwtVerify(logoutToken, JWKS, {
+        issuer: iss,
+        audience: clientOptions.clientId,
+      });
+
+      // Assert OIDC Back-Channel Logout specific requirements
+      const events = decoded.events as Record<string, unknown> | undefined;
+      if (!events || !events['http://schemas.openid.net/event/backchannel-logout']) {
+        throw new Error('Missing back-channel logout event claim');
+      }
+
+      if (decoded.nonce) {
+        throw new Error('Logout token must not contain a nonce');
+      }
+
+      if (decoded.sub && typeof decoded.sub === 'string') {
+        targetSub = decoded.sub;
+      } else if (decoded.sid && typeof decoded.sid === 'string') {
+        targetSub = decoded.sid;
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error('OAuth revocation JWT error:', err.message);
+      }
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: err instanceof Error ? err.message : 'Invalid logout_token signature or claims',
+      });
+    }
+  }
+
+  if (!targetSub) {
+    throw new AppError(AppErrorCode.INVALID_REQUEST, {
+      message: 'Missing provider account ID (sub) for revocation',
+    });
+  }
+
+  const whereCondition: { providerAccountId: string; provider?: string } = {
+    providerAccountId: targetSub,
+  };
+
+  if (detectedProvider) {
+    whereCondition.provider = detectedProvider;
+  }
+
+  // Execute database query, session invalidation, audit logging, and account deletion inside an atomic transaction
+  return await prisma.$transaction(async (tx) => {
+    const existingAccount = await tx.account.findFirst({
+      where: whereCondition,
+      select: {
+        id: true,
+        userId: true,
+        provider: true,
+      },
+    });
+
+    if (!existingAccount) {
+      return c.json({ success: true, message: 'No associated account found' }, 200);
+    }
+
+    // 1. Invalidate all active user sessions inside the transaction
+    await invalidateAllUserSessions({
+      userId: existingAccount.userId,
+      metadata: requestMeta,
+      isRevoke: true,
+      tx,
+    });
+
+    // 2. Remove the revoked OAuth account link inside the transaction
+    await tx.account.delete({
+      where: {
+        id: existingAccount.id,
+      },
+    });
+
+    // 3. Create security audit log entry for account SSO unlinking
+    await tx.userSecurityAuditLog.create({
+      data: {
+        userId: existingAccount.userId,
+        ipAddress: requestMeta.ipAddress ?? null,
+        userAgent: requestMeta.userAgent ?? null,
+        type: UserSecurityAuditLogType.ACCOUNT_SSO_UNLINK,
+      },
+    });
+
+    return c.json({ success: true, message: 'OAuth access revoked and sessions terminated' }, 200);
+  });
+};

--- a/packages/auth/server/lib/utils/open-id.ts
+++ b/packages/auth/server/lib/utils/open-id.ts
@@ -4,6 +4,7 @@ const ZOpenIdConfigurationSchema = z.object({
   authorization_endpoint: z.string(),
   token_endpoint: z.string(),
   scopes_supported: z.array(z.string()).optional(),
+  jwks_uri: z.string().optional(),
 });
 
 type OpenIdConfiguration = z.infer<typeof ZOpenIdConfigurationSchema>;

--- a/packages/auth/server/lib/utils/open-id.ts
+++ b/packages/auth/server/lib/utils/open-id.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 const ZOpenIdConfigurationSchema = z.object({
+  issuer: z.string().optional(),
   authorization_endpoint: z.string(),
   token_endpoint: z.string(),
   scopes_supported: z.array(z.string()).optional(),
@@ -13,23 +14,45 @@ type GetOpenIdConfigurationOptions = {
   requiredScopes?: string[];
 };
 
+const OPEN_ID_CONFIGURATION_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry = {
+  config: OpenIdConfiguration;
+  expiresAt: number;
+};
+
+const openIdConfigurationCache = new Map<string, CacheEntry>();
+
 export const getOpenIdConfiguration = async (
   wellKnownUrl: string,
   options: GetOpenIdConfigurationOptions = {},
 ): Promise<OpenIdConfiguration> => {
-  const response = await fetch(wellKnownUrl);
+  const cached = openIdConfigurationCache.get(wellKnownUrl);
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch OIDC configuration: ${response.statusText}`);
-  }
+  let config: OpenIdConfiguration;
 
-  const rawConfig = await response.json();
+  if (cached && cached.expiresAt > Date.now()) {
+    config = cached.config;
+  } else {
+    const response = await fetch(wellKnownUrl);
 
-  const config = ZOpenIdConfigurationSchema.parse(rawConfig);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OIDC configuration: ${response.statusText}`);
+    }
 
-  // Validate required endpoints
-  if (!config.authorization_endpoint) {
-    throw new Error('Missing authorization_endpoint in OIDC configuration');
+    const rawConfig = await response.json();
+
+    config = ZOpenIdConfigurationSchema.parse(rawConfig);
+
+    // Validate required endpoints
+    if (!config.authorization_endpoint) {
+      throw new Error('Missing authorization_endpoint in OIDC configuration');
+    }
+
+    openIdConfigurationCache.set(wellKnownUrl, {
+      config,
+      expiresAt: Date.now() + OPEN_ID_CONFIGURATION_CACHE_TTL_MS,
+    });
   }
 
   const supportedScopes = config.scopes_supported ?? [];

--- a/packages/auth/server/routes/oauth.ts
+++ b/packages/auth/server/routes/oauth.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { GoogleAuthOptions, MicrosoftAuthOptions, OidcAuthOptions } from '../config';
 import { handleOAuthAuthorizeUrl } from '../lib/utils/handle-oauth-authorize-url';
+import { handleOAuthRevocation } from '../lib/utils/handle-oauth-revocation';
 import { getOrganisationAuthenticationPortalOptions } from '../lib/utils/organisation-portal';
 import type { HonoAuthContext } from '../types/context';
 
@@ -65,5 +66,24 @@ export const oauthRoute = new Hono<HonoAuthContext>()
       c,
       clientOptions,
       prompt: 'select_account',
+    });
+  })
+  /**
+   * OpenID Connect Back-Channel Logout & OAuth Revocation endpoint.
+   */
+  .post('/backchannel-logout', async (c) => {
+    let logoutToken: string | undefined;
+    const contentType = c.req.header('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      const json = await c.req.json().catch(() => ({}));
+      logoutToken = typeof json.logout_token === 'string' ? json.logout_token : undefined;
+    } else {
+      const body = await c.req.parseBody().catch(() => ({}));
+      logoutToken = typeof body.logout_token === 'string' ? body.logout_token : undefined;
+    }
+
+    return handleOAuthRevocation({
+      c,
+      logoutToken,
     });
   });


### PR DESCRIPTION
Invalidates active database sessions and deletes OAuth account links upon receiving OAuth revocation or OIDC back-channel logout requests. Closes #2190.