### PR TITLE
fix: stop the V1 signing page inverting includeSenderDetails

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
@@ -131,12 +131,17 @@ export const DocumentSigningPageViewV1 = ({
     }
   };
 
-  let senderName = document.user.name ?? '';
-  let senderEmail = `(${document.user.email})`;
+  // includeSenderDetails=true shows the individual sender ("send on behalf of
+  // the team"); false hides them behind the team identity. This matches the
+  // canonical server-side helper (get-envelope-for-recipient-signing.ts) — the
+  // branches here used to be inverted, disclosing the sender's name and email
+  // in exactly the configuration chosen to hide them (#3198).
+  let senderName = document.team?.name ?? '';
+  let senderEmail = document.team?.teamEmail?.email ? `(${document.team.teamEmail.email})` : '';
 
   if (includeSenderDetails) {
-    senderName = document.team?.name ?? '';
-    senderEmail = document.team?.teamEmail?.email ? `(${document.team.teamEmail.email})` : '';
+    senderName = document.user.name ?? '';
+    senderEmail = `(${document.user.email})`;
   }
 
   const selectedSigner = allRecipients?.find((r) => r.id === selectedSignerId);


### PR DESCRIPTION
## Summary

Fixes #3198.

## The bug (as diagnosed in the issue, verified)

The V1 signing page resolved the sender with the `includeSenderDetails` branches **inverted** relative to the two internal references that define the correct polarity:

1. the canonical server-side helper, `get-envelope-for-recipient-signing.ts`:
   ```ts
   const sender = settings.includeSenderDetails
     ? { email: envelope.user.email,  name: envelope.user.name || '' }   // the USER
     : { email: team.teamEmail?.email, name: team.name || '' };          // the TEAM
   ```
2. the setting's own preview ("Send on Behalf of Team").

Rendered consequences on `/sign/:token` (V1):

- setting **ON** → `Acme (billing@acme.com) on behalf of "Acme" has invited you…` — the team on behalf of itself; the human sender disappears;
- setting **OFF** → `John Doe (john@acme.com) has invited you…` — **the individual's name and email disclosed to the external signer in exactly the configuration chosen to avoid that** (a privacy inversion, not just a cosmetic one).

## Fix

The page now resolves the sender the same way the canonical helper does: `includeSenderDetails=true` shows the user (rendered by the existing markup as "… on behalf of the team"), `false` shows only the team identity.

No markup or copy changes — only the two variable assignments swap polarity, with a comment pointing at the canonical helper.
