### PR TITLE
fix: enforce envelope visibility on file access

### DIFF
--- a/apps/remix/server/api/files/files.helpers.ts
+++ b/apps/remix/server/api/files/files.helpers.ts
@@ -1,8 +1,8 @@
 import { getOptionalSession } from '@documenso/auth/server/lib/utils/get-session';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import { verifyEmbeddingPresignToken } from '@documenso/lib/server-only/embedding-presign/verify-embedding-presign-token';
+import { getEnvelopeWhereInput } from '@documenso/lib/server-only/envelope/get-envelope-by-id';
 import { generatePartialSignedPdf } from '@documenso/lib/server-only/pdf/generate-partial-signed-pdf';
-import { getTeamById } from '@documenso/lib/server-only/team/get-team';
 import { sha256 } from '@documenso/lib/universal/crypto';
 import { getFileServerSide } from '@documenso/lib/universal/upload/get-file.server';
 import { prisma } from '@documenso/prisma';
@@ -261,6 +261,7 @@ const handlePendingFileRequest = async ({
 
 type CheckEnvelopeFileAccessOptions = {
   userId: number;
+  envelopeId: string;
   teamId: number;
   envelopeType: EnvelopeType;
   templateType: TemplateType;
@@ -269,19 +270,36 @@ type CheckEnvelopeFileAccessOptions = {
 /**
  * Check whether a user has access to an envelope's file.
  *
- * First checks team membership. If that fails and the envelope is an
- * ORGANISATION template (not a document), falls back to checking whether
- * the user belongs to any team in the same organisation.
+ * Re-derives access through the same visibility-gated where-input used by the
+ * tRPC envelope read path (`getEnvelopeWhereInput`), so a user's team role and
+ * the envelope's `visibility` are enforced here exactly as they are everywhere
+ * else. Falls back to an organisation-membership check for ORGANISATION
+ * templates, which are not owned by a single team.
  */
 export const checkEnvelopeFileAccess = async ({
   userId,
+  envelopeId,
   teamId,
   envelopeType,
   templateType,
 }: CheckEnvelopeFileAccessOptions): Promise<boolean> => {
-  const team = await getTeamById({ userId, teamId }).catch(() => null);
+  const hasVisibilityGatedAccess = await getEnvelopeWhereInput({
+    id: { type: 'envelopeId', id: envelopeId },
+    userId,
+    teamId,
+    type: null,
+  })
+    .then(async ({ envelopeWhereInput }) => {
+      const envelope = await prisma.envelope.findFirst({
+        where: { ...envelopeWhereInput, id: envelopeId },
+        select: { id: true },
+      });
 
-  if (team) {
+      return envelope !== null;
+    })
+    .catch(() => false);
+
+  if (hasVisibilityGatedAccess) {
     return true;
   }
 

--- a/apps/remix/server/api/files/files.ts
+++ b/apps/remix/server/api/files/files.ts
@@ -109,6 +109,7 @@ export const filesRoute = new Hono<HonoEnv>()
 
       const hasAccess = await checkEnvelopeFileAccess({
         userId,
+        envelopeId: envelope.id,
         teamId: envelope.teamId,
         envelopeType: envelope.type,
         templateType: envelope.templateType,
@@ -181,6 +182,7 @@ export const filesRoute = new Hono<HonoEnv>()
 
         const hasDownloadAccess = await checkEnvelopeFileAccess({
           userId: session.user.id,
+          envelopeId: envelope.id,
           teamId: envelope.teamId,
           envelopeType: envelope.type,
           templateType: envelope.templateType,

--- a/apps/remix/server/api/files/routes/get-envelope-item-pdf.ts
+++ b/apps/remix/server/api/files/routes/get-envelope-item-pdf.ts
@@ -81,6 +81,7 @@ route.get(
     // Check whether the user has access to the document.
     const hasAccess = await checkEnvelopeFileAccess({
       userId,
+      envelopeId: envelopeItem.envelope.id,
       teamId: envelopeItem.envelope.teamId,
       envelopeType: envelopeItem.envelope.type,
       templateType: envelopeItem.envelope.templateType,


### PR DESCRIPTION
File access previously relied solely on team membership, which let users with no role on the envelope still reach its files. Re-derive access through the visibility-gated getEnvelopeWhereInput used by the envelope read path so visibility and role checks match everywhere else.

## Description

`checkEnvelopeFileAccess` in `apps/remix/server/api/files/files.helpers.ts` decided file access purely from team membership (`getTeamById`). That meant any user belonging to the envelope's team could fetch its PDF/items even when the envelope `visibility` should have excluded them — a plain MEMBER could read an ADMIN/MANAGER-restricted document.

This PR re-derives access through `getEnvelopeWhereInput` — the same visibility-gated where-input used by the tRPC envelope read path (`get-envelope-by-id.ts`) — so a user's team role and the envelope's `visibility` are enforced here exactly as they are everywhere else. The organisation-membership fallback is kept for ORGANISATION templates, which are not owned by a single team.

## Related Issue

- Addresses #3112 (PDF file route ignores document visibility / broken access control).

## Changes Made

- Added `envelopeId` to `CheckEnvelopeFileAccessOptions` and `checkEnvelopeFileAccess`.
- Replaced the `getTeamById` membership check with a `getEnvelopeWhereInput`-based lookup that enforces:
  - envelope ownership (`userId`),
  - team role + `visibility` via `TEAM_DOCUMENT_VISIBILITY_MAP`,
  - team-email access where configured.
- Wired `envelope.id` / `envelopeItem.envelope.id` through all three call sites:
  - `apps/remix/server/api/files/files.ts` 
  - `apps/remix/server/api/files/files.ts`
  - `apps/remix/server/api/files/routes/get-envelope-item-pdf.ts` 
- Retained the organisation-membership fallback for ORGANISATION templates.

## Testing Performed

- `npx tsc --noEmit` — no type errors in the changed files (`apps/remix/server/api/files/`). The remaining reported errors are pre-existing `+types/` route-type resolution issues unrelated to this PR.
- Manually traced the visibility matrix: owner always passes; MEMBER role only passes for `EVERYONE`-visibility envelopes; ADMIN/MANAGER roles pass for their visibility tier; non-team users denied.
- Runtime end-to-end testing pending a local DB.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [x] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

- This aligns file-access authorization with the canonical envelope read path, closing the visibility bypass described in #3112.
- The secondary cross-tenant `documentDataId` primitive in #3112 (ownership binding/validation in `create-envelope.ts`) is out of scope for this PR and remains a separate remediation.