### PR TITLE
fix: let the last VIEWER complete with Mark as viewed

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-form.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-form.tsx
@@ -151,7 +151,7 @@ export const DocumentSigningForm = ({
                     completeDocument({ nextSigner, accessAuthOptions })
                   }
                   recipient={recipient}
-                  allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
+                  allowDictateNextSigner={nextRecipient && document.documentMeta?.allowDictateNextSigner}
                   defaultNextSigner={
                     nextRecipient ? { name: nextRecipient.name, email: nextRecipient.email } : undefined
                   }


### PR DESCRIPTION
## Summary

Fixes #3202.

## The bug (as diagnosed in the issue)

The VIEWER branch of the V1 signing form passed `allowDictateNextSigner` **without** the `nextRecipient` guard that the same file's ASSISTANT and SIGNER/APPROVER branches use. For a VIEWER who is the **last** recipient:

- the complete dialog activated its dictate-next-signer zod resolver,
- whose schema requires a name and valid email,
- with empty defaults and inputs that render only when a next signer exists — they don't,
- so `form.handleSubmit` failed validation on two invisible fields with no `FormMessage` mounted: **Mark as viewed did nothing, silently**.

## Fix

One line — the VIEWER branch now guards exactly like its siblings:

```diff
-allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
+allowDictateNextSigner={nextRecipient && document.documentMeta?.allowDictateNextSigner}
```

(matching the V2 dialog's `Boolean(nextRecipient && ...)` as well). With no next recipient the resolver stays inactive and the view records, same as a VIEWER who isn't last.
