### PR TITLE
Complete benchmark task 2 with S model

### DIFF
--- a/packages/lib/constants/envelope-reminder.test.ts
+++ b/packages/lib/constants/envelope-reminder.test.ts
@@ -1,0 +1,287 @@
+import { Duration } from 'luxon';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+  MAX_REMINDERS_BEFORE_RESEND,
+  MAX_REMINDER_WINDOW_DAYS,
+  deriveEffectiveReminderSettings,
+  getEnvelopeReminderDuration,
+  resolveNextReminderAt,
+  type TEnvelopeReminderDurationPeriod,
+  type TEnvelopeReminderSettings,
+} from './envelope-reminder';
+
+const ENABLED_SEND_AFTER: TEnvelopeReminderDurationPeriod = { unit: 'day', amount: 5 };
+const ENABLED_REPEAT_EVERY: TEnvelopeReminderDurationPeriod = { unit: 'day', amount: 2 };
+
+const ENABLED: TEnvelopeReminderSettings = {
+  sendAfter: ENABLED_SEND_AFTER,
+  repeatEvery: ENABLED_REPEAT_EVERY,
+};
+
+const DISABLED: TEnvelopeReminderSettings = {
+  sendAfter: { disabled: true },
+  repeatEvery: { disabled: true },
+};
+
+describe('deriveEffectiveReminderSettings', () => {
+  it('uses the document override when present', () => {
+    const doc: TEnvelopeReminderSettings = {
+      sendAfter: { unit: 'week', amount: 1 },
+      repeatEvery: { disabled: true },
+    };
+
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: doc,
+      teamReminderSettings: ENABLED,
+      organisationReminderSettings: ENABLED,
+    });
+
+    expect(result).toEqual(doc);
+  });
+
+  it('prefers document over team and organisation', () => {
+    const doc: TEnvelopeReminderSettings = {
+      sendAfter: { unit: 'day', amount: 1 },
+      repeatEvery: { unit: 'day', amount: 1 },
+    };
+
+    const team: TEnvelopeReminderSettings = {
+      sendAfter: { unit: 'day', amount: 9 },
+      repeatEvery: { unit: 'day', amount: 9 },
+    };
+
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: doc,
+      teamReminderSettings: team,
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(doc);
+  });
+
+  it('inherits the team setting when the document does not override', () => {
+    const team: TEnvelopeReminderSettings = {
+      sendAfter: { unit: 'week', amount: 2 },
+      repeatEvery: { unit: 'day', amount: 3 },
+    };
+
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: null,
+      teamReminderSettings: team,
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(team);
+  });
+
+  it('inherits the enabled organisation default when both document and team inherit', () => {
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: null,
+      teamReminderSettings: null,
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(DEFAULT_ENVELOPE_REMINDER_SETTINGS);
+  });
+
+  it('returns null (disabled) when every level inherits and org has no default', () => {
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: null,
+      teamReminderSettings: null,
+      organisationReminderSettings: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('treats explicitly disabled settings as a real override (does not fall through)', () => {
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: DISABLED,
+      teamReminderSettings: ENABLED,
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(DISABLED);
+  });
+
+  it('lets an explicitly disabled team setting cascade past an inheriting document', () => {
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: null,
+      teamReminderSettings: DISABLED,
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(DISABLED);
+  });
+
+  it('treats undefined and JSON-null markers as inherit, not as disabled', () => {
+    // JSON columns may contain a JSON-null marker (e.g. Prisma.DbNull) which
+    // is a non-null runtime value but does NOT match the settings schema. The
+    // cascade must skip it and fall through to the organisation default.
+    const jsonNullMarker = Object.create(null);
+
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: undefined,
+      teamReminderSettings: jsonNullMarker,
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(DEFAULT_ENVELOPE_REMINDER_SETTINGS);
+  });
+
+  it('ignores malformed values at a level and continues the cascade', () => {
+    const result = deriveEffectiveReminderSettings({
+      documentReminderSettings: { sendAfter: { disabled: true } }, // missing repeatEvery
+      teamReminderSettings: 'not-an-object',
+      organisationReminderSettings: DEFAULT_ENVELOPE_REMINDER_SETTINGS,
+    });
+
+    expect(result).toEqual(DEFAULT_ENVELOPE_REMINDER_SETTINGS);
+  });
+});
+
+describe('resolveNextReminderAt', () => {
+  const sentAt = new Date('2026-01-01T00:00:00.000Z');
+
+  it('returns null when config is null (no effective settings)', () => {
+    expect(
+      resolveNextReminderAt({
+        config: null,
+        sentAt,
+        lastReminderSentAt: null,
+        reminderCount: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it('schedules the first reminder using sendAfter when nothing has been sent yet', () => {
+    const result = resolveNextReminderAt({
+      config: ENABLED,
+      sentAt,
+      lastReminderSentAt: null,
+      reminderCount: 0,
+    });
+
+    const expected = new Date(sentAt.getTime() + getEnvelopeReminderDuration(ENABLED_SEND_AFTER).toMillis());
+
+    expect(result).toEqual(expected);
+  });
+
+  it('returns null when the first reminder is explicitly disabled', () => {
+    const result = resolveNextReminderAt({
+      config: { sendAfter: { disabled: true }, repeatEvery: { unit: 'day', amount: 2 } },
+      sentAt,
+      lastReminderSentAt: null,
+      reminderCount: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('schedules subsequent reminders using repeatEvery', () => {
+    const lastReminderSentAt = new Date('2026-01-06T00:00:00.000Z');
+
+    const result = resolveNextReminderAt({
+      config: ENABLED,
+      sentAt,
+      lastReminderSentAt,
+      reminderCount: 1,
+    });
+
+    const expected = new Date(
+      lastReminderSentAt.getTime() + getEnvelopeReminderDuration(ENABLED_REPEAT_EVERY).toMillis(),
+    );
+
+    expect(result).toEqual(expected);
+  });
+
+  it('returns null when repeatEvery is explicitly disabled', () => {
+    const lastReminderSentAt = new Date('2026-01-06T00:00:00.000Z');
+
+    const result = resolveNextReminderAt({
+      config: { sendAfter: { unit: 'day', amount: 5 }, repeatEvery: { disabled: true } },
+      sentAt,
+      lastReminderSentAt,
+      reminderCount: 1,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('stops scheduling after MAX_REMINDERS_BEFORE_RESEND reminders have been sent', () => {
+    // After the 5th reminder, reminderCount is 5 — the 6th must not be scheduled.
+    const lastReminderSentAt = new Date(
+      sentAt.getTime() + Duration.fromObject({ days: 13 }).toMillis(),
+    );
+
+    const result = resolveNextReminderAt({
+      config: ENABLED,
+      sentAt,
+      lastReminderSentAt,
+      reminderCount: MAX_REMINDERS_BEFORE_RESEND,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('still schedules the 5th reminder boundary (reminderCount < MAX)', () => {
+    // reminderCount = 4 means 4 reminders already sent, scheduling the 5th.
+    const lastReminderSentAt = new Date(
+      sentAt.getTime() + Duration.fromObject({ days: 11 }).toMillis(),
+    );
+
+    const result = resolveNextReminderAt({
+      config: ENABLED,
+      sentAt,
+      lastReminderSentAt,
+      reminderCount: MAX_REMINDERS_BEFORE_RESEND - 1,
+    });
+
+    expect(result).not.toBeNull();
+  });
+
+  it('stops scheduling when the candidate falls outside the 30-day window', () => {
+    // Configure a long repeat that would push past the 30-day cap.
+    const config: TEnvelopeReminderSettings = {
+      sendAfter: { unit: 'day', amount: 29 },
+      repeatEvery: { unit: 'week', amount: 2 },
+    };
+
+    const firstReminder = resolveNextReminderAt({
+      config,
+      sentAt,
+      lastReminderSentAt: null,
+      reminderCount: 0,
+    });
+
+    expect(firstReminder).not.toBeNull();
+
+    // Simulate having sent that first reminder; the repeat (2 weeks) is past day 30.
+    const secondReminder = resolveNextReminderAt({
+      config,
+      sentAt,
+      lastReminderSentAt: firstReminder,
+      reminderCount: 1,
+    });
+
+    expect(secondReminder).toBeNull();
+  });
+
+  it('never schedules beyond MAX_REMINDER_WINDOW_DAYS from sentAt', () => {
+    const config: TEnvelopeReminderSettings = {
+      sendAfter: { unit: 'day', amount: MAX_REMINDER_WINDOW_DAYS + 1 },
+      repeatEvery: { unit: 'day', amount: 1 },
+    };
+
+    const result = resolveNextReminderAt({
+      config,
+      sentAt,
+      lastReminderSentAt: null,
+      reminderCount: 0,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/lib/constants/envelope-reminder.ts
+++ b/packages/lib/constants/envelope-reminder.ts
@@ -53,9 +53,81 @@ export const getEnvelopeReminderDuration = (period: TEnvelopeReminderDurationPer
 };
 
 /**
+ * Parse a raw reminder-settings value (coming from a JSON column or an
+ * incoming payload) into a concrete `TEnvelopeReminderSettings`.
+ *
+ * Returns `null` when the value is absent (`null`/`undefined`), a JSON null
+ * marker (e.g. `Prisma.DbNull`) or does not match the schema. This lets the
+ * cascade treat "no value" the same as "inherit from the next level up".
+ */
+const parseReminderSettings = (raw: unknown): TEnvelopeReminderSettings | null => {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+
+  const result = ZEnvelopeReminderSettings.safeParse(raw);
+
+  return result.success ? result.data : null;
+};
+
+/**
+ * Resolve the effective reminder settings that apply to an envelope, given
+ * the raw values stored at each level of the cascade.
+ *
+ * The cascade is:
+ *   1. Document-level override (when set)
+ *   2. Team-level override (when set)
+ *   3. Organisation-level default (when set)
+ *   4. `null` (reminders disabled) when nothing is configured
+ *
+ * Each level may be:
+ *   - a valid `TEnvelopeReminderSettings` object (enabled or explicitly disabled)
+ *   - `null`/`undefined`/JSON-null (inherit from the level below)
+ *
+ * An explicitly disabled config (`{ sendAfter: { disabled: true }, repeatEvery:
+ * { disabled: true } }`) is a real override — it stops the cascade and is
+ * returned as-is so that `resolveNextReminderAt` honours the "no reminders"
+ * semantics.
+ *
+ * The `disabled` flags inside an otherwise-enabled config (e.g. a first
+ * reminder that is turned off) are NOT resolved here; `resolveNextReminderAt`
+ * interprets them at scheduling time.
+ *
+ * NOTE: manual distribution (link sharing) is intentionally NOT handled here.
+ * The server-side caller is responsible for returning `null` when the envelope
+ * is distributed manually, because that gating is unrelated to the settings
+ * cascade and differs per call site.
+ */
+export const deriveEffectiveReminderSettings = (options: {
+  documentReminderSettings: unknown;
+  teamReminderSettings: unknown;
+  organisationReminderSettings: unknown;
+}): TEnvelopeReminderSettings | null => {
+  const document = parseReminderSettings(options.documentReminderSettings);
+
+  if (document) {
+    return document;
+  }
+
+  const team = parseReminderSettings(options.teamReminderSettings);
+
+  if (team) {
+    return team;
+  }
+
+  const organisation = parseReminderSettings(options.organisationReminderSettings);
+
+  if (organisation) {
+    return organisation;
+  }
+
+  return null;
+};
+
+/**
  * Resolve the next reminder timestamp from the config and the last reminder sent time.
  *
- * - `null` config means reminders are disabled (inherit = no override, resolved as disabled).
+ * - `null` config means reminders are disabled (no override at any cascade level).
  * - `{ sendAfter: { disabled: true }, ... }` means never send the first reminder.
  * - `{ repeatEvery: { disabled: true }, ... }` means don't repeat after the first reminder.
  *

--- a/packages/lib/server-only/recipient/resolve-envelope-reminder-settings.ts
+++ b/packages/lib/server-only/recipient/resolve-envelope-reminder-settings.ts
@@ -1,0 +1,72 @@
+import { prisma } from '@documenso/prisma';
+import { DocumentDistributionMethod } from '@prisma/client';
+
+import { deriveEffectiveReminderSettings, type TEnvelopeReminderSettings } from '../../constants/envelope-reminder';
+
+/**
+ * Resolve the *effective* reminder settings for an envelope by walking the
+ * Document -> Team -> Organisation cascade.
+ *
+ * This is the single source of truth used by every reminder scheduling path
+ * (first send, settings-change recompute, auto-reminder follow-ups). Callers
+ * must NOT read `documentMeta.reminderSettings` directly and treat `null` as
+ * disabled — `null` on a document means "inherit", not "off".
+ *
+ * Rules enforced here:
+ *   - An explicit document-level value always wins (enabled or disabled).
+ *   - When the document inherits, the team override (if any) applies, then the
+ *     organisation default.
+ *   - A disabled config (`{ sendAfter: { disabled: true }, ... }`) is a real
+ *     override and is returned as-is.
+ *   - Manually distributed envelopes (`DocumentDistributionMethod.NONE`) never
+ *     get email reminders, regardless of the cascade result.
+ *   - If no level is configured, reminders are disabled (returns `null`).
+ */
+export const resolveEnvelopeReminderSettings = async (
+  envelopeId: string,
+): Promise<TEnvelopeReminderSettings | null> => {
+  const envelope = await prisma.envelope.findFirst({
+    where: { id: envelopeId },
+    select: {
+      documentMeta: {
+        select: {
+          reminderSettings: true,
+          distributionMethod: true,
+        },
+      },
+      team: {
+        select: {
+          teamGlobalSettings: {
+            select: {
+              reminderSettings: true,
+            },
+          },
+          organisation: {
+            select: {
+              organisationGlobalSettings: {
+                select: {
+                  reminderSettings: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!envelope?.documentMeta) {
+    return null;
+  }
+
+  // Manually distributed documents (link sharing) never send email reminders.
+  if (envelope.documentMeta.distributionMethod === DocumentDistributionMethod.NONE) {
+    return null;
+  }
+
+  return deriveEffectiveReminderSettings({
+    documentReminderSettings: envelope.documentMeta.reminderSettings,
+    teamReminderSettings: envelope.team?.teamGlobalSettings?.reminderSettings,
+    organisationReminderSettings: envelope.team?.organisation?.organisationGlobalSettings?.reminderSettings,
+  });
+};

--- a/packages/lib/server-only/recipient/update-recipient-next-reminder.ts
+++ b/packages/lib/server-only/recipient/update-recipient-next-reminder.ts
@@ -1,14 +1,24 @@
 import { prisma } from '@documenso/prisma';
-import { DocumentDistributionMethod, RecipientRole, SendStatus, SigningStatus } from '@prisma/client';
+import { RecipientRole, SendStatus, SigningStatus } from '@prisma/client';
 
-import { resolveNextReminderAt, ZEnvelopeReminderSettings } from '../../constants/envelope-reminder';
+import { resolveNextReminderAt, type TEnvelopeReminderSettings } from '../../constants/envelope-reminder';
+import { resolveEnvelopeReminderSettings } from './resolve-envelope-reminder-settings';
 
 /**
  * Compute and store `nextReminderAt` for a single recipient.
  *
+ * The effective reminder settings are resolved through the
+ * Document -> Team -> Organisation cascade via `resolveEnvelopeReminderSettings`
+ * so that a document whose settings are "inherit" (i.e. `null` at the document
+ * level) still picks up the team/organisation default.
+ *
  * Pass `resetReminderCount: true` to restart the reminder cycle (e.g. on a
  * manual resend): the count is zeroed and the schedule recomputed as if the
  * request was freshly sent at `sentAt`.
+ *
+ * Callers may pass an explicit `reminderSettings` override (already parsed) to
+ * skip the cascade lookup; otherwise the envelope's effective settings are
+ * fetched.
  */
 export const updateRecipientNextReminder = async (options: {
   recipientId: number;
@@ -17,21 +27,14 @@ export const updateRecipientNextReminder = async (options: {
   lastReminderSentAt: Date | null;
   reminderCount?: number;
   resetReminderCount?: boolean;
-  reminderSettings?: ReturnType<typeof ZEnvelopeReminderSettings.parse> | null;
+  reminderSettings?: TEnvelopeReminderSettings | null;
 }) => {
   const { recipientId, envelopeId, sentAt, lastReminderSentAt, reminderCount = 0, resetReminderCount } = options;
 
   let settings = options.reminderSettings;
 
   if (settings === undefined) {
-    const envelope = await prisma.envelope.findFirst({
-      where: { id: envelopeId },
-      select: { documentMeta: { select: { reminderSettings: true } } },
-    });
-
-    settings = envelope?.documentMeta?.reminderSettings
-      ? ZEnvelopeReminderSettings.parse(envelope.documentMeta.reminderSettings)
-      : null;
+    settings = await resolveEnvelopeReminderSettings(envelopeId);
   }
 
   const nextReminderAt = resolveNextReminderAt({
@@ -52,25 +55,30 @@ export const updateRecipientNextReminder = async (options: {
 
 /**
  * Recompute `nextReminderAt` for all active (unsigned, sent) recipients
- * of a given envelope. Call when document-level reminder settings change.
+ * of a given envelope. Call when document-level reminder settings change so
+ * that switching to/from "inherit" or editing an explicit schedule is
+ * immediately reflected for every unsigned recipient.
+ *
+ * Recipients that must NOT be re-queued:
+ *   - CC recipients
+ *   - recipients not yet sent or already signed/declined
+ *   - recipients whose signing deadline has passed
+ *
+ * Manually distributed envelopes (`DocumentDistributionMethod.NONE`) and
+ * envelopes with no effective reminder config (inherit-without-default or
+ * explicitly disabled) produce `nextReminderAt = null`, which the sweep job
+ * treats as "no reminder scheduled".
+ *
+ * The 30-day window, `MAX_REMINDERS_BEFORE_RESEND` cap, and manual-resend
+ * reset semantics are enforced inside `resolveNextReminderAt` /
+ * `updateRecipientNextReminder` and are unchanged by this recompute.
  */
 export const recomputeNextReminderForEnvelope = async (envelopeId: string) => {
-  const envelope = await prisma.envelope.findFirst({
-    where: { id: envelopeId },
-    select: {
-      documentMeta: {
-        select: { reminderSettings: true, distributionMethod: true },
-      },
-    },
-  });
-
-  // No reminders for manually distributed documents.
-  const isEmailDistribution = envelope?.documentMeta?.distributionMethod !== DocumentDistributionMethod.NONE;
-
-  const settings =
-    isEmailDistribution && envelope?.documentMeta?.reminderSettings
-      ? ZEnvelopeReminderSettings.parse(envelope.documentMeta.reminderSettings)
-      : null;
+  // `resolveEnvelopeReminderSettings` already returns `null` for manually
+  // distributed envelopes and for inherit-with-no-default, which causes
+  // `resolveNextReminderAt` to produce `null` and clear any previously
+  // scheduled reminder for each active recipient below.
+  const settings = await resolveEnvelopeReminderSettings(envelopeId);
 
   const now = new Date();
 


### PR DESCRIPTION
<!--
  We are no longer accepting external pull requests.

  Aside from a small group of trusted contributors we reach out to directly,
  new external PRs will usually be closed with a request to open an issue instead.
  This is a security decision. See https://documenso.com/blog/why-we-re-pausing-external-pull-requests

  If you're a trusted contributor or maintainer, continue below.
  Otherwise, please open a detailed issue: https://github.com/documenso/documenso/issues/new/choose
-->

## Description

<!--- Describe the changes introduced by this pull request. -->
<!--- Explain what problem it solves or what feature/fix it adds. -->

## Related Issue

<!--- If this pull request is related to a specific issue, reference it here using #issue_number. -->
<!--- For example, "Fixes #123" or "Addresses #456". -->

## Changes Made

<!--- Provide a summary of the changes made in this pull request. -->
<!--- Include any relevant technical details or architecture changes. -->

- Change 1
- Change 2
- ...

## Testing Performed

<!--- Describe the testing that you have performed to validate these changes. -->
<!--- Include information about test cases, testing environments, and results. -->

- Tested feature X in scenario Y.
- Ran unit tests for component Z.
- Tested on browsers A, B, and C.
- ...

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [ ] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

<!--- Provide any additional context or notes for the reviewers. -->
<!--- This might include details about design decisions, potential concerns, or anything else relevant. -->
