### PR TITLE
ci: add Commitlint commit message validation (#267)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "@commitlint/config-conventional"
+  ]
+}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,24 @@
+name: Commitlint CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Commitlint
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+
+      - name: Validate Commit Messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
## Description
This PR adds Commitlint validation to enforce conventional commit messages across pull requests, resolving issue #267.

### Changes Included
- Added `.commitlintrc.json` using `@commitlint/config-conventional` standard rules.
- Added `.github/workflows/commitlint.yml` to automatically validate all incoming PR commit messages in CI.

Resolves #267

/claim #267
