### PR TITLE
feat(tables): allow CC recipients to view incomplete documents

### DIFF
--- a/apps/remix/app/components/tables/documents-table-action-button.tsx
+++ b/apps/remix/app/components/tables/documents-table-action-button.tsx
@@ -41,10 +41,7 @@ export const DocumentsTableActionButton = ({ row }: DocumentsTableActionButtonPr
   const documentsPath = formatDocumentsPath(team.url);
   const formatPath = `${documentsPath}/${row.envelopeId}/edit`;
 
-  // TODO: Consider if want to keep this logic for hiding viewing for CC'ers
-  if (recipient?.role === RecipientRole.CC && isComplete === false) {
-    return null;
-  }
+  // Allow CC'ers to view the document progress even if incomplete
 
   return match({
     isOwner,

--- a/apps/remix/app/components/tables/inbox-table.tsx
+++ b/apps/remix/app/components/tables/inbox-table.tsx
@@ -187,10 +187,7 @@ export const InboxTableActionButton = ({ row }: InboxTableActionButtonProps) => 
     return null;
   }
 
-  // TODO: Consider if want to keep this logic for hiding viewing for CC'ers
-  if (recipient?.role === RecipientRole.CC && isComplete === false) {
-    return null;
-  }
+  // Allow CC'ers to view the document progress even if incomplete
 
   return match({
     isPending,


### PR DESCRIPTION
## Summary
Resolves an open TODO inside tables for CC recipients, allowing CC'd users to view incomplete documents.
