### PR TITLE
fix: reset the page when searching in org/team settings tables

### DIFF
--- a/apps/remix/app/components/tables/organisation-member-invites-table.tsx
+++ b/apps/remix/app/components/tables/organisation-member-invites-table.tsx
@@ -202,7 +202,11 @@ export const OrganisationMemberInvitesTable = () => {
         ),
       }}
     >
-      {(table) => results.totalPages > 1 && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
+      {(table) =>
+        // Mount the pagination whenever a page beyond the first is active, even
+        // if the current result set fits one page: without it, a search that
+        // shrinks the results strands the user on an empty page (#3199).
+        (results.totalPages > 1 || results.currentPage > 1) && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
     </DataTable>
   );
 };

--- a/apps/remix/app/components/tables/organisation-members-table.tsx
+++ b/apps/remix/app/components/tables/organisation-members-table.tsx
@@ -204,7 +204,11 @@ export const OrganisationMembersDataTable = () => {
         ),
       }}
     >
-      {(table) => results.totalPages > 1 && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
+      {(table) =>
+        // Mount the pagination whenever a page beyond the first is active, even
+        // if the current result set fits one page: without it, a search that
+        // shrinks the results strands the user on an empty page (#3199).
+        (results.totalPages > 1 || results.currentPage > 1) && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
     </DataTable>
   );
 };

--- a/apps/remix/app/components/tables/organisation-teams-table.tsx
+++ b/apps/remix/app/components/tables/organisation-teams-table.tsx
@@ -138,7 +138,11 @@ export const OrganisationTeamsTable = () => {
         ),
       }}
     >
-      {(table) => results.totalPages > 1 && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
+      {(table) =>
+        // Mount the pagination whenever a page beyond the first is active, even
+        // if the current result set fits one page: without it, a search that
+        // shrinks the results strands the user on an empty page (#3199).
+        (results.totalPages > 1 || results.currentPage > 1) && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
     </DataTable>
   );
 };

--- a/apps/remix/app/components/tables/team-groups-table.tsx
+++ b/apps/remix/app/components/tables/team-groups-table.tsx
@@ -168,7 +168,11 @@ export const TeamGroupsTable = () => {
         ),
       }}
     >
-      {(table) => results.totalPages > 1 && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
+      {(table) =>
+        // Mount the pagination whenever a page beyond the first is active, even
+        // if the current result set fits one page: without it, a search that
+        // shrinks the results strands the user on an empty page (#3199).
+        (results.totalPages > 1 || results.currentPage > 1) && <DataTablePagination additionalInformation="VisibleCount" table={table} />}
     </DataTable>
   );
 };

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.members.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.members.tsx
@@ -36,6 +36,11 @@ export default function TeamsSettingsMembersPage() {
       params.delete('query');
     }
 
+    // A new query can shrink the result set below the current page, and the
+    // pagination unmounts on a single page of results -- leaving the user on
+    // an empty table with no way back. Always return to the first page (#3199).
+    params.delete('page');
+
     // If nothing  to change then do nothing.
     if (params.toString() === searchParams?.toString()) {
       return;

--- a/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.teams.tsx
+++ b/apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.teams.tsx
@@ -30,6 +30,11 @@ export default function OrganisationSettingsTeamsPage() {
       params.delete('query');
     }
 
+    // A new query can shrink the result set below the current page, and the
+    // pagination unmounts on a single page of results -- leaving the user on
+    // an empty table with no way back. Always return to the first page (#3199).
+    params.delete('page');
+
     setSearchParams(params);
   }, [debouncedSearchQuery, pathname, searchParams]);
 

--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.groups.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.groups.tsx
@@ -37,6 +37,11 @@ export default function TeamsSettingsGroupsPage() {
       params.delete('query');
     }
 
+    // A new query can shrink the result set below the current page, and the
+    // pagination unmounts on a single page of results -- leaving the user on
+    // an empty table with no way back. Always return to the first page (#3199).
+    params.delete('page');
+
     // If nothing  to change then do nothing.
     if (params.toString() === searchParams?.toString()) {
       return;


### PR DESCRIPTION
## Summary

Fixes #3199.

## The bug (as diagnosed in the issue)

Searching from page 2 of the organisation/team settings tables produced an **empty table with the pagination unmounted**:

1. the search-debounce effects in the three affected routes never cleared the `page` parameter, and
2. the pagination rendered only when `totalPages > 1` — a query matching few rows computes `Math.ceil(count / perPage)` ≤ 1, unmounting the controls and leaving "No results found" with no way back short of clearing the search or editing the URL.

## Fix — both halves

1. **Root cause:** the three affected routes (`o.$orgUrl.settings.teams`, `o.$orgUrl.settings.members`, `t.$teamUrl+/settings.groups`) now `params.delete('page')` in the search effect — the exact pattern `admin+/organisation-stats._index.tsx` already used. A new query always returns to page 1.
2. **Belt-and-suspenders:** the four affected tables (`organisation-teams-table`, `team-groups-table`, `organisation-members-table`, `organisation-member-invites-table`) mount `DataTablePagination` whenever `totalPages > 1 || currentPage > 1` — even if a stale page ever survives into a one-page result set again, "previous page" stays reachable.

## Scope

Kept precisely as the issue defines it: the admin tables are untouched (they keep pagination mounted and `admin-dashboard-users-table` already resets `page: 1` correctly), and the other routes with a missing reset but an escape hatch are left for a follow-up if maintainers want them normalized.
