### PR TITLE
fix: stop writing EMAIL_SENT audit entries when no email was sent

### DIFF
--- a/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
@@ -185,54 +185,60 @@ export const run = async ({ payload, io }: { payload: TSendSigningEmailJobDefini
     reportUrl,
   });
 
-  if (isRecipientEmailValidForSending(recipient)) {
-    try {
-      await assertOrganisationRatesAndLimits({
-        organisationId,
-        organisationClaim: claims,
-        type: 'email',
-        count: 1,
-      });
-    } catch (_err) {
-      io.logger.warn({
-        msg: 'Recipient signing email dropped: org rate limit exceeded',
-        organisationId,
-        recipientId: recipient.id,
-        envelopeId: envelope.id,
-      });
-
-      // Job is consumed and NOT retried.
-      return;
-    }
-
-    await io.runTask('send-signing-email', async () => {
-      const [html, text] = await Promise.all([
-        renderEmailWithI18N(template, { lang: emailLanguage, branding }),
-        renderEmailWithI18N(template, {
-          lang: emailLanguage,
-          branding,
-          plainText: true,
-        }),
-      ]);
-
-      await emailTransport.sendMail({
-        to: {
-          name: recipient.name,
-          address: recipient.email,
-        },
-        from: senderEmail,
-        replyTo: replyToEmail,
-        subject: renderCustomEmailTemplate(documentMeta?.subject || emailSubject, customEmailTemplate),
-        html,
-        text,
-        headers: buildEnvelopeEmailHeaders({
-          userId,
-          envelopeId: envelope.id,
-          teamId: envelope.teamId,
-        }),
-      });
-    });
+  if (!isRecipientEmailValidForSending(recipient)) {
+    // An explicitly empty email (the in-person signer the recipient schema
+    // sanctions) means no email is sent: no sendStatus=SENT, no sentAt, and
+    // no EMAIL_SENT audit entry. That entry feeds the signing certificate and
+    // must attest only to deliveries that actually happened (#3194).
+    return;
   }
+
+  try {
+    await assertOrganisationRatesAndLimits({
+      organisationId,
+      organisationClaim: claims,
+      type: 'email',
+      count: 1,
+    });
+  } catch (_err) {
+    io.logger.warn({
+      msg: 'Recipient signing email dropped: org rate limit exceeded',
+      organisationId,
+      recipientId: recipient.id,
+      envelopeId: envelope.id,
+    });
+
+    // Job is consumed and NOT retried.
+    return;
+  }
+
+  await io.runTask('send-signing-email', async () => {
+    const [html, text] = await Promise.all([
+      renderEmailWithI18N(template, { lang: emailLanguage, branding }),
+      renderEmailWithI18N(template, {
+        lang: emailLanguage,
+        branding,
+        plainText: true,
+      }),
+    ]);
+
+    await emailTransport.sendMail({
+      to: {
+        name: recipient.name,
+        address: recipient.email,
+      },
+      from: senderEmail,
+      replyTo: replyToEmail,
+      subject: renderCustomEmailTemplate(documentMeta?.subject || emailSubject, customEmailTemplate),
+      html,
+      text,
+      headers: buildEnvelopeEmailHeaders({
+        userId,
+        envelopeId: envelope.id,
+        teamId: envelope.teamId,
+      }),
+    });
+  });
 
   const sentAt = new Date();
 


### PR DESCRIPTION
## Summary

Fixes #3194.

## The bug (as diagnosed in the issue, verified)

In `send-signing-email.handler.ts` the send was guarded by `isRecipientEmailValidForSending`, but the guard's `if` closed **before** the state writes — so when no email was sent:

- `sendStatus` was still set to `SENT`,
- `sentAt` was stamped,
- the next reminder was scheduled, and
- an `EMAIL_SENT` audit entry was written.

This is reachable through a **supported configuration**: the recipient schema explicitly sanctions an empty email (the in-person signer), and `send-document.ts` triggers the job with no validity filter. Beyond the misleading table state, the `EMAIL_SENT` entry feeds the **signing certificate** (`generate-certificate-pdf.ts`, `certificate.tsx`) — the evidentiary artefact stated that an email was sent to a party who was never contacted.

## Fix

The guard is inverted into an **early return**: no valid email means no send, no `sendStatus`/`sentAt` write, no reminder scheduling, and no audit entry. The send-side body is de-nested; behavior for valid emails is byte-for-byte the same, including the rate-limit consume-and-return branch.

This aligns the handler with the convention of the four other `EMAIL_SENT` write sites (all of which write only after a successful send, as the issue verified).
