### PR TITLE
fix(seal): preserve /FreeText annotations without an appearance stream

### DIFF
--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { PDFDocument } from '@cantoo/pdf-lib';
 import { finalizeTspEnvelopeCompletion } from '@documenso/ee/server-only/signing/csc/finalize-tsp-completion';
 import { addRejectionStampToPdf } from '@documenso/lib/server-only/pdf/add-rejection-stamp-to-pdf';
+import { bakeAnnotationAppearances } from '@documenso/lib/server-only/pdf/bake-annotation-appearances';
 import { generateAuditLogPdf } from '@documenso/lib/server-only/pdf/generate-audit-log-pdf';
 import { generateCertificatePdf } from '@documenso/lib/server-only/pdf/generate-certificate-pdf';
 import { getLastPageDimensions } from '@documenso/lib/server-only/pdf/get-page-size';
@@ -381,7 +382,14 @@ const decorateAndSignPdf = async ({
   certificateDoc,
   auditLogDoc,
 }: DecorateAndSignPdfOptions) => {
-  let pdfDoc = await PDF.load(pdfData);
+  // Some tools (pypdf, Stirling PDF, and most scripted annotators) add text as
+  // /FreeText annotations without an appearance stream. flattenAll() below
+  // deletes any annotation it cannot produce an appearance for, so that text
+  // would vanish from the sealed PDF. Give those annotations an appearance
+  // first; flattenAll() then bakes them into the page content instead.
+  const preparedPdfData = await bakeAnnotationAppearances(pdfData);
+
+  let pdfDoc = await PDF.load(preparedPdfData);
 
   // Normalize and flatten layers that could cause issues with the signature
   pdfDoc.flattenAll();

--- a/packages/lib/server-only/pdf/bake-annotation-appearances.test.ts
+++ b/packages/lib/server-only/pdf/bake-annotation-appearances.test.ts
@@ -1,0 +1,124 @@
+import { PDFDocument, PDFString, StandardFonts } from '@cantoo/pdf-lib';
+import { PDF } from '@libpdf/core';
+import { describe, expect, it } from 'vitest';
+
+import { bakeAnnotationAppearances } from './bake-annotation-appearances';
+
+const STATIC_MARKER = 'STATICPAGECONTENT';
+const ANNOT_MARKERS = ['ANNOTVALUEALPHA', 'ANNOTVALUEBRAVO', 'ANNOTVALUECHARLIE'];
+
+// Text is asserted with pdf.js, not @libpdf/core's extractText(): flattened
+// annotations are drawn as Form XObjects (`/FlatAnnot0 Do`), and extractText()
+// does not descend into XObjects, so it reports a false negative for content
+// that renders perfectly well. pdf.js is the reference renderer the app's viewer
+// uses, so "pdf.js can read it" is the meaningful assertion about what a signer
+// actually sees.
+const extractText = async (bytes: Uint8Array): Promise<string> => {
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+
+  const doc = await pdfjs.getDocument({
+    data: new Uint8Array(bytes),
+    isEvalSupported: false,
+    useSystemFonts: false,
+    verbosity: 0,
+  }).promise;
+
+  const pages: string[] = [];
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i);
+    const content = await page.getTextContent();
+    pages.push(
+      content.items.map((item) => ('str' in item ? item.str : '')).join(' '),
+    );
+  }
+  return pages.join('\n');
+};
+
+/**
+ * Build a PDF whose only "typed" content lives in /FreeText annotations that
+ * carry NO appearance stream — i.e. what pypdf / Stirling PDF / most scripted
+ * annotators emit.
+ */
+const buildAnnotatedPdf = async (): Promise<Uint8Array> => {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([612, 792]);
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+
+  // Real page content, so we can prove text extraction works at all.
+  page.drawText(STATIC_MARKER, { x: 50, y: 750, size: 12, font });
+
+  const ctx = doc.context;
+  const refs = ANNOT_MARKERS.map((marker, index) => {
+    const y = 600 - index * 60;
+    return ctx.register(
+      ctx.obj({
+        Type: 'Annot',
+        Subtype: 'FreeText',
+        Rect: [50, y, 400, y + 30],
+        Contents: PDFString.of(marker),
+        DA: PDFString.of('0 0 0 rg /Helv 12 Tf'),
+        F: 4, // Print
+      }),
+    );
+  });
+
+  page.node.set(ctx.obj('Annots'), ctx.obj(refs));
+
+  return doc.save({ useObjectStreams: false });
+};
+
+/** Run the same flatten + save the seal pipeline does, then extract text. */
+const flattenAndExtract = async (bytes: Uint8Array) => {
+  const pdf = await PDF.load(bytes);
+  const flattenStats = pdf.flattenAll();
+  pdf.upgradeVersion('1.7');
+  const out = await pdf.save({ useXRefStream: true });
+
+  return { flattenStats, text: await extractText(out), bytes: out };
+};
+
+describe('bakeAnnotationAppearances', () => {
+  it('reproduces the drop of /AP-less /FreeText annotations on flatten (baseline)', async () => {
+    const raw = await buildAnnotatedPdf();
+    const rawBytes = Buffer.from(raw).toString('latin1');
+    expect(ANNOT_MARKERS.every((m) => rawBytes.includes(m))).toBe(true);
+
+    const baseline = await flattenAndExtract(raw);
+    const baselineBytes = Buffer.from(baseline.bytes).toString('latin1');
+
+    // Ordinary page content still survives...
+    expect(baseline.text).toContain(STATIC_MARKER);
+    // ...but every annotation value is gone from both the render and the bytes.
+    for (const marker of ANNOT_MARKERS) {
+      expect(baseline.text).not.toContain(marker);
+      expect(baselineBytes).not.toContain(marker);
+    }
+  });
+
+  it('preserves the annotation text through flatten after the pre-pass', async () => {
+    const raw = await buildAnnotatedPdf();
+    const baked = await bakeAnnotationAppearances(raw);
+
+    expect(baked).not.toBe(raw);
+
+    const fixed = await flattenAndExtract(baked);
+
+    // The annotations are now flattened, not dropped.
+    expect(fixed.flattenStats.annotations).toBe(ANNOT_MARKERS.length);
+    expect(fixed.text).toContain(STATIC_MARKER);
+    for (const marker of ANNOT_MARKERS) {
+      expect(fixed.text).toContain(marker);
+    }
+  });
+
+  it('returns an annotation-free PDF unchanged', async () => {
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+    doc.addPage([612, 792]).drawText(STATIC_MARKER, { x: 50, y: 750, size: 12, font });
+    const plainBytes = await doc.save({ useObjectStreams: false });
+
+    const result = await bakeAnnotationAppearances(plainBytes);
+
+    expect(result).toBe(plainBytes);
+  });
+});

--- a/packages/lib/server-only/pdf/bake-annotation-appearances.ts
+++ b/packages/lib/server-only/pdf/bake-annotation-appearances.ts
@@ -1,0 +1,347 @@
+import {
+  PDFArray,
+  PDFDict,
+  PDFDocument,
+  type PDFFont,
+  PDFHexString,
+  PDFName,
+  PDFNumber,
+  type PDFRef,
+  PDFString,
+  StandardFonts,
+} from '@cantoo/pdf-lib';
+
+/**
+ * Bake appearance streams onto annotations that carry text but have no
+ * appearance, so the seal pipeline's `flattenAll()` preserves their content
+ * instead of deleting it.
+ *
+ * Why this is needed
+ * ------------------
+ * The seal path (`decorateAndSignPdf`) calls `pdfDoc.flattenAll()` from
+ * `@libpdf/core` before signing. Its annotation flattener does, per page:
+ *
+ * ```
+ * let appearance = annotation.getNormalAppearance();
+ * if (!appearance) appearance = this.generateAppearance(annotation);
+ * if (!appearance) { refsToRemove.add(...); continue; } // <-- annotation deleted
+ * ```
+ *
+ * and `generateAppearance()` only synthesises appearances for Highlight /
+ * Underline / StrikeOut / Squiggly. A `/FreeText` annotation with no `/AP`
+ * therefore falls through to the delete branch: its text never reaches the page
+ * content stream and the signed PDF comes back blank where the user typed.
+ *
+ * This is tool-dependent, which is why the symptom looks inconsistent:
+ *   - Acrobat form-fills produce AcroForm `/Widget` annots  -> already flattened.
+ *   - Acrobat's Typewriter writes `/FreeText` *with* an `/AP` -> already baked.
+ *   - pypdf / Stirling PDF / most scripted annotators write `/FreeText` with NO
+ *     `/AP` (viewers render from `/DA` + `/Contents`)         -> DROPPED.
+ *
+ * The fix
+ * -------
+ * Before `flattenAll()` runs, synthesise a standards-compliant Form XObject
+ * appearance (`/AP /N`) for every annotation that carries renderable content but
+ * has no appearance. `flattenAll()` then takes its normal "bake the appearance
+ * into page content" path and the text survives. We deliberately do not
+ * reimplement flattening — we only fill the gap that makes it give up.
+ *
+ * Safety: this never throws and never returns invalid bytes. On any failure the
+ * original buffer is returned unchanged, so a malformed PDF degrades to the
+ * prior behaviour rather than breaking sealing.
+ */
+
+const LOG = '[pdf/bake-annotation-appearances]';
+
+// Subtypes `flattenAll()` never flattens (it leaves them in place), so we must
+// not touch them either.
+const SKIP_SUBTYPES = new Set(['Widget', 'Link', 'Popup']);
+
+// Subtypes the flattener can already synthesise an appearance for.
+const ALREADY_HANDLED = new Set(['Highlight', 'Underline', 'StrikeOut', 'Squiggly']);
+
+// Annotation flag bits (PDF 32000-1 12.5.3): 1 = Invisible, 2 = Hidden,
+// 6 = NoView. Anything carrying these is meant to be unrendered; the flattener
+// drops it and so should we.
+const isHiddenFlags = (flags: number): boolean =>
+  Boolean(flags & 0b1) || Boolean(flags & 0b10) || Boolean(flags & 0b100000);
+
+/** Map text into the Latin-1 range WinAnsiEncoding can actually represent. */
+const sanitiseForWinAnsi = (text: string): string =>
+  text
+    .replace(/[‘’‚′]/g, "'")
+    .replace(/[“”„″]/g, '"')
+    .replace(/[‐-―−]/g, '-')
+    .replace(/…/g, '...')
+    .replace(/ /g, ' ')
+    .replace(/[\t\v\f]/g, ' ')
+    // anything still outside Latin-1 (or a control char) becomes '?'
+    .replace(/[^\x20-\x7e\xa0-\xff]/g, '?');
+
+type ParsedDefaultAppearance = {
+  size: number | null;
+  color: [number, number, number];
+};
+
+/**
+ * Pull font size + fill colour out of an annotation's `/DA` default-appearance
+ * string, e.g. `"0 0 0 rg /Helv 12 Tf"` or `"/Helv 0 Tf 0.2 g"`. A size of 0
+ * means "auto-fit" per the spec; it is resolved later.
+ */
+const parseDefaultAppearance = (da: string | null): ParsedDefaultAppearance => {
+  const out: ParsedDefaultAppearance = { size: null, color: [0, 0, 0] };
+  if (!da) return out;
+
+  const tf = da.match(/\/([^\s/]+)\s+([\d.]+)\s+Tf/);
+  if (tf) out.size = Number.parseFloat(tf[2]);
+
+  const rg = da.match(/([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+rg/);
+  if (rg) {
+    out.color = [Number.parseFloat(rg[1]), Number.parseFloat(rg[2]), Number.parseFloat(rg[3])];
+    return out;
+  }
+
+  const g = da.match(/(?:^|\s)([\d.]+)\s+g(?:\s|$)/);
+  if (g) {
+    const v = Number.parseFloat(g[1]);
+    out.color = [v, v, v];
+    return out;
+  }
+
+  const k = da.match(/([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+k/);
+  if (k) {
+    const [c, m, y, kk] = k.slice(1, 5).map((n) => Number.parseFloat(n));
+    out.color = [(1 - c) * (1 - kk), (1 - m) * (1 - kk), (1 - y) * (1 - kk)];
+  }
+
+  return out;
+};
+
+/** Greedy word-wrap to a pixel width, honouring explicit newlines. */
+const wrapLines = (text: string, font: PDFFont, size: number, maxWidth: number): string[] => {
+  const paragraphs = text.split(/\r\n|\r|\n/);
+  const lines: string[] = [];
+
+  for (const paragraph of paragraphs) {
+    if (paragraph.trim() === '') {
+      lines.push('');
+      continue;
+    }
+
+    let current = '';
+    for (const word of paragraph.split(/\s+/)) {
+      const candidate = current === '' ? word : `${current} ${word}`;
+      let width = 0;
+      try {
+        width = font.widthOfTextAtSize(candidate, size);
+      } catch {
+        width = candidate.length * size * 0.5;
+      }
+
+      if (width <= maxWidth || current === '') {
+        current = candidate;
+      } else {
+        lines.push(current);
+        current = word;
+      }
+    }
+    lines.push(current);
+  }
+
+  return lines;
+};
+
+const readText = (value: unknown): string | null => {
+  if (value instanceof PDFHexString || value instanceof PDFString) {
+    try {
+      return value.decodeText();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+const readName = (value: unknown): string | null => {
+  if (value instanceof PDFName) return value.asString().replace(/^\//, '');
+  return null;
+};
+
+type NormalisedRect = { x1: number; y1: number; x2: number; y2: number };
+
+const normaliseRect = (rectArray: unknown): NormalisedRect | null => {
+  if (!(rectArray instanceof PDFArray) || rectArray.size() < 4) return null;
+  const nums: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    const n = rectArray.lookup(i);
+    if (!(n instanceof PDFNumber)) return null;
+    nums.push(n.asNumber());
+  }
+  const [a, b, c, d] = nums;
+  return { x1: Math.min(a, c), y1: Math.min(b, d), x2: Math.max(a, c), y2: Math.max(b, d) };
+};
+
+/**
+ * Build the Form XObject appearance stream for one FreeText annotation and
+ * attach it as `/AP /N`. Returns true if an appearance was written.
+ */
+const bakeFreeText = (doc: PDFDocument, annot: PDFDict, font: PDFFont, fontRef: PDFRef): boolean => {
+  const rect = normaliseRect(annot.lookup(PDFName.of('Rect')));
+  if (!rect) return false;
+
+  const width = rect.x2 - rect.x1;
+  const height = rect.y2 - rect.y1;
+  // Zero-area boxes are rejected by the flattener and by viewers.
+  if (!(width > 0) || !(height > 0)) return false;
+
+  const raw = readText(annot.lookup(PDFName.of('Contents')));
+  if (raw === null || raw.trim() === '') return false;
+
+  const text = sanitiseForWinAnsi(raw);
+  const da = readText(annot.lookup(PDFName.of('DA')));
+  const { size: daSize, color } = parseDefaultAppearance(da);
+
+  // FreeText boxes are drawn with a small inset; 2pt matches Acrobat.
+  const pad = 2;
+  const innerWidth = Math.max(width - pad * 2, 1);
+
+  // A `/DA` size of 0 means auto-size. Shrink until the wrapped text fits.
+  let size = daSize && daSize > 0 ? daSize : 11;
+  let lines = wrapLines(text, font, size, innerWidth);
+  if (!daSize || daSize <= 0) {
+    while (size > 4 && lines.length * size * 1.16 > height - pad * 2) {
+      size -= 0.5;
+      lines = wrapLines(text, font, size, innerWidth);
+    }
+  }
+
+  const leading = size * 1.16;
+  const ascent = size * 0.85;
+
+  const ops = [
+    '/Tx BMC',
+    'q',
+    'BT',
+    `${color.map((c) => Number(c.toFixed(4))).join(' ')} rg`,
+    `/BakedFont ${Number(size.toFixed(2))} Tf`,
+    `${Number(leading.toFixed(2))} TL`,
+    // Origin is the BBox's bottom-left; start one ascent below the top edge.
+    `${pad} ${Number((height - pad - ascent).toFixed(2))} Td`,
+  ];
+
+  lines.forEach((line, index) => {
+    if (index > 0) ops.push('T*');
+    if (line === '') return;
+    let encoded: string;
+    try {
+      encoded = font.encodeText(line).toString();
+    } catch {
+      return;
+    }
+    ops.push(`${encoded} Tj`);
+  });
+
+  ops.push('ET', 'Q', 'EMC');
+
+  const stream = doc.context.stream(ops.join('\n'), {
+    Type: 'XObject',
+    Subtype: 'Form',
+    FormType: 1,
+    BBox: [0, 0, width, height],
+    Resources: { Font: { BakedFont: fontRef } },
+  });
+
+  const apDict = PDFDict.withContext(doc.context);
+  apDict.set(PDFName.of('N'), doc.context.register(stream));
+  annot.set(PDFName.of('AP'), apDict);
+
+  return true;
+};
+
+export const bakeAnnotationAppearances = async (pdfData: Uint8Array): Promise<Uint8Array> => {
+  try {
+    const doc = await PDFDocument.load(pdfData, {
+      ignoreEncryption: true,
+      updateMetadata: false,
+    });
+
+    // First pass: is there anything worth doing? Avoid embedding a font (and
+    // re-serialising the file) for the overwhelmingly common no-annotations case.
+    const candidates: PDFDict[] = [];
+    const unhandled = new Map<string, number>();
+
+    for (const page of doc.getPages()) {
+      const annots = page.node.lookup(PDFName.of('Annots'), PDFArray);
+      if (!annots) continue;
+
+      for (let i = 0; i < annots.size(); i++) {
+        let annot: PDFDict | undefined;
+        try {
+          annot = annots.lookup(i, PDFDict);
+        } catch {
+          continue;
+        }
+        if (!annot) continue;
+
+        const subtype = readName(annot.lookup(PDFName.of('Subtype')));
+        if (!subtype || SKIP_SUBTYPES.has(subtype) || ALREADY_HANDLED.has(subtype)) continue;
+
+        const flags = annot.lookup(PDFName.of('F'));
+        if (flags instanceof PDFNumber && isHiddenFlags(flags.asNumber())) continue;
+
+        // Already has an appearance -> the flattener will bake it; leave it be.
+        const ap = annot.lookup(PDFName.of('AP'));
+        if (ap instanceof PDFDict && ap.lookup(PDFName.of('N'))) continue;
+
+        if (subtype === 'FreeText') {
+          candidates.push(annot);
+        } else {
+          unhandled.set(subtype, (unhandled.get(subtype) ?? 0) + 1);
+        }
+      }
+    }
+
+    // Safety net: an annotation carrying content we still cannot render is about
+    // to be silently deleted by flattenAll(). Say so, loudly.
+    if (unhandled.size > 0) {
+      const summary = [...unhandled.entries()].map(([k, v]) => `${k}x${v}`).join(', ');
+      console.warn(
+        `${LOG} ${summary} annotation(s) have no appearance stream and no generator — ` +
+          `the seal flatten will drop them and their content will be absent from the ` +
+          `signed PDF.`,
+      );
+    }
+
+    if (candidates.length === 0) {
+      return pdfData;
+    }
+
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+    const fontRef = font.ref;
+
+    let baked = 0;
+    for (const annot of candidates) {
+      try {
+        if (bakeFreeText(doc, annot, font, fontRef)) baked++;
+      } catch (err) {
+        console.warn(
+          `${LOG} failed to bake one FreeText annotation:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    if (baked === 0) {
+      return pdfData;
+    }
+
+    return await doc.save({ useObjectStreams: false });
+  } catch (err) {
+    // Never let this break sealing — worst case we are back to prior behaviour.
+    console.error(
+      `${LOG} pre-flatten pass failed, continuing unmodified:`,
+      err instanceof Error ? err.message : err,
+    );
+    return pdfData;
+  }
+};


### PR DESCRIPTION
### Problem

When a document is filled in with a tool that adds text as **`/FreeText`
annotations without an appearance stream (`/AP`)** — which is what pypdf,
Stirling PDF, and most scripted PDF annotators produce — the **signed PDF comes
back blank** where the user typed.

The cause is in the seal path. `decorateAndSignPdf` calls
`pdfDoc.flattenAll()` (from `@libpdf/core`) before signing. Its annotation
flattener does, per page:

```
let appearance = annotation.getNormalAppearance();
if (!appearance) appearance = this.generateAppearance(annotation);
if (!appearance) { refsToRemove.add(...); continue; }  // <-- annotation deleted
```

and `generateAppearance()` only synthesises appearances for
Highlight / Underline / StrikeOut / Squiggly. A `/FreeText` annotation with no
`/AP` therefore falls through to the delete branch: its text never reaches the
page content stream and is absent from the sealed output.

This is why the symptom looks inconsistent depending on how the document was
filled:

| How the text got in | Result |
|---|---|
| Acrobat form-fill → AcroForm `/Widget` | Fine — handled by form flattening |
| Acrobat Typewriter → `/FreeText` **with** `/AP` | Fine — existing appearance is baked |
| pypdf / Stirling PDF / most scripted annotators → `/FreeText` **without** `/AP` | **Dropped** |

A `/FreeText` without `/AP` is spec-legal (PDF 32000-1 — viewers are expected to
render it from `/DA` + `/Contents`; Acrobat synthesises an appearance on open),
so silently deleting it at seal time is data loss rather than an unsupported
input.

### Fix

Add a pre-pass, `bakeAnnotationAppearances()`, that runs immediately **before**
`flattenAll()` in `decorateAndSignPdf`. For every annotation that carries
renderable content but has no `/AP`, it synthesises a standards-compliant
`/AP /N` Form XObject from `/Contents` + `/DA` + `/Rect` (greedy word-wrap,
`/DA` size-0 auto-fit, WinAnsi sanitising). `flattenAll()` then takes its normal
"bake the appearance into page content" path and the text survives.

It deliberately does **not** reimplement flattening — it only fills the gap that
makes the flattener give up. Design points:

- **Never throws.** On any failure it returns the original bytes, so a malformed
  PDF degrades to the current behaviour rather than breaking sealing.
- **Cheap no-op path.** If a page has no eligible annotations it returns the
  input untouched, without embedding a font or re-serialising.
- **Loud safety net.** Any annotation subtype it still cannot render logs a
  warning naming the subtype and count, because `flattenAll()` is about to
  delete it.
- Runs on the **seal** path, so already-uploaded documents are fixed
  retroactively and the stored original is left untouched.

### Test

`bake-annotation-appearances.test.ts` builds a PDF whose only typed content is
`/AP`-less `/FreeText` annotations, **reproduces the drop** through the same
`flattenAll()` the seal path uses, then asserts every value **survives** after
the pre-pass. Rendered text is asserted with **pdf.js** (the reference renderer
the app's viewer uses) rather than `@libpdf/core`'s `extractText()`, which does
not descend into the Form XObjects that flattened annotations become and would
report a false negative. A regression case asserts an annotation-free PDF is
returned unchanged.

### Notes

- No new dependencies — `@cantoo/pdf-lib` and `pdfjs-dist` are already in the
  tree.
- Scoped to `/FreeText` (the observed real-world case). Other appearance-less
  subtypes carrying content are surfaced by the warning rather than silently
  handled, so the change stays conservative.
