### PR TITLE
fix(ui): stop multiselect remove/clear buttons submitting forms

### DIFF
--- a/packages/ui/primitives/multi-select-combobox.tsx
+++ b/packages/ui/primitives/multi-select-combobox.tsx
@@ -142,6 +142,7 @@ export function MultiSelectCombobox<T = OptionValue>({
         {showClearButton && !loading && (
           <div className="absolute top-0 right-8 bottom-0 flex items-center justify-center">
             <button
+              type="button"
               className="flex h-4 w-4 items-center justify-center rounded-full bg-muted-foreground/20"
               onClick={() => onChange([])}
             >

--- a/packages/ui/primitives/multiselect.tsx
+++ b/packages/ui/primitives/multiselect.tsx
@@ -431,6 +431,7 @@ const MultiSelect = ({
               >
                 {option.label}
                 <button
+                  type="button"
                   className="absolute -inset-y-px -end-px flex size-7 items-center justify-center rounded-e-md border border-transparent p-0 text-muted-foreground/80 outline-none transition-[color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {


### PR DESCRIPTION
## Summary

Fixes #3201.

## The bug (as diagnosed in the issue)

A `<button>` without a `type` attribute inside a form defaults to **submit**, so clicking the "×" on a selected badge in the multiselect submitted the enclosing dialog form — e.g. Settings → Webhooks → Create created the webhook prematurely with a trigger list the user was still editing. The `onMouseDown` `preventDefault` in the handler suppresses focus/selection, not the subsequent click's default action.

Two sites were missing the attribute:

- `packages/ui/primitives/multiselect.tsx` — the badge remove button (the same file's "clear all" button already carries `type="button"`, which is how the omission stood out);
- `packages/ui/primitives/multi-select-combobox.tsx` — the clear button.

## Fix

`type="button"` on both. No other untyped buttons remain in either file (audited).
