### PR TITLE
ci: use pull_request_target trigger in pr labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: 'PR Labeler'
 
 on:
-  - pull_request
+  - pull_request_target
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Fork PRs now get labels from the "PR Labeler" workflow. The `pull_request` trigger gives a read-only token on PRs from forks, and the `labeler` check stopped with `Resource not accessible by integration`. The workflow now runs on `pull_request_target`, which runs from the base repository with a write token. The labeler does not check out or execute PR code, thus the new trigger is safe.

Related: #3075