### PR TITLE
feat: track last used timestamp for API tokens

### DIFF
--- a/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.tokens.tsx
+++ b/apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.tokens.tsx
@@ -47,6 +47,20 @@ export default function ApiTokensPage() {
         cell: ({ row }) => i18n.date(row.original.createdAt),
       },
       {
+        header: t`Last used`,
+        cell: ({ row }) => {
+          if (!row.original.lastUsedAt) {
+            return (
+              <span className='text-muted-foreground'>
+                <Trans>Never</Trans>
+              </span>
+            );
+          }
+
+          return i18n.date(row.original.lastUsedAt);
+        },
+      },
+      {
         header: t`Expires`,
         cell: ({ row }) => {
           if (!row.original.expires) {

--- a/packages/lib/server-only/public-api/get-api-token-by-token.ts
+++ b/packages/lib/server-only/public-api/get-api-token-by-token.ts
@@ -81,6 +81,17 @@ export const getApiTokenByToken = async ({ token, bypassRateLimit = false }: Get
     });
   }
 
+  // Record usage without blocking the request: token hygiene relies on
+  // knowing which tokens are actively used, not on when this write lands.
+  void prisma.apiToken
+    .update({
+      where: { id: apiToken.id },
+      data: { lastUsedAt: new Date() },
+    })
+    .catch(() => {
+      // A failed usage stamp must never fail the API request it recorded.
+    });
+
   // Handle a silly choice from many moons ago
   if (apiToken.team && !apiToken.user) {
     apiToken.user = apiToken.team.organisation.owner;

--- a/packages/lib/server-only/public-api/get-api-tokens.ts
+++ b/packages/lib/server-only/public-api/get-api-tokens.ts
@@ -22,6 +22,7 @@ export const getApiTokens = async ({ userId, teamId }: GetApiTokensOptions) => {
       name: true,
       createdAt: true,
       expires: true,
+      lastUsedAt: true,
     },
     orderBy: {
       createdAt: 'desc',

--- a/packages/prisma/migrations/20260818120000_add_api_token_last_used_at/migration.sql
+++ b/packages/prisma/migrations/20260818120000_add_api_token_last_used_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ApiToken" ADD COLUMN     "lastUsedAt" TIMESTAMP(3);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -220,12 +220,13 @@ enum ApiTokenAlgorithm {
 }
 
 model ApiToken {
-  id        Int               @id @default(autoincrement())
-  name      String
-  token     String            @unique
-  algorithm ApiTokenAlgorithm @default(SHA512)
-  expires   DateTime?
-  createdAt DateTime          @default(now())
+  id         Int               @id @default(autoincrement())
+  name       String
+  token      String            @unique
+  algorithm  ApiTokenAlgorithm @default(SHA512)
+  expires    DateTime?
+  createdAt  DateTime          @default(now())
+  lastUsedAt DateTime?
   userId    Int?
   user      User?             @relation(fields: [userId], references: [id], onDelete: Cascade)
   teamId    Int

--- a/packages/trpc/server/api-token-router/get-api-tokens.types.ts
+++ b/packages/trpc/server/api-token-router/get-api-tokens.types.ts
@@ -9,6 +9,7 @@ export const ZGetApiTokensResponseSchema = z.array(
     name: true,
     createdAt: true,
     expires: true,
+    lastUsedAt: true,
   }),
 );
 


### PR DESCRIPTION
## Summary

Implements #2756.

## What this does (the issue's proposed shape, end to end)

- **Schema + migration**: `ApiToken.lastUsedAt DateTime?` with the `ALTER TABLE` migration (nullable — unused tokens stay `null`, no table rewrite).
- **Recording usage**: `getApiTokenByToken` stamps `lastUsedAt` on every successful validation as a **fire-and-forget** write — placed after all auth/disabled/expiry checks so only genuinely valid uses count, and `.catch`-guarded so a failed stamp can never fail the API request it recorded.
- **Surfacing it**: the token list query selects the field, the tRPC response schema exposes it (picked from the generated Prisma zod schema), and the team settings table gains a **"Last used"** column — "Never" when null — between Created and Expires.

This gives admins the primary token-hygiene signal the issue describes: an actively used token (deleting it breaks an integration) is distinguishable at a glance from one created months ago and never used.
