### PR TITLE
fix: scale signature images to fill signature fields

### DIFF
--- a/packages/lib/server-only/pdf/insert-field-in-pdf-v1.ts
+++ b/packages/lib/server-only/pdf/insert-field-in-pdf-v1.ts
@@ -135,7 +135,7 @@ export const insertFieldInPDFV1 = async (pdf: PDFDocument, field: FieldWithSigna
           let imageWidth = image.width;
           let imageHeight = image.height;
 
-          const scalingFactor = Math.min(fieldWidth / imageWidth, fieldHeight / imageHeight, 1);
+          const scalingFactor = Math.min(fieldWidth / imageWidth, fieldHeight / imageHeight);
 
           imageWidth = imageWidth * scalingFactor;
           imageHeight = imageHeight * scalingFactor;

--- a/packages/lib/server-only/pdf/legacy-insert-field-in-pdf.ts
+++ b/packages/lib/server-only/pdf/legacy-insert-field-in-pdf.ts
@@ -128,7 +128,7 @@ export const legacy_insertFieldInPDF = async (pdf: PDFDocument, field: FieldWith
           let imageWidth = image.width;
           let imageHeight = image.height;
 
-          const scalingFactor = Math.min(fieldWidth / imageWidth, fieldHeight / imageHeight, 1);
+          const scalingFactor = Math.min(fieldWidth / imageWidth, fieldHeight / imageHeight);
 
           imageWidth = imageWidth * scalingFactor;
           imageHeight = imageHeight * scalingFactor;

--- a/packages/lib/universal/field-renderer/render-signature-field.ts
+++ b/packages/lib/universal/field-renderer/render-signature-field.ts
@@ -23,7 +23,7 @@ const getImageDimensions = (img: HTMLImageElement, fieldWidth: number, fieldHeig
   let imageWidth = img.width;
   let imageHeight = img.height;
 
-  const scalingFactor = Math.min(fieldWidth / imageWidth, fieldHeight / imageHeight, 1);
+  const scalingFactor = Math.min(fieldWidth / imageWidth, fieldHeight / imageHeight);
 
   imageWidth = imageWidth * scalingFactor;
   imageHeight = imageHeight * scalingFactor;


### PR DESCRIPTION
## Description

Before this change, a signature image smaller than the field showed at its native pixel size, small and centered in the field. The renderers only decreased images to the field size. This occurred with low-resolution uploads from different tools, for example DocuSign. This change removes the cap of 1 on the scale factor. A small image scales to fill the field, and the aspect ratio stays the same.

## Related Issue

Fixes documenso/backlog-internal#802

## Changes Made

- Removes the scale factor cap in `getImageDimensions` in `render-signature-field.ts`. This renderer draws the fields in the signing UI and in the v2 PDF export.
- Removes the same cap in `insert-field-in-pdf-v1.ts` and `legacy-insert-field-in-pdf.ts` for the v1 and legacy PDF exports.

## Testing Performed

- A test used `insertFieldInPDFV1` with a 40x12 px PNG in a 200x50 pt field. The image in the PDF became 166.67x50, centered in the field.
- A test used `renderSignatureFieldElement` under the skia backend with the same input. The Konva image node showed 166.67x50 at the center of the field.
- Before-and-after renders of the two paths: https://artifacts.duncan.land/documenso-802-signature-upscale-proof
- `npx tsc --noEmit -p packages/lib` showed only the errors that exist on the main branch, in files that this change does not touch.

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.

## Additional Notes

- The cap on the typed-signature font size stays the same. That cap keeps the font at or below `maxFontSize`.
- A very low-resolution image will show blur at the field size. This is the expected result of the size increase.