### PR TITLE
docs: replace dead enterprise Cal.com booking link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Join us in creating the next generation of open trust infrastructure.
 
 Contact us if you are interested in our Enterprise plan for large organizations that need extra flexibility and control.
 
-<a href="https://cal.com/timurercan/enterprise-customers?utm_source=banner&utm_campaign=oss"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" /></a>
+<a href="https://cal.com/timurercan/30min"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" /></a>
 
 ## Tech Stack
 


### PR DESCRIPTION
The README's enterprise banner links to `cal.com/timurercan/enterprise-customers` which now returns 404 — that Cal.com event appears to have been removed. Updated to `cal.com/timurercan/30min`, which is the founder's general booking page (verified live, 200). If there's a different preferred enterprise contact link, happy to swap.