### PR TITLE
fix(envelope): keep same-email recipients distinct when resolving PDF placeholder tags

### DIFF
--- a/packages/lib/server-only/envelope/create-envelope.ts
+++ b/packages/lib/server-only/envelope/create-envelope.ts
@@ -416,7 +416,12 @@ export const createEnvelope = async ({
 
     const allRecipients = [...(data.recipients || []), ...mappedDefaultRecipients];
 
-    await Promise.all(
+    // Promise.all resolves in input order, so createdRecipientRecords[i] is the
+    // recipient created from allRecipients[i] (and therefore from data.recipients[i]
+    // for the leading entries). Keeping this correspondence lets placeholder tags be
+    // resolved by index below instead of by email, which is what allows two recipients
+    // that share an email to stay distinct (#3115).
+    const createdRecipientRecords = await Promise.all(
       allRecipients.map(async (recipient) => {
         const recipientAuthOptions = createRecipientAuthOptions({
           accessAuth: recipient.accessAuth ?? [],
@@ -455,7 +460,7 @@ export const createEnvelope = async ({
           };
         });
 
-        await tx.recipient.create({
+        return tx.recipient.create({
           data: {
             envelopeId: envelope.id,
             name: recipient.name,
@@ -472,6 +477,7 @@ export const createEnvelope = async ({
               },
             },
           },
+          select: { id: true, email: true },
         });
       }),
     );
@@ -547,16 +553,21 @@ export const createEnvelope = async ({
               recipientPlaceholder,
               placeholder,
               data.recipients && data.recipients.length > 0
-                ? data.recipients.map((r) => {
-                    const found = availableRecipients.find((cr) => cr.email === r.email);
+                ? // Index-based: r1 -> data.recipients[0], r2 -> data.recipients[1], etc.
+                  // Matching each entry back by email collapsed recipients that share an
+                  // email onto whichever row was found first, so every tag bound to one of
+                  // them (#3115). createdRecipientRecords lines up with data.recipients by
+                  // position, so index resolution keeps same-email recipients distinct.
+                  data.recipients.map((_, index) => {
+                    const created = createdRecipientRecords[index];
 
-                    if (!found) {
+                    if (!created) {
                       throw new AppError(AppErrorCode.NOT_FOUND, {
-                        message: `Recipient not found for email: ${r.email}`,
+                        message: `Recipient not found for placeholder index r${index + 1}`,
                       });
                     }
 
-                    return found;
+                    return created;
                   })
                 : undefined,
               availableRecipients,


### PR DESCRIPTION
Fixes #3115.

## Problem

When creating an envelope with two or more recipients that share the same `email` (but a different `signingOrder`/`name`), every PDF placeholder tag (`{{signature, r1}}`, `{{signature, r2}}`, …) resolves to the same recipient, and the later recipients get no fields.

`findRecipientByPlaceholder` already resolves tags by index when it is handed a per-index `recipients` array, and that part is correct. The problem is how `create-envelope` builds that array:

```ts
data.recipients.map((r) => {
  const found = availableRecipients.find((cr) => cr.email === r.email)
  ...
  return found
})
```

`availableRecipients` is re-fetched from the DB, and each input recipient is matched back to it by email. For two recipients with the same email, `find` returns the same first row for both, so the resulting array is `[rowA, rowA]` and `r1`/`r2` both land on `rowA`.

## Fix

Capture the created recipients from the `Promise.all` that inserts them. `Promise.all` resolves in input order, so `createdRecipientRecords[i]` is exactly the recipient created from `data.recipients[i]`. Resolving placeholder tags against that array by index removes the email round-trip, so same-email recipients stay distinct. The email-based lookup is still used for the placeholder-recipient path (no explicit recipients provided), where the generated emails are unique.

## Verifying

The exact repro in the issue — `POST /api/v2/envelope/create` with two `SIGNER` recipients sharing `dup@example.com` (signing order 1 and 2) and a PDF tagged `{{signature, r1}}` / `{{signature, r2}}` — now creates two fields bound to two different `recipientId`s, matching the behaviour when the emails differ.
