### PR TITLE
fix: compare grouped number field values against min/max correctly

### DIFF
--- a/packages/lib/advanced-fields-validation/validate-number.test.ts
+++ b/packages/lib/advanced-fields-validation/validate-number.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TNumberFieldMeta as NumberFieldMeta } from '../types/field-meta';
+import { parseNumberFieldValue, validateNumberField } from './validate-number';
+
+const meta = (overrides: Partial<NumberFieldMeta>): NumberFieldMeta =>
+  ({ type: 'number', ...overrides }) as NumberFieldMeta;
+
+describe('parseNumberFieldValue', () => {
+  it('parses a plain decimal', () => {
+    expect(parseNumberFieldValue('1234.56')).toBe(1234.56);
+  });
+
+  it('parses a comma-grouped value', () => {
+    expect(parseNumberFieldValue('1,234.56', '123,456,789.00')).toBe(1234.56);
+    expect(parseNumberFieldValue('1,000')).toBe(1000);
+  });
+
+  it('parses a dot-grouped value with a comma decimal', () => {
+    expect(parseNumberFieldValue('1.234,56', '123.456.789,00')).toBe(1234.56);
+  });
+});
+
+describe('validateNumberField', () => {
+  it('accepts a grouped value within the range', () => {
+    expect(
+      validateNumberField(
+        '1,234.56',
+        meta({ minValue: 1000, maxValue: 2000, numberFormat: '123,456,789.00' }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects a grouped value above the maximum', () => {
+    // Regression: parseFloat('1,234.56') is 1, so this compared 1 against the
+    // maximum and let a value well over it through.
+    const errors = validateNumberField(
+      '1,234.56',
+      meta({ maxValue: 100, numberFormat: '123,456,789.00' }),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('greater than the maximum value');
+  });
+
+  it('does not report a grouped value as below the minimum', () => {
+    // Regression: parseFloat('1,234.56') is 1, so a value comfortably above the
+    // minimum was rejected.
+    expect(
+      validateNumberField('1,234.56', meta({ minValue: 500, numberFormat: '123,456,789.00' })),
+    ).toEqual([]);
+  });
+
+  it('applies the range to a dot-grouped value', () => {
+    expect(
+      validateNumberField('1.234,56', meta({ minValue: 1000, numberFormat: '123.456.789,00' })),
+    ).toEqual([]);
+
+    const errors = validateNumberField(
+      '1.234,56',
+      meta({ maxValue: 100, numberFormat: '123.456.789,00' }),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('greater than the maximum value');
+  });
+
+  it('still enforces the range on ungrouped values', () => {
+    expect(validateNumberField('5', meta({ minValue: 10 }))[0]).toContain(
+      'less than the minimum value',
+    );
+    expect(validateNumberField('50', meta({ maxValue: 10 }))[0]).toContain(
+      'greater than the maximum value',
+    );
+    expect(validateNumberField('15', meta({ minValue: 10, maxValue: 20 }))).toEqual([]);
+  });
+});

--- a/packages/lib/advanced-fields-validation/validate-number.ts
+++ b/packages/lib/advanced-fields-validation/validate-number.ts
@@ -2,6 +2,25 @@ import { numberFormatValues } from '@documenso/ui/primitives/document-flow/field
 
 import type { TNumberFieldMeta as NumberFieldMeta } from '../types/field-meta';
 
+/**
+ * The number formats use a separator that `parseFloat` stops at, so the raw
+ * value cannot be compared against `minValue`/`maxValue` directly - it has to
+ * be normalised to a plain decimal first.
+ *
+ * `123.456.789,00` groups with dots and uses a comma for the decimal; the
+ * other formats (and an unset format, whose values are still allowed to
+ * contain commas) group with commas and use a dot.
+ */
+export const parseNumberFieldValue = (value: string, numberFormat?: string | null): number => {
+  const trimmed = value.trim();
+
+  if (numberFormat === '123.456.789,00') {
+    return parseFloat(trimmed.replace(/\./g, '').replace(',', '.'));
+  }
+
+  return parseFloat(trimmed.replace(/,/g, ''));
+};
+
 export const validateNumberField = (
   value: string,
   fieldMeta?: NumberFieldMeta,
@@ -23,7 +42,7 @@ export const validateNumberField = (
     }
   }
 
-  const numberValue = parseFloat(value);
+  const numberValue = parseNumberFieldValue(value, numberFormat);
 
   if (isSigningPage && required && !value) {
     errors.push('Value is required');


### PR DESCRIPTION
A number field with a thousands separator is compared against `minValue`/`maxValue` using only its leading group.

## Problem

`validateNumberField` calls `parseFloat` on the raw value, but every configured number format uses a separator `parseFloat` stops at:

```js
parseFloat("1,234.56")  // 1        (format 123,456,789.00)
parseFloat("1.234,56")  // 1.234    (format 123.456.789,00)
```

The value passes its format regex, then the range check runs against `1` instead of `1234.56`. Both directions are wrong:

| field config | entered | today | expected |
|---|---|---|---|
| `maxValue: 100` | `1,234.56` | accepted | rejected |
| `minValue: 500` | `1,234.56` | rejected | accepted |

`sign-field-with-token.ts` calls this with `isSigningPage: true`, so this runs on the value a recipient submits — a signed field can end up holding a number outside the range the sender configured.

## Fix

Normalise the value before comparing, using the format to decide which separator groups and which is the decimal:

- `123.456.789,00` — dots group, comma is the decimal
- `123,456,789.00`, `123456,789.00`, and an unset format — commas group, dot is the decimal

Only the parsing changes; the format regex, the required/read-only rules and the error messages are untouched.

## Tests

`validate-number.ts` had no test file. Added one covering the parser directly and the range checks for grouped, dot-grouped and ungrouped values. I verified 4 of the 8 fail against the current code and all pass with the fix; the full `packages/lib` suite is green (193 tests).

## Note

`minValue`/`maxValue` are also guarded by `> 0`, so a limit of exactly `0` is ignored. That looked like a separate decision so I left it alone.