### PR TITLE
fix(emails): remove trailing period from document pending email subject

### DIFF
--- a/packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts
@@ -93,7 +93,7 @@ export const run = async ({ payload }: { payload: TSendDocumentPendingEmailJobDe
     },
     from: senderEmail,
     replyTo: replyToEmail,
-    subject: i18n._(msg`Waiting for others to complete signing.`),
+    subject: i18n._(msg`Waiting for others to complete signing`),
     html,
     text,
   });


### PR DESCRIPTION
## Problem

The document pending email subject ends with a trailing period:

> "Waiting for others to complete signing."

According to UI/typography guidelines, email subjects and short headers should not end with full stops.

## Solution

Removed the trailing period from the subject string:

> "Waiting for others to complete signing"

## Changes

- `packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts`: Removed trailing `.` from the `msg\`...\`` call

## References

Fixes #3212