### PR TITLE
fix: make the template document filters clearable

### DIFF
--- a/apps/remix/app/components/general/template/template-page-view-documents-table.tsx
+++ b/apps/remix/app/components/general/template/template-page-view-documents-table.tsx
@@ -175,7 +175,11 @@ export const TemplatePageViewDocumentsTable = ({ templateId }: TemplatePageViewD
 
         <SearchParamSelector
           paramKey="status"
-          isValueValid={(value) => [...DocumentStatusEnum.COMPLETED].includes(value as unknown as string)}
+          isValueValid={(value) =>
+            [DocumentStatusEnum.COMPLETED, DocumentStatusEnum.PENDING, DocumentStatusEnum.DRAFT].includes(
+              value as unknown as DocumentStatusEnum,
+            )
+          }
         >
           <SelectItem value="all">
             <Trans>Any Status</Trans>
@@ -193,7 +197,7 @@ export const TemplatePageViewDocumentsTable = ({ templateId }: TemplatePageViewD
 
         <SearchParamSelector
           paramKey="source"
-          isValueValid={(value) => [...DocumentSource.TEMPLATE].includes(value as unknown as string)}
+          isValueValid={(value) => [DocumentSource.TEMPLATE].includes(value as unknown as DocumentSource)}
         >
           <SelectItem value="all">
             <Trans>Any Source</Trans>


### PR DESCRIPTION
## Summary

Fixes #3200.

## The bug (as diagnosed in the issue)

Both `isValueValid` validators spread the enum's **string value** into an array literal:

```ts
[...DocumentStatusEnum.COMPLETED]  // → ['C','O','M','P','L','E','T','E','D']
[...DocumentSource.TEMPLATE]       // → ['T','E','M','P','L','A','T','E']
```

so `.includes('COMPLETED')` was always false. Consequences: the selector always fell back to displaying "Any" while the table stayed server-side filtered, and — because the underlying Radix Select is uncontrolled with its internal value stuck at `'all'` and `onChange` only fires on real changes — **picking "Any Status" emitted nothing**: the filter could not be cleared from the UI.

## Fix

The validators now list the actual values the menus offer:

- status: `[COMPLETED, PENDING, DRAFT]`
- source: `[TEMPLATE]`

A URL-carried filter now displays correctly on load, and "Any …" clears it.
