### PR TITLE
fix: stop failed completions freezing their date into documents

### DIFF
--- a/packages/lib/server-only/document/complete-document-with-token.ts
+++ b/packages/lib/server-only/document/complete-document-with-token.ts
@@ -245,6 +245,18 @@ export const completeDocumentWithToken = async ({
     });
   }
 
+  // Validate required non-DATE fields BEFORE auto-stamping dates: the stamps
+  // are persisted outside the transaction below and are never corrected on a
+  // later attempt, so a failed completion must not freeze its date into the
+  // document. DATE fields are excluded from this early check because the block
+  // right after auto-inserts them for V2 envelopes (#3193).
+  if (fieldsContainUnsignedRequiredField(fields.filter((field) => field.type !== FieldType.DATE))) {
+    throw new AppError(AppErrorCode.RECIPIENT_HAS_UNSIGNED_FIELDS, {
+      message: `Recipient ${recipient.id} has unsigned fields`,
+      statusCode: 400,
+    });
+  }
+
   // Auto-insert all un-inserted date fields for V2 envelopes at completion time.
   if (envelope.internalVersion === 2 && uninsertedDateFields.length > 0) {
     const formattedDate = DateTime.now()


### PR DESCRIPTION
## Summary

Fixes #3193.

## The bug (as diagnosed in the issue, verified)

In `completeDocumentWithToken`, uninserted DATE fields were stamped and audit-logged **before** the required-field validation and **outside** the transaction — so a completion that failed validation (an unfilled required field) still persisted its timestamp, and the later successful attempt skipped the stamping block (the fields were now `inserted`), leaving the sealed document permanently carrying the date of the **failed** attempt. Reachable through the token-authenticated public procedure even though the UI normally disables Complete.

## Fix — one adjustment to the suggested direction

Moving the validation wholesale above the DATE block would break the auto-stamp's purpose: a **required-but-uninserted DATE field** is exactly what that block auto-inserts on V2 envelopes. So the required-field check now runs twice:

1. **before the stamping block, over non-DATE fields** — a completion missing any other required field throws *before* any date write is persisted;
2. **after the stamping block, over all fields** (unchanged) — still covers V1 envelopes, where DATE fields are not auto-inserted and must genuinely be filled.

The residual window is only the concurrency loser of the existing conditional-update transaction (same instant, same date value) — not the days-later failure from the report.

No changes to the stamping, audit-log shape, or transaction behavior for successful completions.
