### PR TITLE
fix(i18n): add plural forms for command menu results and item counts (#3207)

### DIFF
--- a/apps/remix/app/components/general/app-command-menu.tsx
+++ b/apps/remix/app/components/general/app-command-menu.tsx
@@ -17,7 +17,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 import type { MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { Trans } from '@lingui/react/macro';
+import { Plural, Trans } from '@lingui/react/macro';
 import { keepPreviousData } from '@tanstack/react-query';
 import { defaultFilter as commandScore } from 'cmdk';
 import {
@@ -596,9 +596,21 @@ export const AppCommandMenu = ({ open, onOpenChange }: AppCommandMenuProps) => {
 
             <span className="ml-auto text-muted-foreground text-xs">
               {hasValidSearch ? (
-                <Trans>{formatChipCount(totalVisibleCount, isVisibleCountCapped)} results</Trans>
+                isVisibleCountCapped ? (
+                  <Trans>{formatChipCount(totalVisibleCount, isVisibleCountCapped)} results</Trans>
+                ) : (
+                  <Plural
+                    value={totalVisibleCount}
+                    one="# result"
+                    other="# results"
+                  />
+                )
               ) : (
-                <Trans>{totalVisibleCount} items</Trans>
+                <Plural
+                  value={totalVisibleCount}
+                  one="# item"
+                  other="# items"
+                />
               )}
             </span>
           </div>


### PR DESCRIPTION
# Title
fix(i18n): add plural forms for command menu results and item counts (#3207)

## Description
- Replaces static `<Trans>` elements with Lingui `<Plural>` macro in `app-command-menu.tsx` for search result counts and item counts.
- Preserves capped count formatting when `isVisibleCountCapped` is true.
- Ensures accurate pluralization across languages with multiple plural forms.

Closes #3207
