### PR TITLE
fix: internal jobs resolve team settings and webhooks system-side

### DIFF
--- a/packages/lib/jobs/definitions/internal/process-recipient-expired.handler.ts
+++ b/packages/lib/jobs/definitions/internal/process-recipient-expired.handler.ts
@@ -68,7 +68,6 @@ export const run = async ({ payload, io }: { payload: TProcessRecipientExpiredJo
   await triggerWebhook({
     event: WebhookTriggerEvents.RECIPIENT_EXPIRED,
     data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(envelope)),
-    userId: envelope.userId,
     teamId: envelope.teamId,
   });
 

--- a/packages/lib/jobs/definitions/internal/process-signing-reminder.handler.ts
+++ b/packages/lib/jobs/definitions/internal/process-signing-reminder.handler.ts
@@ -239,7 +239,6 @@ export const run = async ({ payload, io }: { payload: TProcessSigningReminderJob
     await triggerWebhook({
       event: WebhookTriggerEvents.DOCUMENT_REMINDER_SENT,
       data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(envelope)),
-      userId: envelope.userId,
       teamId: envelope.teamId,
     });
   }

--- a/packages/lib/jobs/definitions/internal/seal-document.handler.ts
+++ b/packages/lib/jobs/definitions/internal/seal-document.handler.ts
@@ -76,8 +76,11 @@ export const run = async ({ payload, io }: { payload: TSealDocumentJobDefinition
       throw new Error('At least one envelope item required');
     }
 
+    // System-side resolution: scoping through the author's current membership
+    // makes sealing throw NOT_FOUND the moment their team access is revoked
+    // (e.g. a group removal, which re-parents nothing), leaving a fully
+    // signed document unsealed forever (#3192).
     const settings = await getTeamSettings({
-      userId: envelope.userId,
       teamId: envelope.teamId,
     });
 
@@ -336,7 +339,6 @@ export const run = async ({ payload, io }: { payload: TSealDocumentJobDefinition
   await triggerWebhook({
     event: isRejected ? WebhookTriggerEvents.DOCUMENT_REJECTED : WebhookTriggerEvents.DOCUMENT_COMPLETED,
     data: ZWebhookDocumentSchema.parse(mapEnvelopeToWebhookDocumentPayload(updatedEnvelope)),
-    userId: updatedEnvelope.userId,
     teamId: updatedEnvelope.teamId ?? undefined,
   });
 

--- a/packages/lib/server-only/webhooks/get-all-webhooks-by-event-trigger.ts
+++ b/packages/lib/server-only/webhooks/get-all-webhooks-by-event-trigger.ts
@@ -5,7 +5,13 @@ import { buildTeamWhereQuery } from '../../utils/teams';
 
 export type GetAllWebhooksByEventTriggerOptions = {
   event: WebhookTriggerEvents;
-  userId: number;
+  /**
+   * Scope through the user's current team membership (request contexts).
+   * Internal jobs act on behalf of the system and must omit it: resolving
+   * through the document author's membership breaks the moment their access
+   * is revoked, silently disabling the team's webhooks (#3192).
+   */
+  userId?: number;
   teamId: number;
 };
 
@@ -16,10 +22,7 @@ export const getAllWebhooksByEventTrigger = async ({ event, userId, teamId }: Ge
       eventTriggers: {
         has: event,
       },
-      team: buildTeamWhereQuery({
-        teamId,
-        userId,
-      }),
+      team: userId !== undefined ? buildTeamWhereQuery({ teamId, userId }) : { id: teamId },
     },
   });
 };

--- a/packages/lib/server-only/webhooks/trigger/trigger-webhook.ts
+++ b/packages/lib/server-only/webhooks/trigger/trigger-webhook.ts
@@ -6,7 +6,8 @@ import { getAllWebhooksByEventTrigger } from '../get-all-webhooks-by-event-trigg
 export type TriggerWebhookOptions = {
   event: WebhookTriggerEvents;
   data: Record<string, unknown>;
-  userId: number;
+  /** Omit for internal jobs: they act system-side, not as the author (#3192). */
+  userId?: number;
   teamId: number;
 };
 


### PR DESCRIPTION
## Summary

Fixes #3192 (the job-layer half; see scope note below).

## The bug (as diagnosed in the issue, verified)

Internal jobs resolved team settings and webhook subscriptions **through the document author's current team membership**. When the author's access came from a group and that group was revoked — a path that re-parents nothing, unlike member removal — `getTeamSettings({ userId, teamId })` threw `NOT_FOUND`, the seal job exhausted its retries, and a **fully signed document stayed unsealed forever**: no sealed PDF, no `DOCUMENT_COMPLETED` webhook, no completion email. On the webhook side the failure was silent (zero subscriptions resolved).

## Fix — system-side resolution for internal jobs

- `seal-document.handler` uses the documented unscoped form: `getTeamSettings({ teamId })`.
- `getAllWebhooksByEventTrigger` and `triggerWebhook` gain an **optional** `userId`:
  - request contexts keep passing it — behavior unchanged, still scoped through the acting user;
  - the three internal handlers that acted as the document author (`seal-document`, `process-signing-reminder`, `process-recipient-expired`) now omit it, resolving the team's webhooks by team alone so they keep firing after an access change.

## Scope note

Re-parenting envelopes on the group-deletion paths (`team.group.delete`, `organisation group delete/update`) — as the member-removal path already does — is deliberately **not** included: it's a data-shape change across three routers that deserves its own review, and the job-layer fix already removes the dependency on the author's membership.
