### PR TITLE
fix: keep document filters across pagination; reset page on search

### DIFF
--- a/apps/remix/app/components/general/document/document-search.tsx
+++ b/apps/remix/app/components/general/document/document-search.tsx
@@ -2,7 +2,7 @@ import { useDebouncedValue } from '@documenso/lib/client-only/hooks/use-debounce
 import { Input } from '@documenso/ui/primitives/input';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { useQueryState } from 'nuqs';
+import { useQueryStates } from 'nuqs';
 import { useEffect, useState } from 'react';
 
 import { documentsSearchParams } from '~/utils/documents-search-params';
@@ -10,14 +10,23 @@ import { documentsSearchParams } from '~/utils/documents-search-params';
 export const DocumentSearch = () => {
   const { _ } = useLingui();
 
-  const [query, setQuery] = useQueryState('query', documentsSearchParams.query);
+  const [query, setQuery] = useQueryStates(
+    {
+      query: documentsSearchParams.query,
+      page: documentsSearchParams.page,
+    },
+    { history: 'push' },
+  );
 
   const [searchTerm, setSearchTerm] = useState(query ?? '');
   const debouncedSearchTerm = useDebouncedValue(searchTerm, 500);
 
   useEffect(() => {
     if (debouncedSearchTerm !== (query ?? '')) {
-      void setQuery(debouncedSearchTerm || null);
+      // A new query shrinks the result set; staying on page 3 of a smaller
+      // set renders an empty table. Reset the page like every sibling
+      // filter does (#3196).
+      void setQuery({ query: debouncedSearchTerm || null, page: null });
     }
   }, [debouncedSearchTerm, query, setQuery]);
 

--- a/packages/lib/client-only/hooks/use-update-search-params.ts
+++ b/packages/lib/client-only/hooks/use-update-search-params.ts
@@ -1,10 +1,15 @@
 import { useSearchParams } from 'react-router';
 
 export const useUpdateSearchParams = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   return (params: Record<string, string | number | boolean | null | undefined>) => {
-    const nextSearchParams = new URLSearchParams(searchParams?.toString() ?? '');
+    // Rebuild from the live URL, not the router's snapshot: nuqs shallow
+    // updates write with pushState and never notify React Router (no popstate
+    // fires), so useSearchParams can lag behind filters written moments
+    // earlier -- paginating from that snapshot silently dropped every active
+    // filter (#3196). window.location reflects both nuqs and router writes.
+    const nextSearchParams = new URLSearchParams(window.location.search);
 
     Object.entries(params).forEach(([key, value]) => {
       if (value === undefined || value === null) {


### PR DESCRIPTION
## Summary

Fixes #3196.

## Root cause (as diagnosed in the issue, fixed at the URL-state layer)

The documents list kept URL state in **two competing places**:

- filters wrote through **nuqs** — shallow by default, i.e. `pushState`, which never notifies React Router (`history.listen` subscribes to `popstate`, and `pushState` doesn't fire it), so `useSearchParams`/`useLocation` go stale;
- pagination rebuilt the next URL from that stale React Router snapshot via `useUpdateSearchParams`, silently discarding whatever the filters had just written. The asymmetry made it one-directional (nuqs recomposes from the live URL, so router writes survived; router recomposition from nuqs writes did not).

## Fix

1. **`useUpdateSearchParams` rebuilds from `window.location.search`** — the live URL that **both** writers keep current (nuqs `pushState` and router `navigate` both update it). `setSearchParams` still routes through React Router, refreshing its state exactly as before. This fixes every consumer of the hook (33 files), not just the documents table.
2. **`DocumentSearch` resets `page: null` on a new query**, matching its three sibling filters (status/sender/period all do) — searching from page 3 no longer requests page 3 of a smaller result set.

No changes to the nuqs write side: filters keep their shallow updates and push history, so back/forward and per-keystroke performance are untouched.
