### PR TITLE
fix(i18n): pluralize the command menu result and item counts

### DIFF
--- a/apps/remix/app/components/general/app-command-menu.tsx
+++ b/apps/remix/app/components/general/app-command-menu.tsx
@@ -17,7 +17,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 import type { MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { Trans } from '@lingui/react/macro';
+import { Plural, Trans } from '@lingui/react/macro';
 import { keepPreviousData } from '@tanstack/react-query';
 import { defaultFilter as commandScore } from 'cmdk';
 import {
@@ -596,9 +596,15 @@ export const AppCommandMenu = ({ open, onOpenChange }: AppCommandMenuProps) => {
 
             <span className="ml-auto text-muted-foreground text-xs">
               {hasValidSearch ? (
-                <Trans>{formatChipCount(totalVisibleCount, isVisibleCountCapped)} results</Trans>
+                isVisibleCountCapped ? (
+                  <Trans>
+                    ≥{totalVisibleCount} <Plural value={totalVisibleCount} one="result" other="results" />
+                  </Trans>
+                ) : (
+                  <Plural value={totalVisibleCount} one="# result" other="# results" />
+                )
               ) : (
-                <Trans>{totalVisibleCount} items</Trans>
+                <Plural value={totalVisibleCount} one="# item" other="# items" />
               )}
             </span>
           </div>


### PR DESCRIPTION
## Summary
Fixes #3207.

Both command-menu counts (`results`, `items`) were fixed strings regardless of the count — translators could not express additional plural forms. Both now use lingui's `<Plural>`:

- uncapped: `<Plural one="# result" other="# results" />` (Plural renders the count);
- capped: the existing `≥N` prefix renders alongside a `<Plural value={N} .../>`, so the cap indicator survives while the noun still pluralizes.