### PR TITLE
fix(emails): drop the last trailing period from a subject

### DIFF
--- a/packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts
@@ -93,7 +93,7 @@ export const run = async ({ payload }: { payload: TSendDocumentPendingEmailJobDe
     },
     from: senderEmail,
     replyTo: replyToEmail,
-    subject: i18n._(msg`Waiting for others to complete signing.`),
+    subject: i18n._(msg`Waiting for others to complete signing`),
     html,
     text,
   });


### PR DESCRIPTION
## Summary

Addresses #3212 (continuing what #3213 started).

## What this does

- Removes the last remaining trailing **period** from an email subject: `Waiting for others to complete signing.` → no full stop (`send-document-pending-email.handler.ts`).
- A repo-wide sweep of every `subject:` line confirms no other period-ended subjects remain.

## On the ?/! cases the issue mentions

Kept deliberately: `Forgot Password?` is an actual question, and `Signing Complete!` / `Document Deleted!` read as intentional emphasis rather than stray punctuation. If maintainers prefer the stricter no-terminal-punctuation rule for subjects, those can follow in a one-line-each follow-up.
