### PR TITLE
feat: make the Vertex AI model configurable (GOOGLE_VERTEX_MODEL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,6 +211,10 @@ GOOGLE_VERTEX_LOCATION="global"
 # OPTIONAL: API key for Google Vertex AI (Gemini). Get your key from:
 # https://console.cloud.google.com/vertex-ai/studio/settings/api-keys
 GOOGLE_VERTEX_API_KEY=""
+# OPTIONAL: Vertex AI model for the AI features (recipient & field detection).
+# The default preview model is only served by the "global" endpoint; EU regional
+# endpoints need a GA model served there.
+GOOGLE_VERTEX_MODEL=""
 
 # [[CLOUDFLARE TURNSTILE]]
 # OPTIONAL: Cloudflare Turnstile site key (public). When configured, Turnstile challenges

--- a/packages/lib/server-only/ai/envelope/detect-fields/index.ts
+++ b/packages/lib/server-only/ai/envelope/detect-fields/index.ts
@@ -9,7 +9,7 @@ import { getFileServerSide } from '../../../../universal/upload/get-file.server'
 import { resizeImageToGeminiImage } from '../../../../utils/images/resize-image-to-gemini-image';
 import { getEnvelopeById } from '../../../envelope/get-envelope-by-id';
 import { createEnvelopeRecipients } from '../../../recipient/create-envelope-recipients';
-import { vertex } from '../../google';
+import { VERTEX_MODEL, vertex } from '../../google';
 import { pdfToImages } from '../../pdf-to-images';
 import { buildRecipientContextMessage, normalizeDetectedField, resolveRecipientFromKey } from './helpers';
 import { SYSTEM_PROMPT } from './prompt';
@@ -272,7 +272,7 @@ const detectFieldsFromPage = async ({ image, pageNumber, recipients, context }: 
   });
 
   const result = await generateObject({
-    model: vertex('gemini-3-flash-preview'),
+    model: vertex(VERTEX_MODEL),
     system: SYSTEM_PROMPT,
     schema: ZSubmitDetectedFieldsInputSchema,
     messages,

--- a/packages/lib/server-only/ai/envelope/detect-recipients/index.ts
+++ b/packages/lib/server-only/ai/envelope/detect-recipients/index.ts
@@ -6,7 +6,7 @@ import { chunk } from 'remeda';
 import { AppError, AppErrorCode } from '../../../../errors/app-error';
 import { getFileServerSide } from '../../../../universal/upload/get-file.server';
 import { getEnvelopeById } from '../../../envelope/get-envelope-by-id';
-import { vertex } from '../../google';
+import { VERTEX_MODEL, vertex } from '../../google';
 import { pdfToImages } from '../../pdf-to-images';
 import { SYSTEM_PROMPT } from './prompt';
 import type { TDetectedRecipientSchema } from './schema';
@@ -195,7 +195,7 @@ const detectRecipientsFromImages = async ({ images, onProgress }: DetectRecipien
     });
 
     const result = await generateObject({
-      model: vertex('gemini-3-flash-preview'),
+      model: vertex(VERTEX_MODEL),
       system: SYSTEM_PROMPT,
       schema: ZDetectedRecipientsSchema,
       messages,

--- a/packages/lib/server-only/ai/google.ts
+++ b/packages/lib/server-only/ai/google.ts
@@ -7,3 +7,14 @@ export const vertex = createVertex({
   location: env('GOOGLE_VERTEX_LOCATION') || 'global',
   apiKey: env('GOOGLE_VERTEX_API_KEY'),
 });
+
+/**
+ * The Vertex model the AI features (recipient & field detection) run on.
+ *
+ * The default preview model is only served by the global endpoint; every EU
+ * regional endpoint 404s for it, so EU-residency deployments pointing
+ * GOOGLE_VERTEX_LOCATION at a regional endpoint could not use the feature at
+ * all. GOOGLE_VERTEX_MODEL lets those deployments pick a GA model their
+ * region serves (#3240).
+ */
+export const VERTEX_MODEL = env('GOOGLE_VERTEX_MODEL') || 'gemini-3-flash-preview';

--- a/packages/tsconfig/process-env.d.ts
+++ b/packages/tsconfig/process-env.d.ts
@@ -138,5 +138,6 @@ declare namespace NodeJS {
     GOOGLE_VERTEX_PROJECT_ID?: string;
     GOOGLE_VERTEX_LOCATION?: string;
     GOOGLE_VERTEX_API_KEY?: string;
+    GOOGLE_VERTEX_MODEL?: string;
   }
 }


### PR DESCRIPTION
## Summary
Implements #3240.

## Root cause
Both AI features (recipient & field detection) hardcode `vertex('gemini-3-flash-preview')`. Per the issue's empirical table, that preview model is served **only by the global endpoint** — all eight EU regional endpoints 404 — so the documented EU-residency configuration (`GOOGLE_VERTEX_LOCATION` → EU region) made the features unusable, and the only working setup sent full document page images to the global endpoint with no residency guarantee.

## What this does
- `GOOGLE_VERTEX_MODEL` (optional; **default unchanged**: `gemini-3-flash-preview`) read once in `ai/google.ts` next to the provider into a shared `VERTEX_MODEL` constant;
- both detection features use the constant — one place to change;
- typed in `process-env.d.ts`; documented in `.env.example` with the EU-endpoint rationale.

`GOOGLE_VERTEX_LOCATION=europe-west3` + `GOOGLE_VERTEX_MODEL=<GA model served there>` now keeps the entire feature inside the region. Also future-proofs against the preview model's deprecation (GA successors already shipped).
