### PR TITLE
docs(self-hosting): document NEXTAUTH_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 NEXT_PRIVATE_DOCUMENSO_LICENSE_KEY=
 
 # [[AUTH]]
+# REQUIRED: Public URL used by the auth service. Must match NEXT_PUBLIC_WEBAPP_URL in production.
+NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="secret"
 
 # [[CRYPTO]]

--- a/apps/docs/content/docs/self-hosting/configuration/environment.mdx
+++ b/apps/docs/content/docs/self-hosting/configuration/environment.mdx
@@ -9,6 +9,7 @@ These variables must be set for Documenso to function:
 
 | Variable                                | Description                                                                                |
 | --------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `NEXTAUTH_URL`                          | Public URL used by authentication (e.g., `https://sign.example.com`)                       |
 | `NEXTAUTH_SECRET`                       | Secret key for NextAuth.js encryption and signing. Generate with `openssl rand -base64 32` |
 | `NEXT_PRIVATE_ENCRYPTION_KEY`           | Primary encryption key for symmetric encryption (minimum 32 characters)                    |
 | `NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY` | Secondary encryption key for symmetric encryption (minimum 32 characters)                  |
@@ -51,11 +52,12 @@ For detailed database setup, see [Database Configuration](/docs/self-hosting/con
 
 ### Core Authentication
 
-| Variable                                | Required | Description                                                               |
-| --------------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `NEXTAUTH_SECRET`                       | Yes      | Secret for NextAuth.js session encryption. Must be at least 32 characters |
-| `NEXT_PRIVATE_ENCRYPTION_KEY`           | Yes      | Primary key for encrypting sensitive data. Must be at least 32 characters |
-| `NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY` | Yes      | Secondary encryption key for key rotation. Must be at least 32 characters |
+| Variable                                | Required | Description                                                                      |
+| --------------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `NEXTAUTH_URL`                          | Yes      | Public authentication URL. Set this to the same origin as `NEXT_PUBLIC_WEBAPP_URL` |
+| `NEXTAUTH_SECRET`                       | Yes      | Secret for NextAuth.js session encryption. Must be at least 32 characters        |
+| `NEXT_PRIVATE_ENCRYPTION_KEY`           | Yes      | Primary key for encrypting sensitive data. Must be at least 32 characters        |
+| `NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY` | Yes      | Secondary encryption key for key rotation. Must be at least 32 characters        |
 
 ### Google OAuth
 
@@ -462,6 +464,7 @@ A minimal production configuration:
 
 ```bash
 # Required
+NEXTAUTH_URL="https://sign.example.com"
 NEXTAUTH_SECRET="your-random-secret-at-least-32-chars"
 NEXT_PRIVATE_ENCRYPTION_KEY="your-encryption-key-at-least-32-chars"
 NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY="your-secondary-key-at-least-32-chars"


### PR DESCRIPTION
## Summary
- documents `NEXTAUTH_URL` in the self-hosting environment variable reference
- adds it to `.env.example` next to `NEXTAUTH_SECRET`
- includes it in the minimal production `.env` example

## Rationale
The Docker image docs list `NEXTAUTH_URL` as required for self-hosted deployments, but the self-hosting environment variable reference did not mention it. This keeps the docs aligned and makes the required auth URL setting easier to discover.

Closes #3150

## Test Plan
- `git diff --check`
- Secret/privacy scan of added lines
- `npx biome check .env.example apps/docs/content/docs/self-hosting/configuration/environment.mdx` (paths are ignored by current Biome config; no files processed)
