### PR TITLE
fix(i18n): allow exact matching of region locales in accept-language header negotiation

### DIFF
--- a/packages/lib/utils/i18n.ts
+++ b/packages/lib/utils/i18n.ts
@@ -21,17 +21,24 @@ export async function dynamicActivate(locale: string) {
 }
 
 const parseLanguageFromLocale = (locale: string): SupportedLanguageCodes | null => {
-  const [language, _country] = locale.split('-');
+  const cleaned = locale.split(';')[0].trim();
 
-  const foundSupportedLanguage = APP_I18N_OPTIONS.supportedLangs.find(
-    (lang): lang is SupportedLanguageCodes => lang === language,
+  const exactMatch = APP_I18N_OPTIONS.supportedLangs.find(
+    (lang): lang is SupportedLanguageCodes => lang.toLowerCase() === cleaned.toLowerCase(),
   );
 
-  if (!foundSupportedLanguage) {
-    return null;
+  if (exactMatch) {
+    return exactMatch;
   }
 
-  return foundSupportedLanguage;
+  const [language] = cleaned.split('-');
+
+  const languageMatch = APP_I18N_OPTIONS.supportedLangs.find(
+    (lang): lang is SupportedLanguageCodes =>
+      lang.split('-')[0].toLowerCase() === language.toLowerCase(),
+  );
+
+  return languageMatch ?? null;
 };
 
 /**


### PR DESCRIPTION
### Problem
Browser-language detection for Brazilian Portuguese (`pt-BR`) fails to match the supported locale during `Accept-Language` header negotiation. Because `pt-BR` is the only supported language code in `APP_I18N_OPTIONS.supportedLangs` that contains a region subtag, stripping the subtag beforehand caused negotiation to compare `'pt'` against `'pt-BR'`, always failing and falling back to English.

### Root cause
In `packages/lib/utils/i18n.ts` (`parseLanguageFromLocale`), `locale.split('-')` extracted only the language subtag before checking against `APP_I18N_OPTIONS.supportedLangs`. Since `pt-BR` is stored with its full tag, `pt` never matched `pt-BR`. Additionally, quality parameters (e.g. `;q=0.9`) were not stripped prior to matching.

### Change
Updated `parseLanguageFromLocale` in `packages/lib/utils/i18n.ts` to:
1. Strip quality parameters (`;q=...`) from the locale string.
2. Check for an exact case-insensitive match against supported language codes (enabling `pt-BR` and `de` to match directly).
3. Fall back to matching the base language subtag against the supported codes' language subtags (allowing generic `pt` or `pt-PT` to resolve to `pt-BR`).

### Proof

#### Test Red (Before Fix)
```
Buggy parse for 'pt-BR': null
Buggy parse for 'pt': null
```

#### Test Green (After Fix)
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_3090.mjs
▶ Documenso Issue #3090: Brazilian Portuguese Locale Negotiation
  ✔ reproduces bug: pt-BR and pt headers fail to match pt-BR with buggy parser (1.9369ms)
  ✔ verified fix: pt-BR, pt, and quality factor headers correctly resolve to pt-BR (0.4368ms)
✔ Documenso Issue #3090: Brazilian Portuguese Locale Negotiation (3.8337ms)
ℹ tests 2
ℹ suites 1
ℹ pass 2
ℹ fail 0
```

### Reference
Fixes #3090
