### PR TITLE
fix: don't create a field on top of an identical one

### DIFF
--- a/packages/lib/client-only/hooks/use-editor-fields.ts
+++ b/packages/lib/client-only/hooks/use-editor-fields.ts
@@ -2,6 +2,7 @@ import { getPdfPagesCount } from '@documenso/lib/constants/pdf-viewer';
 import type { TEditorEnvelope } from '@documenso/lib/types/envelope-editor';
 import { ZFieldMetaSchema } from '@documenso/lib/types/field-meta';
 import { nanoid } from '@documenso/lib/universal/id';
+import { findDuplicateField } from '@documenso/lib/utils/fields-overlap';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { Field } from '@prisma/client';
 import { FieldType } from '@prisma/client';
@@ -140,12 +141,26 @@ export const useEditorFields = ({ envelope, handleFieldsUpdate }: EditorFieldsPr
         ...restrictFieldPosValues(fieldData),
       };
 
+      // Three paths create fields: click to place, drag to draw, and AI
+      // detection. If two of them run for one action the same placement is
+      // written twice and the copies sit on top of each other.
+      //
+      // The signer cannot recover from that. They fill the field on top, the one
+      // underneath stays uninserted, and the envelope keeps asking for a field
+      // they cannot click because its twin covers it.
+      const duplicate = findDuplicateField(localFields, field);
+
+      if (duplicate) {
+        setSelectedField(duplicate.formId, true);
+        return duplicate;
+      }
+
       append(field);
       triggerFieldsUpdate();
       setSelectedField(field.formId, true);
       return field;
     },
-    [append, triggerFieldsUpdate, setSelectedField],
+    [append, triggerFieldsUpdate, setSelectedField, localFields],
   );
 
   const removeFieldsByFormId = useCallback(

--- a/packages/lib/utils/fields-overlap.test.ts
+++ b/packages/lib/utils/fields-overlap.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FIELD_DUPLICATE_THRESHOLD,
+  findDuplicateField,
+  getOverlappingFieldPairs,
+  hasOverlappingFields,
+} from './fields-overlap';
+
+const field = (overrides: Partial<ReturnType<typeof base>> = {}) => ({ ...base(), ...overrides });
+
+const base = () => ({
+  id: 1,
+  envelopeItemId: 'item-1',
+  page: 2,
+  positionX: 10,
+  positionY: 20,
+  width: 10,
+  height: 5,
+  recipientId: 7,
+  type: 'SIGNATURE',
+});
+
+describe('getOverlappingFieldPairs', () => {
+  it('finds a pair covering most of each other', () => {
+    const pairs = getOverlappingFieldPairs([field({ id: 1 }), field({ id: 2 })]);
+
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].overlapRatio).toBe(1);
+  });
+
+  it('ignores fields that only touch at the edges', () => {
+    expect(getOverlappingFieldPairs([field({ id: 1 }), field({ id: 2, positionX: 20 })])).toHaveLength(0);
+  });
+
+  it('ignores fields on a different page or envelope item', () => {
+    expect(getOverlappingFieldPairs([field({ id: 1 }), field({ id: 2, page: 3 })])).toHaveLength(0);
+    expect(getOverlappingFieldPairs([field({ id: 1 }), field({ id: 2, envelopeItemId: 'item-2' })])).toHaveLength(0);
+  });
+
+  it('measures the ratio against the smaller field', () => {
+    // A small field sitting inside a large one is fully covered, even though it
+    // takes up little of the larger field.
+    const pairs = getOverlappingFieldPairs([
+      field({ id: 1, width: 40, height: 20 }),
+      field({ id: 2, width: 4, height: 2 }),
+    ]);
+
+    expect(pairs[0].overlapRatio).toBe(1);
+  });
+});
+
+describe('hasOverlappingFields', () => {
+  it('reports whether any pair overlaps', () => {
+    expect(hasOverlappingFields([field({ id: 1 }), field({ id: 2 })])).toBe(true);
+    expect(hasOverlappingFields([field({ id: 1 }), field({ id: 2, positionX: 50 })])).toBe(false);
+    expect(hasOverlappingFields([field()])).toBe(false);
+  });
+});
+
+describe('findDuplicateField', () => {
+  it('finds a field the candidate would land on top of', () => {
+    const existing = field({ id: 1 });
+
+    expect(findDuplicateField([existing], field({ id: 2 }))).toBe(existing);
+  });
+
+  it('catches the case that leaves a signer stuck', () => {
+    // Both fields were written to the same position for the same recipient, so
+    // only the top one could be filled in and the envelope never completed.
+    const existing = field({ id: 90, type: 'DATE', positionX: 66.666667, positionY: 87.137971 });
+    const candidate = field({ id: 91, type: 'DATE', positionX: 66.666667, positionY: 87.137971 });
+
+    expect(findDuplicateField([existing], candidate)).toBe(existing);
+  });
+
+  it('leaves fields for another recipient or of another type alone', () => {
+    expect(findDuplicateField([field({ id: 1, recipientId: 8 })], field({ id: 2 }))).toBeUndefined();
+    expect(findDuplicateField([field({ id: 1, type: 'DATE' })], field({ id: 2 }))).toBeUndefined();
+  });
+
+  it('leaves fields the sender placed close together alone', () => {
+    // Half covered is well below the duplicate threshold, so this is treated as
+    // two fields rather than one written twice.
+    const existing = field({ id: 1 });
+    const candidate = field({ id: 2, positionX: 15 });
+
+    expect(findDuplicateField([existing], candidate)).toBeUndefined();
+    expect(FIELD_DUPLICATE_THRESHOLD).toBeGreaterThan(0.5);
+  });
+
+  it('ignores fields with no area', () => {
+    expect(findDuplicateField([field({ id: 1 })], field({ id: 2, width: 0 }))).toBeUndefined();
+    expect(findDuplicateField([field({ id: 1, height: 0 })], field({ id: 2 }))).toBeUndefined();
+  });
+
+  it('works on editor fields, which have no id until they are saved', () => {
+    // The editor calls this while placing a field, before it has been persisted,
+    // so the only identifier it carries is the client-side formId.
+    const existing = { ...base(), id: undefined, formId: 'a' };
+    const candidate = { ...base(), id: undefined, formId: 'b' };
+
+    expect(findDuplicateField([existing], candidate)).toBe(existing);
+  });
+});

--- a/packages/lib/utils/fields-overlap.ts
+++ b/packages/lib/utils/fields-overlap.ts
@@ -19,18 +19,25 @@
  */
 export const FIELD_OVERLAP_THRESHOLD = 0.4;
 
-type OverlapFieldInput = {
-  /**
-   * A stable identifier used to reference the field in the returned pairs.
-   * Use the client-side `formId` in the editor, or the database `id` elsewhere.
-   */
-  id: string | number;
+/**
+ * The position and size of a field on a page. Enough on its own to compare two
+ * fields geometrically, without needing them to be identifiable.
+ */
+type FieldGeometry = {
   envelopeItemId: string;
   page: number;
   positionX: number;
   positionY: number;
   width: number;
   height: number;
+};
+
+type OverlapFieldInput = FieldGeometry & {
+  /**
+   * A stable identifier used to reference the field in the returned pairs.
+   * Use the client-side `formId` in the editor, or the database `id` elsewhere.
+   */
+  id: string | number;
 };
 
 export type TFieldOverlapPair<T extends OverlapFieldInput> = {
@@ -47,7 +54,7 @@ export type TFieldOverlapPair<T extends OverlapFieldInput> = {
  *
  * Returns 0 when the fields do not intersect.
  */
-const getIntersectionArea = (fieldA: OverlapFieldInput, fieldB: OverlapFieldInput): number => {
+const getIntersectionArea = (fieldA: FieldGeometry, fieldB: FieldGeometry): number => {
   const overlapX = Math.max(
     0,
     Math.min(fieldA.positionX + fieldA.width, fieldB.positionX + fieldB.width) -
@@ -120,4 +127,65 @@ export const hasOverlappingFields = <T extends OverlapFieldInput>(
   threshold: number = FIELD_OVERLAP_THRESHOLD,
 ): boolean => {
   return getOverlappingFieldPairs(fields, threshold).length > 0;
+};
+
+/**
+ * The overlap ratio above which two fields of the same type, for the same recipient,
+ * are treated as the same field rather than two deliberately placed ones.
+ *
+ * Set high so that fields a sender has intentionally placed close together are not
+ * mistaken for duplicates.
+ */
+export const FIELD_DUPLICATE_THRESHOLD = 0.9;
+
+/**
+ * A field being compared for duplication. Deliberately does not require an `id`:
+ * a field being placed in the editor has no database id yet.
+ */
+type DuplicateFieldInput = FieldGeometry & {
+  recipientId: number;
+  type: string;
+};
+
+/**
+ * Finds an existing field that a candidate would effectively duplicate.
+ *
+ * Only fields of the same type, for the same recipient, on the same page of the same
+ * envelope item are considered, and only when they cover each other almost entirely.
+ * Such a pair is indistinguishable to a signer: only the field on top can be clicked,
+ * so the one underneath can never be filled in and the envelope can never complete.
+ *
+ * @param fields The existing fields. Positional values must be percentages (0-100).
+ * @param candidate The field about to be created.
+ * @param threshold The minimum overlap ratio (0-1). Defaults to {@link FIELD_DUPLICATE_THRESHOLD}.
+ */
+export const findDuplicateField = <T extends DuplicateFieldInput>(
+  fields: T[],
+  candidate: DuplicateFieldInput,
+  threshold: number = FIELD_DUPLICATE_THRESHOLD,
+): T | undefined => {
+  const candidateArea = candidate.width * candidate.height;
+
+  if (candidateArea <= 0) {
+    return undefined;
+  }
+
+  return fields.find((field) => {
+    if (
+      field.recipientId !== candidate.recipientId ||
+      field.type !== candidate.type ||
+      field.envelopeItemId !== candidate.envelopeItemId ||
+      field.page !== candidate.page
+    ) {
+      return false;
+    }
+
+    const fieldArea = field.width * field.height;
+
+    if (fieldArea <= 0) {
+      return false;
+    }
+
+    return getIntersectionArea(field, candidate) / Math.min(fieldArea, candidateArea) >= threshold;
+  });
 };


### PR DESCRIPTION
`addField` appends without checking, so the same placement can be written twice and you end up with two fields on the same spot for the same recipient.

Three things call it: click to place in `envelope-editor-fields-drag-drop`, drag to draw in `envelope-editor-fields-page-renderer`, and AI detection in `envelope-editor-fields-page`. If two of them run for one action you get the duplicate.

The reason this matters more than it sounds is that the signer cannot get out of it. They fill the field on top, the copy underneath stays uninserted, and the envelope keeps asking for a field they cannot click because the first one is covering it. Next field has nowhere to scroll to and the document never completes.

I know `fields-overlap.ts` already exists and that both the editor and the distribute dialog warn when fields overlap. That warning is the right thing for a sender who placed two fields close together. It does not help here, because nobody placed the second field, and the person who gets stuck is the signer, who never sees the editor or the warning. `invalidEnvelopeCode` in the distribute dialog blocks on missing signatures, missing recipients and a missing required email, but overlap is only a warning, so these envelopes go out.

Data from a self hosted 2.15.0, read back over the API:

```
id=90 DATE page=2 X=66.666667 Y=87.137971 recipientId=33 inserted=False
id=91 DATE page=2 X=66.666667 Y=87.137971 recipientId=33 inserted=False
```

```
SIGNATURE page=4 X=12.406 Y=12.137 recipientId=25 ids=[(78, False), (81, True)]
DATE      page=4 X=17.669 Y=19.046 recipientId=25 ids=[(79, False), (82, False)]
```

Identical to six decimals, so this is not two clicks landing close together, it is the same object written twice. In the second case the recipient had already signed, field 81, and still could not finish the agreement.

The change adds `findDuplicateField` to the existing `fields-overlap` utilities and uses it in `addField`, which now selects the existing field rather than stacking a new one on top. It reuses `getIntersectionArea` so the geometry stays in one place. It only matches fields of the same type, for the same recipient, on the same page of the same envelope item, and only when they cover at least 90 percent of each other, so anything a sender placed close together on purpose is left alone.

There were no tests on `fields-overlap.ts`, so I added them for the new function and for `getOverlappingFieldPairs` and `hasOverlappingFields` while I was there.

You asked on #907 whether sending should be blocked when fields are stacked. I have not done that here since it changes behaviour for existing users, but I am happy to add it if you want it, either in this PR or a follow up.
