### PR TITLE
fix: discard an abandoned signature drawing when the pad closes

### DIFF
--- a/packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
@@ -109,7 +109,22 @@ export const SignaturePadDialog = ({
         )}
       </motion.button>
 
-      <Dialog open={showSignatureModal} onOpenChange={disabled ? undefined : setShowSignatureModal}>
+      <Dialog
+        open={showSignatureModal}
+        onOpenChange={(open) => {
+          if (disabled) return;
+
+          // Reset the local draft when the dialog closes: the Radix content
+          // unmounts on close, so the reopened pad remounts from the parent's
+          // value -- an abandoned drawing kept here would diverge from what is
+          // displayed and be committed by the next confirm (#3203).
+          if (!open) {
+            setSignature(value ?? '');
+          }
+
+          setShowSignatureModal(open);
+        }}
+      >
         <DialogContent hideClose={true} className="p-6 pt-4">
           <SignaturePad
             id="signature"


### PR DESCRIPTION
## Summary

Fixes #3203.

## The bug (as diagnosed in the issue, verified)

The signature pad dialog kept its drawing in local state declared **outside** the `<Dialog>` and never re-synced to `value`. Since the Radix dialog content **unmounts on close**, the reopened pad remounted from the parent's value — while the stale draft lingered in local state:

- the confirm button (`disabled={!signature}`) was **enabled** over whatever was actually displayed (including a visually empty pad), and
- confirming committed the **previously discarded drawing**, not the canvas contents.

On a signing product that means a signature the user believes they discarded can end up on the document.

## Fix (the issue's first suggested direction)

`onOpenChange` now resets the draft when the dialog closes:

```ts
if (!open) {
  setSignature(value ?? '');
}
```

Displayed state and committable state can no longer diverge — after Cancel, the abandoned drawing is gone, exactly as the pad's remounted canvas already showed.
