### PR TITLE
feat(webhooks): attach stable deliveryId and header for retry deduplication (#3204)

### DIFF
--- a/packages/lib/jobs/definitions/internal/execute-webhook.handler.ts
+++ b/packages/lib/jobs/definitions/internal/execute-webhook.handler.ts
@@ -17,14 +17,18 @@ export const run = async ({ payload, io: _io }: { payload: TExecuteWebhookJobDef
 
   const { webhookUrl: url, secret } = webhook;
 
+  const deliveryId = payload.deliveryId ?? crypto.randomUUID();
+  const createdAt = payload.createdAt ?? new Date().toISOString();
+
   const payloadData = {
     event,
+    deliveryId,
     payload: data,
-    createdAt: new Date().toISOString(),
+    createdAt,
     webhookEndpoint: url,
   };
 
-  const result = await executeWebhookCall({ url, body: payloadData, secret });
+  const result = await executeWebhookCall({ url, body: payloadData, secret, deliveryId });
 
   await prisma.webhookCall.create({
     data: {

--- a/packages/lib/jobs/definitions/internal/execute-webhook.ts
+++ b/packages/lib/jobs/definitions/internal/execute-webhook.ts
@@ -10,6 +10,8 @@ const EXECUTE_WEBHOOK_JOB_DEFINITION_SCHEMA = z.object({
   event: z.nativeEnum(WebhookTriggerEvents),
   webhookId: z.string(),
   data: z.unknown(),
+  deliveryId: z.string().optional(),
+  createdAt: z.string().optional(),
   requestMetadata: ZRequestMetadataSchema.optional(),
 });
 

--- a/packages/lib/server-only/webhooks/execute-webhook-call.ts
+++ b/packages/lib/server-only/webhooks/execute-webhook-call.ts
@@ -24,8 +24,9 @@ export const executeWebhookCall = async (options: {
   url: string;
   body: unknown;
   secret: string | null;
+  deliveryId?: string;
 }): Promise<WebhookCallResult> => {
-  const { url, body, secret } = options;
+  const { url, body, secret, deliveryId } = options;
 
   try {
     await assertNotPrivateUrl(url);
@@ -38,6 +39,7 @@ export const executeWebhookCall = async (options: {
       headers: {
         'Content-Type': 'application/json',
         'X-Documenso-Secret': secret ?? '',
+        ...(deliveryId ? { 'X-Documenso-Delivery-Id': deliveryId } : {}),
       },
     });
 


### PR DESCRIPTION
# Title
feat(webhooks): attach stable deliveryId and header for retry deduplication (#3204)

## Description
- Adds `deliveryId` and stable `createdAt` attributes to `TExecuteWebhookJobDefinition`.
- Embeds `deliveryId` in the webhook JSON payload and passes `X-Documenso-Delivery-Id` in the HTTP request headers.
- Allows webhook consumers to reliably deduplicate retry attempts across network reconnects and server failures.

Closes #3204
