### PR TITLE
fix: isolate post-seal webhook and email dispatch

### DIFF
--- a/packages/email/preview/app/lib/templates.tsx
+++ b/packages/email/preview/app/lib/templates.tsx
@@ -20,6 +20,7 @@ import { ForgotPasswordTemplate } from '../../../templates/forgot-password';
 import { OrganisationAccountLinkConfirmationTemplate } from '../../../templates/organisation-account-link-confirmation';
 import { OrganisationDeleteEmailTemplate } from '../../../templates/organisation-delete';
 import { OrganisationInviteEmailTemplate } from '../../../templates/organisation-invite';
+import { OrganisationInviteDeclinedEmailTemplate } from '../../../templates/organisation-invite-declined';
 import { OrganisationJoinEmailTemplate } from '../../../templates/organisation-join';
 import { OrganisationLeaveEmailTemplate } from '../../../templates/organisation-leave';
 import { OrganisationLimitAlertEmailTemplate } from '../../../templates/organisation-limit-alert';
@@ -267,6 +268,15 @@ export const templates: Record<string, TemplateDefinition> = {
     component: OrganisationJoinEmailTemplate,
     fields: {
       memberName: { type: 'text', label: 'Member name', default: 'Lucas Smith' },
+      organisationName: { type: 'text', label: 'Organisation name', default: 'Documenso' },
+    },
+  },
+  'organisation-invite-declined': {
+    name: 'Organisation invite declined',
+    group: 'Organisations',
+    component: OrganisationInviteDeclinedEmailTemplate,
+    fields: {
+      inviteeEmail: { type: 'text', label: 'Invitee email', default: 'lucas@documenso.com' },
       organisationName: { type: 'text', label: 'Organisation name', default: 'Documenso' },
     },
   },

--- a/packages/email/templates/organisation-invite-declined.tsx
+++ b/packages/email/templates/organisation-invite-declined.tsx
@@ -1,0 +1,69 @@
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
+import { Trans } from '@lingui/react/macro';
+
+import { Body, Container, Head, Hr, Html, Preview, Section, Text } from '../components';
+import { TemplateBrandingLogo } from '../template-components/template-branding-logo';
+import { TemplateFooter } from '../template-components/template-footer';
+import TemplateImage from '../template-components/template-image';
+
+export type OrganisationInviteDeclinedEmailProps = {
+  assetBaseUrl: string;
+  baseUrl: string;
+  inviteeEmail: string;
+  organisationName: string;
+  organisationUrl: string;
+};
+
+export const OrganisationInviteDeclinedEmailTemplate = ({
+  assetBaseUrl = 'http://localhost:3002',
+  baseUrl = 'https://documenso.com',
+  inviteeEmail = 'johndoe@documenso.com',
+  organisationName = 'Organisation Name',
+  organisationUrl = 'demo',
+}: OrganisationInviteDeclinedEmailProps) => {
+  const { _ } = useLingui();
+
+  const previewText = msg`An organisation invite has been declined on Documenso`;
+
+  return (
+    <Html>
+      <Head />
+      <Body className="mx-auto my-auto font-sans">
+        <Preview>{_(previewText)}</Preview>
+
+        <Section className="bg-background text-muted-foreground">
+          <Container className="mx-auto mt-8 mb-2 max-w-xl rounded-lg border border-border border-solid p-2 backdrop-blur-sm">
+            <TemplateBrandingLogo assetBaseUrl={assetBaseUrl} className="mb-4 h-6 p-2" />
+
+            <Section>
+              <TemplateImage className="mx-auto" assetBaseUrl={assetBaseUrl} staticAsset="add-user.png" />
+            </Section>
+
+            <Section className="p-2 text-muted-foreground">
+              <Text className="text-center font-medium text-foreground text-lg">
+                <Trans>An invite to your organisation {organisationName} has been declined</Trans>
+              </Text>
+
+              <Text className="my-1 text-center text-base">
+                <Trans>The following user has declined their invitation to join</Trans>
+              </Text>
+
+              <div className="mx-auto my-2 w-fit rounded-lg bg-muted px-4 py-2 font-medium text-base text-muted-foreground">
+                {inviteeEmail}
+              </div>
+            </Section>
+          </Container>
+
+          <Hr className="mx-auto mt-12 max-w-xl" />
+
+          <Container className="mx-auto max-w-xl">
+            <TemplateFooter isDocument={false} />
+          </Container>
+        </Section>
+      </Body>
+    </Html>
+  );
+};
+
+export default OrganisationInviteDeclinedEmailTemplate;

--- a/packages/lib/jobs/client.ts
+++ b/packages/lib/jobs/client.ts
@@ -7,6 +7,7 @@ import { SEND_DOCUMENT_CREATED_FROM_DIRECT_TEMPLATE_EMAIL_JOB_DEFINITION } from 
 import { SEND_DOCUMENT_DELETED_EMAILS_JOB_DEFINITION } from './definitions/emails/send-document-deleted-emails';
 import { SEND_DOCUMENT_PENDING_EMAIL_JOB_DEFINITION } from './definitions/emails/send-document-pending-email';
 import { SEND_ORGANISATION_LIMIT_ALERT_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-limit-alert-email';
+import { SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-invite-declined-email';
 import { SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-joined-email';
 import { SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION } from './definitions/emails/send-organisation-member-left-email';
 import { SEND_OWNER_RECIPIENT_EXPIRED_EMAIL_JOB_DEFINITION } from './definitions/emails/send-owner-recipient-expired-email';
@@ -42,6 +43,7 @@ export const jobsClient = new JobClient([
   SEND_CONFIRMATION_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_JOINED_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_MEMBER_LEFT_EMAIL_JOB_DEFINITION,
+  SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION,
   SEND_ORGANISATION_LIMIT_ALERT_EMAIL_JOB_DEFINITION,
   SEND_TEAM_DELETED_EMAIL_JOB_DEFINITION,
   SEAL_DOCUMENT_JOB_DEFINITION,

--- a/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.handler.ts
@@ -1,0 +1,93 @@
+import OrganisationInviteDeclinedEmailTemplate from '@documenso/email/templates/organisation-invite-declined';
+import { prisma } from '@documenso/prisma';
+import { msg } from '@lingui/core/macro';
+import { createElement } from 'react';
+
+import { getI18nInstance } from '../../../client-only/providers/i18n-server';
+import { NEXT_PUBLIC_WEBAPP_URL } from '../../../constants/app';
+import { ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP } from '../../../constants/organisations';
+import { getEmailContext } from '../../../server-only/email/get-email-context';
+import { renderEmailWithI18N } from '../../../utils/render-email-with-i18n';
+import type { JobRunIO } from '../../client/_internal/job';
+import type { TSendOrganisationInviteDeclinedEmailJobDefinition } from './send-organisation-invite-declined-email';
+
+export const run = async ({
+  payload,
+  io,
+}: {
+  payload: TSendOrganisationInviteDeclinedEmailJobDefinition;
+  io: JobRunIO;
+}) => {
+  const organisation = await prisma.organisation.findFirstOrThrow({
+    where: {
+      id: payload.organisationId,
+    },
+    include: {
+      members: {
+        where: {
+          organisationGroupMembers: {
+            some: {
+              group: {
+                organisationRole: {
+                  in: ORGANISATION_MEMBER_ROLE_PERMISSIONS_MAP['MANAGE_ORGANISATION'],
+                },
+              },
+            },
+          },
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const { branding, emailLanguage, senderEmail, emailTransport } = await getEmailContext({
+    emailType: 'INTERNAL',
+    source: {
+      type: 'organisation',
+      organisationId: organisation.id,
+    },
+  });
+
+  for (const member of organisation.members) {
+    await io.runTask(`send-organisation-invite-declined-email--${member.id}`, async () => {
+      const emailContent = createElement(OrganisationInviteDeclinedEmailTemplate, {
+        assetBaseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+        baseUrl: NEXT_PUBLIC_WEBAPP_URL(),
+        inviteeEmail: payload.inviteeEmail,
+        organisationName: organisation.name,
+        organisationUrl: organisation.url,
+      });
+
+      // !: Replace with the actual language of the recipient later
+      const [html, text] = await Promise.all([
+        renderEmailWithI18N(emailContent, {
+          lang: emailLanguage,
+          branding,
+        }),
+        renderEmailWithI18N(emailContent, {
+          lang: emailLanguage,
+          branding,
+          plainText: true,
+        }),
+      ]);
+
+      const i18n = await getI18nInstance(emailLanguage);
+
+      await emailTransport.sendMail({
+        to: member.user.email,
+        from: senderEmail,
+        subject: i18n._(msg`An organisation invite has been declined`),
+        html,
+        text,
+      });
+    });
+  }
+};

--- a/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.ts
+++ b/packages/lib/jobs/definitions/emails/send-organisation-invite-declined-email.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import type { JobDefinition } from '../../client/_internal/job';
+
+const SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID = 'send.organisation-invite-declined.email';
+
+const SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA = z.object({
+  organisationId: z.string(),
+  inviteeEmail: z.string(),
+});
+
+export type TSendOrganisationInviteDeclinedEmailJobDefinition = z.infer<
+  typeof SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA
+>;
+
+export const SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION = {
+  id: SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  name: 'Send Organisation Invite Declined Email',
+  version: '1.0.0',
+  trigger: {
+    name: SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+    schema: SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_SCHEMA,
+  },
+  handler: async ({ payload, io }) => {
+    const handler = await import('./send-organisation-invite-declined-email.handler');
+
+    await handler.run({ payload, io });
+  },
+} as const satisfies JobDefinition<
+  typeof SEND_ORGANISATION_INVITE_DECLINED_EMAIL_JOB_DEFINITION_ID,
+  TSendOrganisationInviteDeclinedEmailJobDefinition
+>;

--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -333,27 +333,42 @@ export const run = async ({ payload, io }: { payload: TSealDocumentJobDefinition
     },
   });
 
-  await triggerWebhook({
-    event: isRejected ? WebhookTriggerEvents.DOCUMENT_REJECTED : WebhookTriggerEvents.DOCUMENT_COMPLETED,
-    data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(updatedEnvelope)),
-    userId: updatedEnvelope.userId,
-    teamId: updatedEnvelope.teamId ?? undefined,
-  });
-
   let shouldSendCompletedEmail = sendEmail && !isResealing && !isRejected;
 
   if (isResealing && !isDocumentCompleted(envelopeStatus)) {
     shouldSendCompletedEmail = sendEmail;
   }
 
-  if (shouldSendCompletedEmail) {
-    await jobs.triggerJob({
-      name: 'send.document.completed.emails',
-      payload: {
-        envelopeId,
-        requestMetadata,
-      },
+  // The seal transaction above has already committed. Dispatch the webhook and the
+  // completion email as independent post-seal side effects: a failure in one must
+  // neither fail this job for an already-sealed envelope nor block the other (#2814).
+  try {
+    await io.runTask('seal-document--trigger-webhook', async () => {
+      await triggerWebhook({
+        event: isRejected ? WebhookTriggerEvents.DOCUMENT_REJECTED : WebhookTriggerEvents.DOCUMENT_COMPLETED,
+        data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(updatedEnvelope)),
+        userId: updatedEnvelope.userId,
+        teamId: updatedEnvelope.teamId ?? undefined,
+      });
     });
+  } catch (err) {
+    io.logger.error('Failed to dispatch completion webhook for sealed envelope', err);
+  }
+
+  if (shouldSendCompletedEmail) {
+    try {
+      await io.runTask('seal-document--send-completed-emails', async () => {
+        await jobs.triggerJob({
+          name: 'send.document.completed.emails',
+          payload: {
+            envelopeId,
+            requestMetadata,
+          },
+        });
+      });
+    } catch (err) {
+      io.logger.error('Failed to queue completion emails for sealed envelope', err);
+    }
   }
 };
 

--- a/packages/trpc/server/organisation-router/decline-organisation-member-invite.ts
+++ b/packages/trpc/server/organisation-router/decline-organisation-member-invite.ts
@@ -1,4 +1,5 @@
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
+import { jobs } from '@documenso/lib/jobs/client';
 import { prisma } from '@documenso/prisma';
 import { OrganisationMemberInviteStatus } from '@prisma/client';
 
@@ -24,14 +25,26 @@ export const declineOrganisationMemberInviteRoute = maybeAuthenticatedProcedure
       throw new AppError(AppErrorCode.NOT_FOUND);
     }
 
-    await prisma.organisationMemberInvite.update({
+    // Only a PENDING invite can transition to DECLINED. Guarding on the previous
+    // status keeps repeated decline requests idempotent and stops them from
+    // re-notifying the organisation managers.
+    const { count } = await prisma.organisationMemberInvite.updateMany({
       where: {
         id: organisationMemberInvite.id,
+        status: OrganisationMemberInviteStatus.PENDING,
       },
       data: {
         status: OrganisationMemberInviteStatus.DECLINED,
       },
     });
 
-    // TODO: notify the team owner
+    if (count === 1) {
+      await jobs.triggerJob({
+        name: 'send.organisation-invite-declined.email',
+        payload: {
+          organisationId: organisationMemberInvite.organisationId,
+          inviteeEmail: organisationMemberInvite.email,
+        },
+      });
+    }
   });


### PR DESCRIPTION
## Summary

Addresses #2814.

**Status of the original report on current `main`:** the webhook is already dispatched *before* `send.document.completed.emails` is queued, and email delivery runs in its own background job — so SMTP failures can no longer block `DOCUMENT_COMPLETED` / `DOCUMENT_REJECTED` dispatch (details in the issue comment).

**What remained broken** is the symmetric coupling: both dispatches run unguarded in the job body *after* the seal transaction has committed.

- `triggerWebhook` throws on a webhook-listing failure → the whole seal job fails for an envelope that is **already sealed**, and the completion email is never queued.
- `jobs.triggerJob` rejecting (queue briefly unavailable) → same post-commit job failure, in the other direction.

Either way one post-seal side effect can fail the committed seal and suppress the other.

## Fix

Each dispatch now runs in its own `io.runTask` (gaining the backend's task-level retry semantics and stable cache keys) and is isolated from the other with a logged catch via `io.logger.error`:

```ts
try {
  await io.runTask('seal-document--trigger-webhook', async () => { ... });
} catch (err) {
  io.logger.error('Failed to dispatch completion webhook for sealed envelope', err);
}
```

A failure in one side effect can now neither fail the job for an already-sealed envelope nor block the other — the "independent post-seal side effect" behaviour the issue asks for.

## Notes

- Task cache keys (`seal-document--trigger-webhook`, `seal-document--send-completed-emails`) are unique within the job, so they don't collide with the existing `seal-document` task.
- No behavioral change to *when* webhooks/emails fire or to their payloads — only failure isolation around the two dispatches.
