### PR TITLE
fix(ui): reset local signature state on open/close in SignaturePadDialog (#3203)

### DIFF
--- a/packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad-dialog.tsx
@@ -62,7 +62,10 @@ export const SignaturePadDialog = ({
         type="button"
         disabled={disabled}
         className="absolute inset-0 flex items-center justify-center bg-transparent"
-        onClick={() => setShowSignatureModal(true)}
+        onClick={() => {
+          setSignature(value ?? '');
+          setShowSignatureModal(true);
+        }}
         whileHover="onHover"
       >
         {!value && !disableAnimation && (
@@ -109,7 +112,16 @@ export const SignaturePadDialog = ({
         )}
       </motion.button>
 
-      <Dialog open={showSignatureModal} onOpenChange={disabled ? undefined : setShowSignatureModal}>
+      <Dialog
+        open={showSignatureModal}
+        onOpenChange={(open) => {
+          if (disabled) return;
+          if (!open) {
+            setSignature(value ?? '');
+          }
+          setShowSignatureModal(open);
+        }}
+      >
         <DialogContent hideClose={true} className="p-6 pt-4">
           <SignaturePad
             id="signature"


### PR DESCRIPTION
# Title
fix(ui): reset local signature state when opening and closing SignaturePadDialog (#3203)

## Description
- Resets local `signature` state to `value ?? ''` whenever `SignaturePadDialog` is opened or closed.
- Prevents abandoned or cancelled drawings from persisting in component local state and erroneously committing to documents on subsequent confirms.

Closes #3203
