### PR TITLE
feat(webhooks): give deliveries a stable id for retry deduplication

### DIFF
--- a/packages/lib/jobs/definitions/internal/execute-webhook.handler.ts
+++ b/packages/lib/jobs/definitions/internal/execute-webhook.handler.ts
@@ -3,6 +3,8 @@ import { prisma } from '@documenso/prisma';
 import type { Prisma } from '@prisma/client';
 import { WebhookCallStatus } from '@prisma/client';
 
+import { nanoid } from 'nanoid';
+
 import type { JobRunIO } from '../../client/_internal/job';
 import type { TExecuteWebhookJobDefinition } from './execute-webhook';
 
@@ -17,14 +19,19 @@ export const run = async ({ payload, io: _io }: { payload: TExecuteWebhookJobDef
 
   const { webhookUrl: url, secret } = webhook;
 
+  // Stable across retry attempts: minted when the job payload was built. The
+  // fallback only applies to jobs queued before the field existed.
+  const deliveryId = payload.deliveryId ?? nanoid();
+
   const payloadData = {
+    deliveryId,
     event,
     payload: data,
     createdAt: new Date().toISOString(),
     webhookEndpoint: url,
   };
 
-  const result = await executeWebhookCall({ url, body: payloadData, secret });
+  const result = await executeWebhookCall({ url, body: payloadData, secret, deliveryId });
 
   await prisma.webhookCall.create({
     data: {

--- a/packages/lib/jobs/definitions/internal/execute-webhook.ts
+++ b/packages/lib/jobs/definitions/internal/execute-webhook.ts
@@ -10,6 +10,10 @@ const EXECUTE_WEBHOOK_JOB_DEFINITION_SCHEMA = z.object({
   event: z.nativeEnum(WebhookTriggerEvents),
   webhookId: z.string(),
   data: z.unknown(),
+  // Minted when the job payload is built so it stays constant across retry
+  // attempts; optional because jobs queued before the field existed must
+  // still validate. The handler falls back to generating one.
+  deliveryId: z.string().optional(),
   requestMetadata: ZRequestMetadataSchema.optional(),
 });
 

--- a/packages/lib/server-only/webhooks/execute-webhook-call.ts
+++ b/packages/lib/server-only/webhooks/execute-webhook-call.ts
@@ -24,8 +24,10 @@ export const executeWebhookCall = async (options: {
   url: string;
   body: unknown;
   secret: string | null;
+  /** Stable delivery identifier, sent as a header for easy deduplication. */
+  deliveryId?: string;
 }): Promise<WebhookCallResult> => {
-  const { url, body, secret } = options;
+  const { url, body, secret, deliveryId } = options;
 
   try {
     await assertNotPrivateUrl(url);
@@ -38,6 +40,7 @@ export const executeWebhookCall = async (options: {
       headers: {
         'Content-Type': 'application/json',
         'X-Documenso-Secret': secret ?? '',
+        ...(deliveryId ? { 'X-Documenso-Delivery-Id': deliveryId } : {}),
       },
     });
 

--- a/packages/lib/server-only/webhooks/trigger/trigger-webhook.ts
+++ b/packages/lib/server-only/webhooks/trigger/trigger-webhook.ts
@@ -1,4 +1,5 @@
 import type { WebhookTriggerEvents } from '@prisma/client';
+import { nanoid } from 'nanoid';
 
 import { jobs } from '../../../jobs/client';
 import { getAllWebhooksByEventTrigger } from '../get-all-webhooks-by-event-trigger';
@@ -26,6 +27,9 @@ export const triggerWebhook = async ({ event, data, userId, teamId }: TriggerWeb
             event,
             webhookId: webhook.id,
             data,
+            // Minted per delivery and constant across retry attempts, so
+            // consumers can deduplicate the retries the queue performs (#3204).
+            deliveryId: nanoid(),
           },
         });
       }),


### PR DESCRIPTION
## Summary

Implements #3204.

## The gap

Webhook retries are real and intentional (`bullmq.ts` schedules `DEFAULT_MAX_ATTEMPTS`, the handler rethrows on failure), but deliveries carried **no stable identifier**: `createdAt` is recomputed with `new Date()` inside each attempt, so two attempts of the same delivery reached the consumer with different bodies and no shared field — a consumer that acts per delivery (issuing an invoice, filing a document) had no way to avoid acting twice. The server mints a `WebhookCall` row per attempt, but that id is never sent and changes between attempts anyway.

## What this does (the issue's suggested direction)

- `triggerWebhook` mints a **`deliveryId`** (nanoid) when the job payload is built — constant across retry attempts by construction.
- The job schema gains an **optional** `deliveryId` (jobs queued before the change still validate); the handler falls back to generating one for those.
- The handler includes it in the body as `deliveryId`, and `executeWebhookCall` sends it as **`X-Documenso-Delivery-Id`** — matching the existing `X-Documenso-Secret` / `X-Documenso-Envelope-Id` header family — so consumers can deduplicate from either surface without parsing the body.
- `createdAt` still reflects each attempt; `deliveryId` is the stable key.
- The `WebhookCall` row (persisted after the call) records the sent body and therefore the delivery id per attempt, keeping the audit trail aligned with what the consumer received.

## Notes

The webhook retry documentation updated in #3132 can now reference the header for its deduplication guidance. No database migration needed.
