### PR TITLE
fix(email): use the recipient's role in the completed notification instead of always saying "signed"

### DIFF
--- a/packages/email/template-components/template-document-recipient-signed.tsx
+++ b/packages/email/template-components/template-document-recipient-signed.tsx
@@ -1,4 +1,7 @@
+import { RECIPIENT_ROLES_DESCRIPTION } from '@documenso/lib/constants/recipient-roles';
+import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
+import { RecipientRole } from '@prisma/client';
 
 import { Column, Img, Section, Text } from '../components';
 import { TemplateDocumentImage } from './template-document-image';
@@ -7,6 +10,7 @@ export interface TemplateDocumentRecipientSignedProps {
   documentName: string;
   recipientName: string;
   recipientEmail: string;
+  recipientRole?: RecipientRole;
   assetBaseUrl: string;
 }
 
@@ -14,13 +18,17 @@ export const TemplateDocumentRecipientSigned = ({
   documentName,
   recipientName,
   recipientEmail,
+  recipientRole = RecipientRole.SIGNER,
   assetBaseUrl,
 }: TemplateDocumentRecipientSignedProps) => {
+  const { _ } = useLingui();
   const getAssetUrl = (path: string) => {
     return new URL(path, assetBaseUrl).toString();
   };
 
   const recipientReference = recipientName || recipientEmail;
+  const actioned = _(RECIPIENT_ROLES_DESCRIPTION[recipientRole].actioned).toLowerCase();
+  const progressive = _(RECIPIENT_ROLES_DESCRIPTION[recipientRole].progressiveVerb).toLowerCase();
 
   return (
     <>
@@ -42,12 +50,14 @@ export const TemplateDocumentRecipientSigned = ({
 
         <Text className="mb-0 text-center font-semibold text-foreground text-lg">
           <Trans>
-            {recipientReference} has signed "{documentName}"
+            {recipientReference} has {actioned} "{documentName}"
           </Trans>
         </Text>
 
         <Text className="mx-auto mt-1 mb-6 max-w-[80%] text-center text-base text-muted-foreground">
-          <Trans>{recipientReference} has completed signing the document.</Trans>
+          <Trans>
+            {recipientReference} has completed {progressive} the document.
+          </Trans>
         </Text>
       </Section>
     </>

--- a/packages/email/templates/document-recipient-signed.tsx
+++ b/packages/email/templates/document-recipient-signed.tsx
@@ -1,5 +1,7 @@
+import { RECIPIENT_ROLES_DESCRIPTION } from '@documenso/lib/constants/recipient-roles';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
+import { RecipientRole } from '@prisma/client';
 
 import { Body, Container, Head, Html, Preview, Section } from '../components';
 import { TemplateBrandingLogo } from '../template-components/template-branding-logo';
@@ -10,6 +12,7 @@ export interface DocumentRecipientSignedEmailTemplateProps {
   documentName?: string;
   recipientName?: string;
   recipientEmail?: string;
+  recipientRole?: RecipientRole;
   assetBaseUrl?: string;
 }
 
@@ -17,13 +20,16 @@ export const DocumentRecipientSignedEmailTemplate = ({
   documentName = 'Open Source Pledge.pdf',
   recipientName = 'John Doe',
   recipientEmail = 'lucas@documenso.com',
+  recipientRole = RecipientRole.SIGNER,
   assetBaseUrl = 'http://localhost:3002',
 }: DocumentRecipientSignedEmailTemplateProps) => {
   const { _ } = useLingui();
 
   const recipientReference = recipientName || recipientEmail;
 
-  const previewText = msg`${recipientReference} has signed ${documentName}`;
+  const actioned = _(RECIPIENT_ROLES_DESCRIPTION[recipientRole].actioned).toLowerCase();
+
+  const previewText = msg`${recipientReference} has ${actioned} ${documentName}`;
 
   return (
     <Html>
@@ -40,6 +46,7 @@ export const DocumentRecipientSignedEmailTemplate = ({
                 documentName={documentName}
                 recipientName={recipientName}
                 recipientEmail={recipientEmail}
+                recipientRole={recipientRole}
                 assetBaseUrl={assetBaseUrl}
               />
             </Section>

--- a/packages/lib/jobs/definitions/emails/send-recipient-signed-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-recipient-signed-email.handler.ts
@@ -6,6 +6,7 @@ import { createElement } from 'react';
 
 import { getI18nInstance } from '../../../client-only/providers/i18n-server';
 import { NEXT_PUBLIC_WEBAPP_URL } from '../../../constants/app';
+import { RECIPIENT_ROLES_DESCRIPTION } from '../../../constants/recipient-roles';
 import { getEmailContext } from '../../../server-only/email/get-email-context';
 import { extractDerivedDocumentEmailSettings } from '../../../types/document-email';
 import { unsafeBuildEnvelopeIdQuery } from '../../../utils/envelope';
@@ -64,7 +65,7 @@ export const run = async ({ payload, io }: { payload: TSendRecipientSignedEmailJ
   }
 
   const [recipient] = envelope.recipients;
-  const { email: recipientEmail, name: recipientName } = recipient;
+  const { email: recipientEmail, name: recipientName, role: recipientRole } = recipient;
   const { user: owner } = envelope;
 
   const recipientReference = recipientName || recipientEmail;
@@ -91,6 +92,7 @@ export const run = async ({ payload, io }: { payload: TSendRecipientSignedEmailJ
     documentName: envelope.title,
     recipientName,
     recipientEmail,
+    recipientRole,
     assetBaseUrl,
   });
 
@@ -110,7 +112,9 @@ export const run = async ({ payload, io }: { payload: TSendRecipientSignedEmailJ
         address: owner.email,
       },
       from: senderEmail,
-      subject: i18n._(msg`${recipientReference} has signed "${envelope.title}"`),
+      subject: i18n._(
+        msg`${recipientReference} has ${i18n._(RECIPIENT_ROLES_DESCRIPTION[recipientRole].actioned).toLowerCase()} "${envelope.title}"`,
+      ),
       html,
       text,
     });


### PR DESCRIPTION
### Problem

When a recipient completes their step, the notification sent to the document owner always reads **"{name} has signed \"{document}\""** — including when that recipient's role is `APPROVER` or `VIEWER`, and no signature fields were ever bound to them.

The invite and reminder emails in the same package already branch on `RecipientRole` and say "approve"/"view" correctly. This is the one recipient-facing outcome email that doesn't, so an approver's action is reported to the owner as a signature.

### Change

`recipientRole` is threaded from the job handler into the template. The handler already loads the `recipient` record, so **no additional query is needed**.

Rather than adding a new `match` block, this reuses the existing `RECIPIENT_ROLES_DESCRIPTION` constant, so the wording comes from the already-translated `actioned` and `progressiveVerb` entries:

| Role | Headline | Body |
|---|---|---|
| `APPROVER` | has **approved** | has completed **approving** |
| `VIEWER` | has **viewed** | has completed **viewing** |
| `SIGNER` | has **signed** | has completed **signing** *(unchanged)* |

Applied to all four places the verb appears for this email: **subject**, **preview text**, **headline** and **body**.

### Compatibility

`recipientRole` is optional and defaults to `RecipientRole.SIGNER`, so existing callers and the email preview app are unaffected, and the default output is byte-identical to today's for signers.

Because it reuses `actioned` / `progressiveVerb`, this adds **no new translatable strings** beyond the two reworded sentences.

Files touched:
- `packages/lib/jobs/definitions/emails/send-recipient-signed-email.handler.ts`
- `packages/email/templates/document-recipient-signed.tsx`
- `packages/email/template-components/template-document-recipient-signed.tsx`

Happy to adjust the wording or split the subject-line change out if you'd prefer a narrower diff.