### PR TITLE
fix(i18n): pluralize the bulk download limit sentence

### DIFF
--- a/apps/remix/app/components/dialogs/envelopes-bulk-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelopes-bulk-download-dialog.tsx
@@ -291,8 +291,9 @@ export const EnvelopesBulkDownloadDialog = ({
           <Alert variant="warning">
             <AlertDescription>
               <Trans>
-                You can download up to {MAX_BULK_DOWNLOAD_ENVELOPES} documents at a time. Deselect some documents to
-                continue.
+                You can download up to{' '}
+                <Plural value={MAX_BULK_DOWNLOAD_ENVELOPES} one="document" other="documents" /> at a time. Deselect
+                some documents to continue.
               </Trans>
             </AlertDescription>
           </Alert>


### PR DESCRIPTION
## Summary
Fixes #3209.

The bulk download limit alert counted a constant with a fixed `documents` string — translators could not express the additional plural forms many languages need. The sentence now uses lingui's `<Plural>` for the count (`Plural` was already imported in the file).