### PR TITLE
fix: correct read-only number field validation

### DIFF
--- a/packages/lib/advanced-fields-validation/validate-number.test.ts
+++ b/packages/lib/advanced-fields-validation/validate-number.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TNumberFieldMeta } from '../types/field-meta';
+import { validateNumberField } from './validate-number';
+
+const READ_ONLY_ERROR = 'A read-only field must have a value greater than 0';
+
+const meta = (overrides: Partial<TNumberFieldMeta>): TNumberFieldMeta =>
+  ({ type: 'number', ...overrides }) as TNumberFieldMeta;
+
+describe('validateNumberField', () => {
+  describe('read-only fields', () => {
+    it('accepts a positive value below 1 (it is still greater than 0)', () => {
+      expect(validateNumberField('0.5', meta({ readOnly: true }))).not.toContain(READ_ONLY_ERROR);
+    });
+
+    it('rejects zero', () => {
+      expect(validateNumberField('0', meta({ readOnly: true }))).toContain(READ_ONLY_ERROR);
+    });
+  });
+
+  describe('min/max bounds', () => {
+    it('reports a single error when the minimum exceeds the maximum', () => {
+      const errors = validateNumberField('5', meta({ minValue: 10, maxValue: 5 }));
+
+      const minMaxErrors = errors.filter(
+        (error) =>
+          error === 'Minimum value cannot be greater than maximum value' ||
+          error === 'Maximum value cannot be less than minimum value',
+      );
+
+      expect(minMaxErrors).toEqual(['Minimum value cannot be greater than maximum value']);
+    });
+  });
+});

--- a/packages/lib/advanced-fields-validation/validate-number.ts
+++ b/packages/lib/advanced-fields-validation/validate-number.ts
@@ -45,11 +45,7 @@ export const validateNumberField = (
     errors.push('Minimum value cannot be greater than maximum value');
   }
 
-  if (typeof maxValue === 'number' && typeof minValue === 'number' && maxValue < minValue) {
-    errors.push('Maximum value cannot be less than minimum value');
-  }
-
-  if (readOnly && numberValue < 1) {
+  if (readOnly && numberValue <= 0) {
     errors.push('A read-only field must have a value greater than 0');
   }
 


### PR DESCRIPTION
## Summary

Two fixes in `validateNumberField` (`packages/lib/advanced-fields-validation/validate-number.ts`), which previously had no tests.

### 1. Read-only fields reject valid values between 0 and 1

The read-only check uses `numberValue < 1`, but the error message says "A read-only field must have a value greater than 0". A value like `0.5` or `0.75` is greater than 0 yet less than 1, so it was rejected even though it satisfies the stated rule. This can block signing of a document whose read-only number field is pre-filled with a fractional value. Changed the check to `numberValue <= 0` so it matches the message.

### 2. Duplicate error when the minimum exceeds the maximum

Two logically identical checks both push an error when `minValue > maxValue`:

```ts
if (... minValue > maxValue) errors.push('Minimum value cannot be greater than maximum value');
if (... maxValue < minValue) errors.push('Maximum value cannot be less than minimum value');
```

`minValue > maxValue` and `maxValue < minValue` are the same condition, so the author saw two messages for one problem. Removed the redundant second check.

## Tests

Added `validate-number.test.ts` covering the read-only boundary (`0.5` accepted, `0` rejected) and the single min>max error.
