### PR TITLE
fix: stop V1 signing page disclosing sender when the setting hides it

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
@@ -13,6 +13,7 @@ import {
 } from '@documenso/lib/types/field-meta';
 import type { CompletedField } from '@documenso/lib/types/fields';
 import { isFieldUnsignedAndRequired } from '@documenso/lib/utils/advanced-fields-helpers';
+import { resolveDocumentSender } from '@documenso/lib/utils/document-sender';
 import { getDocumentDataUrlForPdfViewer } from '@documenso/lib/utils/envelope-download';
 import { validateFieldsInserted } from '@documenso/lib/utils/fields';
 import type { FieldWithSignatureAndFieldMeta } from '@documenso/prisma/types/field-with-signature-and-fieldmeta';
@@ -131,13 +132,14 @@ export const DocumentSigningPageViewV1 = ({
     }
   };
 
-  let senderName = document.user.name ?? '';
-  let senderEmail = `(${document.user.email})`;
+  const sender = resolveDocumentSender({
+    includeSenderDetails,
+    user: document.user,
+    team: document.team,
+  });
 
-  if (includeSenderDetails) {
-    senderName = document.team?.name ?? '';
-    senderEmail = document.team?.teamEmail?.email ? `(${document.team.teamEmail.email})` : '';
-  }
+  const senderName = sender.name;
+  const senderEmail = sender.email ? `(${sender.email})` : '';
 
   const selectedSigner = allRecipients?.find((r) => r.id === selectedSignerId);
   const targetSigner = recipient.role === RecipientRole.ASSISTANT && selectedSigner ? selectedSigner : null;

--- a/packages/lib/utils/document-sender.test.ts
+++ b/packages/lib/utils/document-sender.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDocumentSender } from './document-sender';
+
+const user = {
+  name: 'John Doe',
+  email: 'john@acme.com',
+};
+
+const team = {
+  name: 'Acme',
+  teamEmail: { email: 'billing@acme.com' },
+};
+
+describe('resolveDocumentSender', () => {
+  it('discloses the individual sender when includeSenderDetails is enabled', () => {
+    expect(resolveDocumentSender({ includeSenderDetails: true, user, team })).toEqual({
+      name: 'John Doe',
+      email: 'john@acme.com',
+    });
+  });
+
+  it('withholds the individual sender and shows the team when includeSenderDetails is disabled', () => {
+    expect(resolveDocumentSender({ includeSenderDetails: false, user, team })).toEqual({
+      name: 'Acme',
+      email: 'billing@acme.com',
+    });
+  });
+
+  it('never leaks the individual name or email when includeSenderDetails is disabled', () => {
+    const sender = resolveDocumentSender({ includeSenderDetails: false, user, team });
+
+    expect(sender.name).not.toBe(user.name);
+    expect(sender.email).not.toBe(user.email);
+  });
+
+  it('falls back to empty strings when the team has no name or team email', () => {
+    expect(
+      resolveDocumentSender({
+        includeSenderDetails: false,
+        user,
+        team: { name: null, teamEmail: null },
+      }),
+    ).toEqual({
+      name: '',
+      email: '',
+    });
+  });
+
+  it('does not fall back to the individual sender when the team is missing', () => {
+    const sender = resolveDocumentSender({ includeSenderDetails: false, user, team: null });
+
+    expect(sender).toEqual({ name: '', email: '' });
+    expect(sender.email).not.toBe(user.email);
+  });
+
+  it('falls back to an empty name when the individual sender has no name set', () => {
+    expect(
+      resolveDocumentSender({
+        includeSenderDetails: true,
+        user: { name: null, email: 'john@acme.com' },
+        team,
+      }),
+    ).toEqual({
+      name: '',
+      email: 'john@acme.com',
+    });
+  });
+});

--- a/packages/lib/utils/document-sender.ts
+++ b/packages/lib/utils/document-sender.ts
@@ -1,0 +1,53 @@
+type DocumentSenderUser = {
+  name?: string | null;
+  email: string;
+};
+
+type DocumentSenderTeam = {
+  name?: string | null;
+  teamEmail?: { email: string } | null;
+};
+
+export type DocumentSender = {
+  name: string;
+  email: string;
+};
+
+type ResolveDocumentSenderOptions = {
+  /**
+   * The team/organisation setting surfaced in the UI as "Send on Behalf of Team".
+   *
+   * When enabled the individual sender is disclosed, when disabled it is withheld.
+   */
+  includeSenderDetails: boolean;
+  user: DocumentSenderUser;
+  team?: DocumentSenderTeam | null;
+};
+
+/**
+ * Resolve the identity presented to a recipient as the sender of a document.
+ *
+ * When `includeSenderDetails` is enabled the individual who sent the document is named,
+ * and the caller pairs it with `on behalf of "<team>"`. When it is disabled the individual's
+ * name and email are withheld from the recipient and only the team is shown.
+ *
+ * Mirrors the canonical server-side behaviour in `getEnvelopeForRecipientSigning` and
+ * `getEnvelopeForDirectTemplateSigning`, and the preview rendered by the setting itself.
+ */
+export const resolveDocumentSender = ({
+  includeSenderDetails,
+  user,
+  team,
+}: ResolveDocumentSenderOptions): DocumentSender => {
+  if (includeSenderDetails) {
+    return {
+      name: user.name ?? '',
+      email: user.email,
+    };
+  }
+
+  return {
+    name: team?.name ?? '',
+    email: team?.teamEmail?.email ?? '',
+  };
+};


### PR DESCRIPTION
Fixes #3198.

## Root cause

`document-signing-page-view-v1.tsx` chose *which* identity to show the recipient with the two `includeSenderDetails` branches swapped:

```ts
let senderName = document.user.name ?? '';
let senderEmail = `(${document.user.email})`;

if (includeSenderDetails) {
  senderName = document.team?.name ?? '';                      // ← team, on the "show sender" branch
  senderEmail = document.team?.teamEmail?.email ? `(${document.team.teamEmail.email})` : '';
}
```

The surrounding JSX is correct — it already pairs the enabled case with `on behalf of "{document.team?.name}"`. Only the value assignment was inverted, so the two cases rendered:

| `includeSenderDetails` | Rendered | Expected |
| --- | --- | --- |
| `true` | `Acme (billing@acme.com) on behalf of "Acme" has invited you…` — team name twice, human sender gone | `John Doe (john@acme.com) on behalf of "Acme" has invited you…` |
| `false` | `John Doe (john@acme.com) has invited you…` — **individual's name and email disclosed** | `Acme (billing@acme.com) has invited you…` |

The `false` case is the privacy problem: with "Send on Behalf of Team" turned **off**, the collaborator's name and email were shown to an external signer, which is the configuration a user picks specifically to avoid that.

Three places in the repo independently agree on the intended semantics — enabled discloses the individual, disabled withholds them and shows only the team:

- `packages/lib/server-only/envelope/get-envelope-for-recipient-signing.ts` — `settings.includeSenderDetails ? { envelope.user… } : { envelope.team… }`
- `packages/lib/server-only/envelope/get-envelope-for-direct-template-signing.ts` — identical ternary
- `apps/remix/app/components/forms/email-preferences-form.tsx` — the setting's own preview: `true` → `"…" on behalf of "Team Name"`, `false` → `"Team Name" has invited you`
- `packages/email/template-components/template-document-invite.tsx` — `includeSenderDetails: true` → `{inviterName} on behalf of "{teamName}"`, else `{teamName} has invited you`

I also checked the route (`sign.$token+/_index.tsx`): the flag is passed straight through from `settings.includeSenderDetails` to the component with no inversion, so the bug was entirely local to the V1 view.

Only V1 is affected — the V2 header does not render this sentence.

## Fix

Rather than just flipping the `if`, I extracted the decision into a pure helper, `resolveDocumentSender` in `packages/lib/utils/document-sender.ts`, mirroring the shape of the canonical server-side ternary. This makes the rule directly unit-testable (the component itself pulls in tRPC, the PDF viewer and analytics, so it is not reachable from a unit test) and removes the mutable `let` in favour of `const`, per `CODE_STYLE.md`.

The helper takes structural types rather than importing Prisma types, so the test needs no Prisma client.

The component now reads:

```ts
const sender = resolveDocumentSender({
  includeSenderDetails,
  user: document.user,
  team: document.team,
});

const senderName = sender.name;
const senderEmail = sender.email ? `(${sender.email})` : '';
```

Behaviour is otherwise unchanged, including the existing empty-string fallbacks and the parenthesised email formatting.

## Verification

`packages/lib/utils/document-sender.test.ts` adds 6 cases covering both branches, the missing-team and missing-name fallbacks, and an explicit assertion that the individual's name and email never appear when the setting is disabled.

**Negative control** — I first wrote the helper with the original inverted branches and confirmed the tests catch the bug, including the leak itself:

```
Tests  6 failed (6)

AssertionError: expected { name: 'John Doe', email: 'john@acme.com' }
  to deeply equal { name: 'Acme', email: 'billing@acme.com' }
```

With the fix applied:

```
✓ utils/document-sender.test.ts (6 tests) 11ms
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Full `packages/lib` suite: **9 of 10 files, 191 tests passing**. The one failing file, `utils/recipients.test.ts`, fails at import with `Cannot find module '.prisma/client/default'` because I could not run `prisma generate` in my environment; it is unrelated to this change and fails independently of it.

Also confirmed: `npx tsc --noEmit --strict` is clean on the new helper, and the call site typechecks against the exact shapes `getDocumentAndSenderByToken` selects (including a nullable `team` and the full `TeamEmail` model). `biome check` reports no new diagnostics on the changed files — the two pre-existing `noUnusedVariables` warnings in the V1 component (`derivedRecipientAccessAuth`, `hasAuthenticator`) are untouched by this PR.

Not verified in a browser: my environment could not run the full dev stack (the npm install and `prisma generate` steps were unavailable), so this is verified by unit test, typecheck and cross-referencing the three internal sources of truth rather than by manually signing a V1 document. An E2E assertion on `/sign/:token` would be a reasonable follow-up if you'd like one.
