### PR TITLE
fix(ui): add type=button to multiselect remove and clear buttons

### DIFF
--- a/packages/ui/primitives/multi-select-combobox.tsx
+++ b/packages/ui/primitives/multi-select-combobox.tsx
@@ -142,6 +142,7 @@ export function MultiSelectCombobox<T = OptionValue>({
         {showClearButton && !loading && (
           <div className="absolute top-0 right-8 bottom-0 flex items-center justify-center">
             <button
+              type="button"
               className="flex h-4 w-4 items-center justify-center rounded-full bg-muted-foreground/20"
               onClick={() => onChange([])}
             >

--- a/packages/ui/primitives/multiselect.tsx
+++ b/packages/ui/primitives/multiselect.tsx
@@ -431,6 +431,7 @@ const MultiSelect = ({
               >
                 {option.label}
                 <button
+                  type="button"
                   className="absolute -inset-y-px -end-px flex size-7 items-center justify-center rounded-e-md border border-transparent p-0 text-muted-foreground/80 outline-none transition-[color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {


### PR DESCRIPTION
### Problem
In `MultiSelect` and `MultiSelectCombobox`, the "×" badge remove button and the clear button lacked an explicit `type="button"` attribute. Under the HTML specification, a `<button>` inside a `<form>` element defaults to `type="submit"`, causing surrounding forms (such as webhook creation, team member creation, and auth selection dialogs) to trigger form submission prematurely when unselecting a badge.

### Root cause
In `packages/ui/primitives/multiselect.tsx` (line 433) and `packages/ui/primitives/multi-select-combobox.tsx` (line 144), `<button>` elements were rendered without a `type` attribute. While `onMouseDown` called `e.preventDefault()`, this only suppressed focus/selection and did not prevent the default submit action of the subsequent `click` event within form boundaries.

### Change
Added explicit `type="button"` attributes to:
1. The badge remove button in `packages/ui/primitives/multiselect.tsx`.
2. The clear button in `packages/ui/primitives/multi-select-combobox.tsx`.

### Reference
Fixes #3201
