### PR TITLE
fix(multiselect): prevent stale async search results and duplicate re…

### DIFF
--- a/packages/ui/primitives/multiselect.tsx
+++ b/packages/ui/primitives/multiselect.tsx
@@ -259,33 +259,40 @@ const MultiSelect = ({
       setOptions(transToGroupOption(res || [], groupBy));
     };
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    const exec = async () => {
+    const exec = () => {
       if (!onSearchSync || !open) {
         return;
       }
 
-      if (triggerSearchOnFocus) {
-        doSearchSync();
-      }
-
-      if (debouncedSearchTerm) {
+      if (debouncedSearchTerm || triggerSearchOnFocus) {
         doSearchSync();
       }
     };
 
-    void exec();
+    exec();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus]);
 
   useEffect(() => {
     /** async search */
 
+    let cancelled = false;
+
     const doSearch = async () => {
       setIsLoading(true);
-      const res = await onSearch?.(debouncedSearchTerm);
-      setOptions(transToGroupOption(res || [], groupBy));
-      setIsLoading(false);
+      try {
+        const res = await onSearch?.(debouncedSearchTerm);
+        if (cancelled) {
+          return;
+        }
+        setOptions(transToGroupOption(res || [], groupBy));
+      } catch {
+        // Swallow search errors; isLoading is reset in the finally block.
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
     };
 
     const exec = async () => {
@@ -293,16 +300,16 @@ const MultiSelect = ({
         return;
       }
 
-      if (triggerSearchOnFocus) {
-        await doSearch();
-      }
-
-      if (debouncedSearchTerm) {
+      if (debouncedSearchTerm || triggerSearchOnFocus) {
         await doSearch();
       }
     };
 
     void exec();
+
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus]);
 
@@ -467,9 +474,6 @@ const MultiSelect = ({
             }}
             onFocus={(event) => {
               setOpen(true);
-              if (triggerSearchOnFocus) {
-                void onSearch?.(debouncedSearchTerm);
-              }
               inputProps?.onFocus?.(event);
             }}
             placeholder={hidePlaceholderWhenSelected && selected.length !== 0 ? '' : placeholder}


### PR DESCRIPTION
<!--
  We are no longer accepting external pull requests.
  Aside from a small group of trusted contributors we reach out to directly,
  new external PRs will usually be closed with a request to open an issue instead.
  This is a security decision. See https://documenso.com/blog/why-we-re-pausing-external-pull-requests
  If you're a trusted contributor or maintainer, continue below.
  Otherwise, please open a detailed issue: https://github.com/documenso/documenso/issues/new/choose
-->

## Description
Fixes a race condition and duplicate request behavior in the multiselect async search flow. Slow responses could overwrite newer results, and the search logic was issuing redundant requests for the same debounced term. This change also makes loading state recovery more reliable when requests fail.

## Related Issue
Fixes #3164

## Changes Made
- Added cancellation guards so stale async search responses cannot overwrite newer results.
- Removed the duplicate request path for non-empty debounced search terms.
- Removed the redundant `onFocus` search call that was immediately discarded.
- Applied the same cleanup to the synchronous search path for consistency.
- Wrapped async search in `try/catch/finally` so loading state is always cleared, even on failure.

## Testing Performed
- Manually tested multiselect search with fast and slow responses.
- Verified newer search results are not replaced by stale responses.
- Confirmed only one request is fired per debounced search term.
- Checked that loading state resets correctly after a failed request.

## Checklist
- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes
This change focuses on search correctness and request deduplication in multiselect. The main goal was to prevent stale async results from winning the race and to keep loading state consistent in all outcomes.