### PR TITLE
ci: fix the assigned-issue labeler crashing on every run

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   label-when-assigned:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Label issue
         uses: actions/github-script@v6
@@ -15,7 +17,7 @@ jobs:
           script: |
             const issue = context.issue;
             // To run only on issues and not on PR
-            if (github.context.payload.issue.pull_request === undefined) {
+            if (context.payload.issue.pull_request === undefined) {
               const labelResponse = await github.rest.issues.addLabels({
                 owner: issue.owner,
                 repo: issue.repo,


### PR DESCRIPTION
## What

`Auto Label Assigned Issues` has never worked. All 29 runs since it was added have failed, from 2025-08-21 through 2026-08-14 — zero successes in a year, so no assigned issue has ever received `status: assigned`.

Every run ends the same way:

```
TypeError: Cannot read properties of undefined (reading 'payload')
```

## Why

In `actions/github-script`, `github` is the authenticated Octokit client and `context` is a **separate top-level binding**. There is no `github.context`, so it is `undefined` and reading `.payload` off it throws immediately, before any API call happens.

The line directly above already gets this right:

```js
const issue = context.issue;                                    // correct
if (github.context.payload.issue.pull_request === undefined) {  // throws
```

## Change

Two things, both matching what already works in this repo:

1. `github.context.payload` → `context.payload`.
2. Declare `permissions: issues: write` on the job. `issue-opened.yml` makes the same `github.rest.issues.addLabels` call, declares that scope, and succeeds — this is the only write-performing workflow here without a `permissions` block, so once the TypeError is gone the default token would likely 403 on the label write.

I left the `pull_request` guard in place rather than removing it, since that is a separate judgement call.
