### PR TITLE
fix(signing): guard allowDictateNextSigner for VIEWER recipient (#3202)

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-form.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-form.tsx
@@ -151,7 +151,7 @@ export const DocumentSigningForm = ({
                     completeDocument({ nextSigner, accessAuthOptions })
                   }
                   recipient={recipient}
-                  allowDictateNextSigner={document.documentMeta?.allowDictateNextSigner}
+                  allowDictateNextSigner={nextRecipient && document.documentMeta?.allowDictateNextSigner}
                   defaultNextSigner={
                     nextRecipient ? { name: nextRecipient.name, email: nextRecipient.email } : undefined
                   }


### PR DESCRIPTION
# Title
fix(signing): guard allowDictateNextSigner for VIEWER recipient when completing document (#3202)

## Description
- Updates `document-signing-form.tsx` to guard `allowDictateNextSigner` with `nextRecipient && document.documentMeta?.allowDictateNextSigner` in the VIEWER branch.
- Prevents the dialog form resolver from requiring next recipient validation on hidden inputs when a VIEWER is the last recipient in sequential signing order.
- Fixes issue where clicking "Mark as viewed" silently failed without updating the document state.

Closes #3202
