### PR TITLE
Add a Miget one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ For full instructions, requirements, and configuration details, see the [Self Ho
 
 [![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/documenso)
 
+#### Miget
+
+[![Deploy to Miget](https://miget.com/deploy-to-miget.svg)](https://miget.com/deploy?repo=https://github.com/deployable-sh/stacks&path=documenso&type=stack)
+
 ## Security
 
 If you believe you have found a security vulnerability in Documenso, please report it through our [Security Policy](https://github.com/documenso/documenso/security/policy). We prioritize private reports via [GitHub Security Advisories](https://github.com/documenso/documenso/security/advisories/new). See [SECURITY.md](./SECURITY.md) for scope and details.


### PR DESCRIPTION
Adds Miget to the One-Click Deploys list, next to Railway, Render, Koyeb and Elestio.

The button deploys the Docker Compose stack from an open-source template repo, the same shape as the Railway and Elestio entries. Compose file: https://github.com/deployable-sh/stacks/tree/main/documenso

What it provisions: `documenso/documenso:v2.15.0` plus a managed Postgres, with `NEXTAUTH_SECRET`, `NEXT_PRIVATE_ENCRYPTION_KEY`, `NEXT_PRIVATE_ENCRYPTION_SECONDARY_KEY` and the signing certificate prompted at deploy time rather than defaulted.

Tested end to end before opening this: fresh deploy, 163 Prisma migrations applied on first boot, `/api/health` returning `{"status":"ok","checks":{"database":{"status":"ok"},"certificate":{"status":"ok"}}}`, and account signup delivering its confirmation mail over SMTP.

Two things the template fixes that are easy to get wrong, in case they are useful upstream:

- `NEXT_PRIVATE_SMTP_HOST` and `NEXT_PRIVATE_SMTP_FROM_ADDRESS` are required rather than defaulted. Signing requests are delivered by email, so a stack that boots without them looks healthy and silently cannot send.
- The app waits on the database instead of racing it. Without that, the first boot fails migrations with `P1001` and restarts a few times before recovering.

Happy to adjust the wording or placement, or to drop it if you would rather keep the list to the four you have.