### PR TITLE
fix: contain signing fields' cqw units to the field box

### DIFF
--- a/packages/ui/lib/field-root-container-classes.ts
+++ b/packages/ui/lib/field-root-container-classes.ts
@@ -1,7 +1,12 @@
 const FIELD_ROOT_CONTAINER_SHARED_CLASS_NAME =
   'field--FieldRootContainer field-card-container dark-mode-disabled group rounded-[2px] bg-white/90 ring-2 ring-gray-200 transition-all';
 
-export const FIELD_ROOT_CONTAINER_CLASS_NAME = `${FIELD_ROOT_CONTAINER_SHARED_CLASS_NAME} relative z-20 flex h-full w-full items-center`;
+// [container-type:inline-size] makes the cqw font units used by field text
+// resolve against the field box itself; without it they resolve against the
+// nearest ancestor container (the page), so pre-filled readOnly TEXT fields
+// wrapped past the field border in the signing preview (#2669). The editor's
+// field-item sets the same containment for the same reason.
+export const FIELD_ROOT_CONTAINER_CLASS_NAME = `${FIELD_ROOT_CONTAINER_SHARED_CLASS_NAME} relative z-20 flex h-full w-full items-center [container-type:inline-size]`;
 
 export const FIELD_ROOT_CONTAINER_PROBE_CLASS_NAME = `field--FieldRootContainerProbe ${FIELD_ROOT_CONTAINER_SHARED_CLASS_NAME}`;
 


### PR DESCRIPTION
## Summary

Fixes #2669.

## Root cause (as diagnosed in the issue, verified)

Field text in the signing preview sizes its font with `cqw` units (`text-[clamp(0.425rem,25cqw,0.825rem)]`), but `FieldRootContainer` never established a containment context — so the units resolved against the nearest ancestor container (the page), and pre-filled readOnly TEXT fields wrapped at page-relative widths, overflowing the field border. The sealed PDF (Konva, field-relative) rendered correctly, and changing the field's `width` never changed the wrap point — both consistent with the diagnosis.

The telling detail: **the editor flow already applies the same containment for the same text** (`field-item.tsx` uses `[container-type:size]`), so the two flows disagreed about the container and the overflow only appeared in the signing preview.

## Fix

`[container-type:inline-size]` on `FIELD_ROOT_CONTAINER_CLASS_NAME` — every `cqw` inside a signing field (TEXT, DATE, the typed-signature sizing in `signing-card.tsx`) now resolves against the field box, matching the editor's behavior. `inline-size` rather than `size` deliberately, so height layout is untouched.
