### PR TITLE
fix(i18n): add Plural support for bulk download limit alert (#3209)

### DIFF
--- a/apps/remix/app/components/dialogs/envelopes-bulk-download-dialog.tsx
+++ b/apps/remix/app/components/dialogs/envelopes-bulk-download-dialog.tsx
@@ -290,10 +290,11 @@ export const EnvelopesBulkDownloadDialog = ({
         {isOverDownloadLimit && (
           <Alert variant="warning">
             <AlertDescription>
-              <Trans>
-                You can download up to {MAX_BULK_DOWNLOAD_ENVELOPES} documents at a time. Deselect some documents to
-                continue.
-              </Trans>
+              <Plural
+                value={MAX_BULK_DOWNLOAD_ENVELOPES}
+                one="You can download up to # document at a time. Deselect some documents to continue."
+                other="You can download up to # documents at a time. Deselect some documents to continue."
+              />
             </AlertDescription>
           </Alert>
         )}


### PR DESCRIPTION
# Title
fix(i18n): add Plural support for bulk download limit alert (#3209)

## Description
- Replaces `<Trans>` with `<Plural>` for the bulk download limit alert in `envelopes-bulk-download-dialog.tsx`.
- Ensures accurate pluralization across languages with multiple plural forms (e.g. Slavic, Czech, Polish, Arabic).

Closes #3209
