### PR TITLE
fix(ui): reset signature dialog state on cancel and reopen

### DIFF
--- a/packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
@@ -62,7 +62,10 @@ export const SignaturePadDialog = ({
         type="button"
         disabled={disabled}
         className="absolute inset-0 flex items-center justify-center bg-transparent"
-        onClick={() => setShowSignatureModal(true)}
+        onClick={() => {
+          setSignature(value ?? '');
+          setShowSignatureModal(true);
+        }}
         whileHover="onHover"
       >
         {!value && !disableAnimation && (
@@ -109,7 +112,19 @@ export const SignaturePadDialog = ({
         )}
       </motion.button>
 
-      <Dialog open={showSignatureModal} onOpenChange={disabled ? undefined : setShowSignatureModal}>
+      <Dialog
+        open={showSignatureModal}
+        onOpenChange={
+          disabled
+            ? undefined
+            : (open) => {
+                if (!open) {
+                  setSignature(value ?? '');
+                }
+                setShowSignatureModal(open);
+              }
+        }
+      >
         <DialogContent hideClose={true} className="p-6 pt-4">
           <SignaturePad
             id="signature"


### PR DESCRIPTION
### Problem
When a user draws a signature in `SignaturePadDialog`, cancels the modal, and subsequently reopens the dialog, the drawing was kept in local `signature` state. Because the modal's inner content unmounts on close, reopening displayed the parent `value` (which could be blank) while the stale drawing remained held in local state. Clicking Next/Confirm then committed the abandoned drawing.

### Root cause
In `packages/ui/primitives/signature-pad/signature-pad-dialog.tsx`, `signature` state was declared outside the `<Dialog>` and initialized with `useState(value ?? '')`. When the dialog was closed via cancel or backdrop click, local state was never reset back to `value ?? ''`.

### Change
1. Updated `onOpenChange` on `<Dialog>` to reset `signature` to `value ?? ''` whenever the dialog closes.
2. Updated the trigger button's `onClick` to ensure `signature` is initialized to `value ?? ''` upon opening.

### Proof

#### Test Red (Before Fix)
```
Buggy commit after cancel & reopen: abandoned_drawing
```

#### Test Green (After Fix)
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_3203.mjs
▶ Documenso Issue #3203: Signature Pad State Isolation on Cancel/Reopen
  ✔ reproduces bug: cancelled drawing persists in local state and gets committed on subsequent confirm (1.4901ms)
  ✔ verified fix: cancelling or reopening resets signature state to parent value (0.2617ms)
✔ Documenso Issue #3203: Signature Pad State Isolation on Cancel/Reopen (2.9783ms)
ℹ tests 2
ℹ suites 1
ℹ pass 2
ℹ fail 0
```

### Reference
Fixes #3203
