### PR TITLE
fix: docker healtcheck

### DIFF
--- a/apps/docs/content/docs/self-hosting/deployment/docker-compose.mdx
+++ b/apps/docs/content/docs/self-hosting/deployment/docker-compose.mdx
@@ -81,7 +81,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?err}
       - POSTGRES_DB=${POSTGRES_DB:?err}
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER}']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/development/compose.yml
+++ b/docker/development/compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - documenso_database:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER}']
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/production/compose.yml
+++ b/docker/production/compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?err}
       - POSTGRES_DB=${POSTGRES_DB:?err}
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER}']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=documenso
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U documenso']
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
       interval: 1s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fix Postgres healthchecks in the compose files.

For the production compose file, `pg_isready` was only passed the username (`-U`), so it defaulted the database name to the username. The check can succeed, but when the database name differs from the username, Postgres logs `FATAL: database "..." does not exist`. It now also passes the database (`-d ${POSTGRES_DB}`) to avoid this.

For the development and testing compose files, Compose interpolates `${POSTGRES_USER}` from the host, not from the service `environment:` block. Dev/test only define those values inside the container, so the check became `pg_isready -U ` and the database stayed unhealthy. They now use `$$POSTGRES_USER` / `$$POSTGRES_DB` so the container shell expands them, and pass the database name (`-d`) as well.