### PR TITLE
fix: notify organisation managers when an invite is declined

### DIFF
--- a/packages/email/preview/app/lib/templates.tsx
+++ b/packages/email/preview/app/lib/templates.tsx
@@ -20,6 +20,7 @@ import { ForgotPasswordTemplate } from '../../../templates/forgot-password';
 import { OrganisationAccountLinkConfirmationTemplate } from '../../../templates/organisation-account-link-confirmation';
 import { OrganisationDeleteEmailTemplate } from '../../../templates/organisation-delete';
 import { OrganisationInviteEmailTemplate } from '../../../templates/organisation-invite';
+import { OrganisationInviteDeclinedEmailTemplate } from '../../../templates/organisation-invite-declined';
 import { OrganisationJoinEmailTemplate } from '../../../templates/organisation-join';
 import { OrganisationLeaveEmailTemplate } from '../../../templates/organisation-leave';
 import { OrganisationLimitAlertEmailTemplate } from '../../../templates/organisation-limit-alert';
@@ -267,6 +268,15 @@ export const templates: Record<string, TemplateDefinition> = {
     component: OrganisationJoinEmailTemplate,
     fields: {
       memberName: { type: 'text', label: 'Member name', default: 'Lucas Smith' },
+      organisationName: { type: 'text', label: 'Organisation name', default: 'Documenso' },
+    },
+  },
+  'organisation-invite-declined': {
+    name: 'Organisation invite declined',
+    group: 'Organisations',
+    component: OrganisationInviteDeclinedEmailTemplate,
+    fields: {
+      inviteeEmail: { type: 'text', label: 'Invitee email', default: 'lucas@documenso.com' },
       organisationName: { type: 'text', label: 'Organisation name', default: 'Documenso' },
     },
   },

--- a/packages/email/templates/organisation-invite-declined.tsx
+++ b/packages/email/templates/organisation-invite-declined.tsx
@@ -1,0 +1,69 @@
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
+import { Trans } from '@lingui/react/macro';
+
+import { Body, Container, Head, Hr, Html, Preview, Section, Text } from '../components';
+import { TemplateBrandingLogo } from '../template-components/template-branding-logo';
+import { TemplateFooter } from '../template-components/template-footer';
+import TemplateImage from '../template-components/template-image';
+
+export type OrganisationInviteDeclinedEmailProps = {
+  assetBaseUrl: string;
+  baseUrl: string;
+  inviteeEmail: string;
+  organisationName: string;
+  organisationUrl: string;
+};
+
+export const OrganisationInviteDeclinedEmailTemplate = ({
+  assetBaseUrl = 'http://localhost:3002',
+  baseUrl = 'https://documenso.com',
+  inviteeEmail = 'johndoe@documenso.com',
+  organisationName = 'Organisation Name',
+  organisationUrl = 'demo',
+}: OrganisationInviteDeclinedEmailProps) => {
+  const { _ } = useLingui();
+
+  const previewText = msg`An organisation invite has been declined on Documenso`;
+
+  return (
+    <Html>
+      <Head />
+      <Body className="mx-auto my-auto font-sans">
+        <Preview>{_(previewText)}</Preview>
+
+        <Section className="bg-background text-muted-foreground">
+          <Container className="mx-auto mt-8 mb-2 max-w-xl rounded-lg border border-border border-solid p-2 backdrop-blur-sm">
+            <TemplateBrandingLogo assetBaseUrl={assetBaseUrl} className="mb-4 h-6 p-2" />
+
+            <Section>
+              <TemplateImage className="mx-auto" assetBaseUrl={assetBaseUrl} staticAsset="add-user.png" />
+            </Section>
+
+            <Section className="p-2 text-muted-foreground">
+              <Text className="text-center font-medium text-foreground text-lg">
+                <Trans>An invite to your organisation {organisationName} has been declined</Trans>
+              </Text>
+
+              <Text className="my-1 text-center text-base">
+                <Trans>The following user has declined their invitation to join</Trans>
+              </Text>
+
+              <div className="mx-auto my-2 w-fit rounded-lg bg-muted px-4 py-2 font-medium text-base text-muted-foreground">
+                {inviteeEmail}
+              </div>
+            </Section>
+          </Container>
+
+          <Hr className="mx-auto mt-12 max-w-xl" />
+
+          <Container className="mx-auto max-w-xl">
+            <TemplateFooter isDocument={false} />
+          </Container>
+        </Section>
+      </Body>
+    </Html>
+  );
+};
+
+export default OrganisationInviteDeclinedEmailTemplate;

--- a/packages/lib/jobs/client.ts
+++ b/packages/lib/jobs/client.ts
@@ -7,6 +7,7 @@ import { SEND_DOCUMENT_CREATED_FROM_DIRECT_TEMPLATE_EMAIL_JOB_DEFINITION } from 
 import { SEND_DOCUMENT_DELETED_EMAILS_JOB_DEFINITION } from './definitions/emails/send-document-deleted-emails';
 import { SEND_DOCUMENT_PENDING_EMAIL_JOB_DEFINITION } from './definitions/emails/send-document-pending-email';
 import { SEND_ORGANISATION_LIMIT_ALERT_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-limit-alert-email';
+import { SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-invite-declined-email';
 import { SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-joined-email';
 import { SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-left-email';
 import { SEND_OWNER_RECIPIENT_EXPIRED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-owner-recipient-expired-email';
@@ -42,6 +43,7 @@ export const jobsClient = new JobClient([
   SEND_CONFIRMATION_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION,
+  SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_LIMIT_ALERT_EMAIL_JOB_DEFINITION,
   SEND_TEAM_DELETED_EMAIL_JOB_DEFINITION,
   SEAL_DOCUMENT_JOB_DEFINITION,

--- a/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.handler.ts
@@ -1,0 +1,93 @@
+import OrganisationInviteDeclinedEmailTemplate from '@documenso/email/templates/organisation-invite-declined';
+import { prisma } from '@documenso/prisma';
+import { msg } from '@lingui/core/macro';
+import { createElement } from 'react';
+
+import { getI18nInstance } from '../../../client-only/providers/i18n-server';
+import { NEXT_PUBLIC_WEBAPP_URL } from '../../../constants/app';
+import { ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP } from '../../../constants/organisations';
+import { getEmailContext } from '../../../server-only/email/get-email-context';
+import { renderEmailWithI18N } from '../../../utils/render-email-with-i18n';
+import type { JobRunIO } from '../../client/_internal/job';
+import type { TSendOrganisationInviteDeclinedEmailJobDefinition } from './send-organisation-invite-declined-email';
+
+export const run = async ({
+  payload,
+  io,
+}: {
+  payload: TSendOrganisationInviteDeclinedEmailJobDefinition;
+  io: JobRunIO;
+}) => {
+  const organisation = await prisma.organisation.findFirstOrThrow({
+    where: {
+      id: payload.organisationId,
+    },
+    include: {
+      members: {
+        where: {
+          organisationGroupMembers: {
+            some: {
+              group: {
+                organisationRole: {
+                  in: ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP['MANAGE_ORGANISATION'],
+                },
+              },
+            },
+          },
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const { branding, emailLanguage, senderEmail, emailTransport } = await getEmailContext({
+    emailType: 'INTERNAL',
+    source: {
+      type: 'organisation',
+      organisationId: organisation.id,
+    },
+  });
+
+  for (const member of organisation.members) {
+    await io.runTask(`send-organisation-invite-declined-email--${member.id}`, async () => {
+      const emailContent = createElement(OrganisationInviteDeclinedEmailTemplate, {
+        assetBaseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+        baseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+        inviteeEmail: payload.inviteeEmail,
+        organisationName: organisation.name,
+        organisationUrl: organisation.url,
+      });
+
+      // !: Replace with the actual language of the recipient later
+      const [html, text] = await Promise.all([
+        renderEmailWithI18N(emailContent, {
+          lang: emailLanguage,
+          branding,
+        }),
+        renderEmailWithI18N(emailContent, {
+          lang: emailLanguage,
+          branding,
+          plainText: true,
+        }),
+      ]);
+
+      const i18n = await getI18nInstance(emailLanguage);
+
+      await emailTransport.sendMail({
+        to: member.user.email,
+        from: senderEmail,
+        subject: i18n._(msg`An organisation invite has been declined`),
+        html,
+        text,
+      });
+    });
+  }
+};

--- a/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import type { JobDefinition } from '../../client/_internal/job';
+
+const SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID = 'send.organisation-invite-declined.email';
+
+const SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA = z.object({
+  organisationId: z.string(),
+  inviteeEmail: z.string(),
+});
+
+export type TSendOrganisationInviteDeclinedEmailJobDefinition = z.infer<
+  typeof SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA
+>;
+
+export const SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION = {
+  id: SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  name: 'Send Organisation Invite Declined Email',
+  version: '1.0.0',
+  trigger: {
+    name: SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+    schema: SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA,
+  },
+  handler: async ({ payload, io }) => {
+    const handler = await import('./send-organisation-invite-declined-email.handler');
+
+    await handler.run({ payload, io });
+  },
+} as const satisfies JobDefinition<
+  typeof SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  TSendOrganisationInviteDeclinedEmailJobDefinition
+>;

--- a/packages/trpc/server/organisation-router/decline-organisation-member-invite.ts
+++ b/packages/trpc/server/organisation-router/decline-organisation-member-invite.ts
@@ -1,4 +1,5 @@
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { jobs } from '@documenso/lib/jobs/client';
 import { prisma } from '@documenso/prisma';
 import { OrganisationMemberInviteStatus } from '@prisma/client';
 
@@ -24,14 +25,26 @@ export const declineOrganisationMemberInviteRoute = maybeAuthenticatedProcedure
       throw new AppError(AppErrorCode.NOT_FOUND);
     }
 
-    await prisma.organisationMemberInvite.update({
+    // Only a PENDING invite can transition to DECLINED. Guarding on the previous
+    // status keeps repeated decline requests idempotent and stops them from
+    // re-notifying the organisation managers.
+    const { count } = await prisma.organisationMemberInvite.updateMany({
       where: {
         id: organisationMemberInvite.id,
+        status: OrganisationMemberInviteStatus.PENDING,
       },
       data: {
         status: OrganisationMemberInviteStatus.DECLINED,
       },
     });
 
-    // TODO: notify the team owner
+    if (count === 1) {
+      await jobs.triggerJob({
+        name: 'send.organisation-invite-declined.email',
+        payload: {
+          organisationId: organisationMemberInvite.organisationId,
+          inviteeEmail: organisationMemberInvite.email,
+        },
+      });
+    }
   });


### PR DESCRIPTION
## Summary

Fixes #2755.

When an organisation member invite was declined, the invite status was updated to `DECLINED` but nobody was told — the route carried a `// TODO: notify the team owner`, so owners had no way to learn an invitation was rejected short of watching the settings page.

## What this does

Follows the exact pattern already used by `send.organisation-member-joined.email` / `send.organisation-member-left.email`:

- **New job** `send.organisation-invite-declined.email` (`packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.ts` + handler), registered in `packages/lib/jobs/client.ts`. The handler emails every organisation member with `MANAGE_ORGANISATION` — the same audience the joined/left notifications go to — carrying the invitee's email and the organisation name.
- **New template** `OrganisationInviteDeclinedEmailTemplate` in `packages/email/templates/organisation-invite-declined.tsx`, modelled on the `organisation-join` template (same layout family, i18n via lingui macros), and registered in the email preview app.
- **Trigger** from `declineOrganisationMemberInviteRoute`, replacing the TODO. The payload is self-contained (`organisationId` + `inviteeEmail`) so the job doesn't depend on the invite row still existing by the time it runs.
- **Idempotence guard**: the status update is now an `updateMany` constrained to `status: PENDING`, and the notification only fires when exactly one row transitioned — repeated decline requests (or two people clicking through the same email link) no longer re-notify managers.

## Notes

- New lingui strings will be picked up by the existing translations extraction workflow (Crowdin), matching how prior email templates landed.
- Didn't add unit tests: the repo has no test infrastructure for tRPC routes or job handlers (all existing tests are pure-utility modules in `packages/lib`); happy to add one if you'd like a harness introduced separately.
