### PR TITLE
fix(tables): preserve active document filters during pagination

### DIFF
--- a/apps/remix/app/components/tables/documents-table-period-filter.tsx
+++ b/apps/remix/app/components/tables/documents-table-period-filter.tsx
@@ -17,7 +17,7 @@ export const DocumentsTablePeriodFilter = () => {
       period: documentsSearchParams.period,
       page: documentsSearchParams.page,
     },
-    { history: 'push' },
+    { history: 'push', shallow: false },
   );
 
   const onChange = (newPeriod: string | null) => {

--- a/apps/remix/app/components/tables/documents-table-sender-filter.tsx
+++ b/apps/remix/app/components/tables/documents-table-sender-filter.tsx
@@ -23,7 +23,7 @@ export const DocumentsTableSenderFilter = ({ teamId }: DocumentsTableSenderFilte
       senderIds: documentsSearchParams.senderIds,
       page: documentsSearchParams.page,
     },
-    { history: 'push' },
+    { history: 'push', shallow: false },
   );
 
   const selectedSenderIds = (senderIds ?? []).map((senderId) => senderId.toString());

--- a/apps/remix/app/components/tables/documents-table-status-filter.tsx
+++ b/apps/remix/app/components/tables/documents-table-status-filter.tsx
@@ -27,7 +27,7 @@ export const DocumentsTableStatusFilter = ({ stats }: DocumentsTableStatusFilter
       status: documentsSearchParams.status,
       page: documentsSearchParams.page,
     },
-    { history: 'push' },
+    { history: 'push', shallow: false },
   );
 
   const selectableStatuses = useMemo(


### PR DESCRIPTION
### Problem
When navigating across pagination pages in the documents list (e.g. going from page 1 to page 2), active table filters (Status, Sender, Period) were unintentionally wiped from the URL.

### Root cause
In `DocumentsTableStatusFilter`, `DocumentsTableSenderFilter`, and `DocumentsTablePeriodFilter`, `useQueryStates` was called with default `shallow: true`. In shallow mode, `nuqs` updates history state directly without invoking React Router's `navigate()`. As a result, React Router's internal `useSearchParams` snapshot (used by pagination in `useUpdateSearchParams`) became stale, and paginating reconstructed the URL query string from the stale router state, dropping the active filter parameters.

### Change
Configured `shallow: false` in `useQueryStates` across:
- `apps/remix/app/components/tables/documents-table-status-filter.tsx`
- `apps/remix/app/components/tables/documents-table-sender-filter.tsx`
- `apps/remix/app/components/tables/documents-table-period-filter.tsx`

This ensures `nuqs` notifies React Router on every filter update, preserving all active filter parameters seamlessly across pagination.

### Proof

#### Test Red (Before Fix)
```
Buggy paginated query: page=2&perPage=10  (status parameter dropped)
```

#### Test Green (After Fix)
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_3196.mjs
▶ Documenso Issue #3196: Preserving filters during pagination
  ✔ reproduces bug: shallow nuqs write causes pagination to drop active status filter (1.3857ms)
  ✔ verified fix: shallow=false nuqs write preserves status and filter params across pagination (0.3978ms)
✔ Documenso Issue #3196: Preserving filters during pagination (2.9923ms)
ℹ tests 2
ℹ suites 1
ℹ pass 2
ℹ fail 0
```

### Reference
Fixes #3196
