### PR TITLE
fix(i18n): formal address (Sie) in German customer-facing emails and signing pages

### DIFF
--- a/packages/lib/translations/de/web.po
+++ b/packages/lib/translations/de/web.po
@@ -315,7 +315,7 @@ msgstr "{0} hat Sie eingeladen, das Dokument \"{1}\" {recipientActionVerb}."
 #. placeholder {0}: team.name
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 msgid "{0} invited you to {recipientActionVerb} a document"
-msgstr "{0} hat dich eingeladen, ein Dokument {recipientActionVerb}"
+msgstr "{0} hat Sie eingeladen, ein Dokument zu {recipientActionVerb}"
 
 #. placeholder {0}: remaining.documents
 #. placeholder {1}: quota.documents
@@ -392,7 +392,7 @@ msgstr "{inviterName} <0>({inviterEmail})</0>"
 
 #: packages/email/templates/document-cancel.tsx
 msgid "{inviterName} has cancelled the document {documentName}, you don't need to sign it anymore."
-msgstr "{inviterName} hat das Dokument {documentName} storniert, du musst es nicht mehr unterzeichnen."
+msgstr "{inviterName} hat das Dokument {documentName} storniert, Sie müssen es nicht mehr unterzeichnen."
 
 #: packages/email/template-components/template-document-cancel.tsx
 msgid "{inviterName} has cancelled the document<0/>\"{documentName}\""
@@ -401,11 +401,11 @@ msgstr "{inviterName} hat das Dokument<0/>\"{documentName}\" storniert"
 #. placeholder {0}: _(actionVerb).toLowerCase()
 #: packages/email/template-components/template-document-invite.tsx
 msgid "{inviterName} has invited you to {0}<0/>\"{documentName}\""
-msgstr "{inviterName} hat dich eingeladen, {0}<0/>\"{documentName}\""
+msgstr "{inviterName} hat Sie eingeladen,<0/>\"{documentName}\" zu {0}"
 
 #: packages/email/templates/document-invite.tsx
 msgid "{inviterName} has invited you to {action} {documentName}"
-msgstr "{inviterName} hat dich eingeladen, {action} {documentName}"
+msgstr "{inviterName} hat Sie eingeladen, das Dokument {documentName} zu {action}"
 
 #: packages/email/templates/document-invite.tsx
 msgid "{inviterName} has invited you to {action} the document \"{documentName}\"."
@@ -413,11 +413,11 @@ msgstr "{inviterName} hat Sie eingeladen, das Dokument \"{documentName}\" {actio
 
 #: packages/email/templates/recipient-removed-from-document.tsx
 msgid "{inviterName} has removed you from the document {documentName}."
-msgstr "{inviterName} hat dich aus dem Dokument {documentName} entfernt."
+msgstr "{inviterName} hat Sie aus dem Dokument {documentName} entfernt."
 
 #: packages/email/templates/recipient-removed-from-document.tsx
 msgid "{inviterName} has removed you from the document<0/>\"{documentName}\""
-msgstr "{inviterName} hat dich aus dem Dokument<0/>\"{documentName}\" entfernt"
+msgstr "{inviterName} hat Sie aus dem Dokument<0/>\"{documentName}\" entfernt"
 
 #. placeholder {0}: team.name
 #. placeholder {1}: envelope.title
@@ -428,7 +428,7 @@ msgstr "{inviterName} im Auftrag von \"{0}\" hat Sie eingeladen, das Dokument \"
 #. placeholder {0}: _(actionVerb).toLowerCase()
 #: packages/email/template-components/template-document-invite.tsx
 msgid "{inviterName} on behalf of \"{teamName}\" has invited you to {0}<0/>\"{documentName}\""
-msgstr "{inviterName} im Namen von \"{teamName}\" hat dich eingeladen, {0}<0/>\"{documentName}\""
+msgstr "{inviterName} im Namen von \"{teamName}\" hat Sie eingeladen,<0/>\"{documentName}\" zu {0}"
 
 #: packages/email/templates/document-invite.tsx
 msgid "{inviterName} on behalf of \"{teamName}\" has invited you to {action} {documentName}"
@@ -507,7 +507,7 @@ msgstr "{subscriptionClaimCount, plural, one {# Abonnementsanforderung} other {#
 #. placeholder {0}: _(actionVerb).toLowerCase()
 #: packages/email/template-components/template-document-invite.tsx
 msgid "{teamName} has invited you to {0}<0/>\"{documentName}\""
-msgstr "{teamName} hat dich eingeladen, {0}<0/>\"{documentName}\""
+msgstr "{teamName} hat Sie eingeladen,<0/>\"{documentName}\" zu {0}"
 
 #: packages/email/templates/document-invite.tsx
 msgid "{teamName} has invited you to {action} {documentName}"
@@ -1004,7 +1004,7 @@ msgstr "Ein Gerät, das in der Lage ist, Dokumente zuzugreifen, zu öffnen und z
 
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 msgid "A document was created by your direct template that requires you to {recipientActionVerb} it."
-msgstr "Ein Dokument wurde von deiner direkten Vorlage erstellt, das erfordert, dass du {recipientActionVerb}."
+msgstr "Aus Ihrer direkten Vorlage wurde ein Dokument erstellt, das Sie {recipientActionVerb} müssen."
 
 #: apps/remix/app/components/dialogs/template-use-dialog.tsx
 msgid "A draft document will be created"
@@ -1102,7 +1102,7 @@ msgstr "Eine stabile Internetverbindung"
 #: packages/email/templates/team-delete.tsx
 #: packages/email/templates/team-delete.tsx
 msgid "A team you were a part of has been deleted"
-msgstr "Ein Team, dem du angehörtest, wurde gelöscht"
+msgstr "Ein Team, dem Sie angehörten, wurde gelöscht"
 
 #: apps/remix/app/components/forms/public-profile-form.tsx
 msgid "A unique URL to access your profile"
@@ -1721,7 +1721,7 @@ msgstr "Fast fertig"
 
 #: apps/remix/app/components/forms/signup.tsx
 msgid "Already have an account? <0>Sign in instead</0>"
-msgstr "Hast du bereits ein Konto? <0>Stattdessen anmelden</0>"
+msgstr "Sie haben bereits ein Konto? <0>Stattdessen anmelden</0>"
 
 #: apps/remix/app/components/tables/organisation-billing-invoices-table.tsx
 msgid "Amount"
@@ -1729,7 +1729,7 @@ msgstr "Betrag"
 
 #: packages/email/templates/document-super-delete.tsx
 msgid "An admin has deleted your document \"{documentName}\"."
-msgstr "Ein Administrator hat dein Dokument \"{documentName}\" gelöscht."
+msgstr "Ein Administrator hat Ihr Dokument \"{documentName}\" gelöscht."
 
 #: packages/email/template-components/template-admin-user-created.tsx
 msgid "An administrator has created a Documenso account for you."
@@ -2399,7 +2399,7 @@ msgstr "Standard-Textfarbe."
 
 #: packages/email/template-components/template-confirmation-email.tsx
 msgid "Before you get started, please confirm your email address by clicking the button below:"
-msgstr "Bitte bestätige vor dem Start deine E-Mail-Adresse, indem du auf den Button unten klickst:"
+msgstr "Bitte bestätigen Sie vor dem Start Ihre E-Mail-Adresse, indem Sie auf die Schaltfläche unten klicken:"
 
 #: apps/remix/app/components/general/org-menu-switcher.tsx
 #: apps/remix/app/routes/_authenticated+/o.$orgUrl.settings.billing.tsx
@@ -3209,7 +3209,7 @@ msgstr "Fortsetzen"
 #: packages/email/template-components/template-document-invite.tsx
 #: packages/email/template-components/template-document-reminder.tsx
 msgid "Continue by approving the document."
-msgstr "Fahre fort, indem du das Dokument genehmigst."
+msgstr "Fahren Sie fort, indem Sie das Dokument genehmigen."
 
 #: packages/email/template-components/template-document-invite.tsx
 #: packages/email/template-components/template-document-reminder.tsx
@@ -3218,17 +3218,17 @@ msgstr "Fahren Sie fort, indem Sie das Dokument unterstützen."
 
 #: packages/email/template-components/template-document-completed.tsx
 msgid "Continue by downloading the document."
-msgstr "Fahre fort, indem du das Dokument herunterlädst."
+msgstr "Fahren Sie fort, indem Sie das Dokument herunterladen."
 
 #: packages/email/template-components/template-document-invite.tsx
 #: packages/email/template-components/template-document-reminder.tsx
 msgid "Continue by signing the document."
-msgstr "Fahre fort, indem du das Dokument signierst."
+msgstr "Fahren Sie fort, indem Sie das Dokument signieren."
 
 #: packages/email/template-components/template-document-invite.tsx
 #: packages/email/template-components/template-document-reminder.tsx
 msgid "Continue by viewing the document."
-msgstr "Fahre fort, indem du das Dokument ansiehst."
+msgstr "Fahren Sie fort, indem Sie das Dokument ansehen."
 
 #: apps/remix/app/routes/_unauthenticated+/organisation.invite.$token.tsx
 msgid "Continue to login"
@@ -3374,7 +3374,7 @@ msgstr "Erstellen"
 
 #: packages/email/template-components/template-document-self-signed.tsx
 msgid "Create a <0>free account</0> to access your signed documents at any time."
-msgstr "Erstelle ein <0>kostenfreies Konto</0>, um jederzeit auf deine unterzeichneten Dokumente zuzugreifen."
+msgstr "Erstellen Sie ein <0>kostenfreies Konto</0>, um jederzeit auf Ihre unterzeichneten Dokumente zuzugreifen."
 
 #: apps/remix/app/components/forms/signup.tsx
 msgid "Create a new account"
@@ -4137,7 +4137,7 @@ msgstr "Sie haben diese E-Mail nicht erwartet? <0>Klicken Sie hier, um den Absen
 
 #: packages/email/templates/reset-password.tsx
 msgid "Didn't request a password change? We are here to help you secure your account, just <0>contact us</0>."
-msgstr "Du hast keine Passwortänderung angefordert? Wir helfen dir, dein Konto zu sichern, kontaktiere uns einfach <0>hier</0>."
+msgstr "Sie haben keine Passwortänderung angefordert? Wir helfen Ihnen, Ihr Konto zu sichern — melden Sie sich einfach <0>hier</0>."
 
 #: apps/remix/app/components/general/template/template-direct-link-badge.tsx
 #: apps/remix/app/components/tables/templates-table.tsx
@@ -6062,7 +6062,7 @@ msgstr "Passwort vergessen?"
 #: apps/remix/app/routes/_unauthenticated+/forgot-password.tsx
 #: packages/email/template-components/template-forgot-password.tsx
 msgid "Forgot your password?"
-msgstr "Hast du dein Passwort vergessen?"
+msgstr "Haben Sie Ihr Passwort vergessen?"
 
 #: apps/remix/app/components/dialogs/organisation-create-dialog.tsx
 msgctxt "Plan price"
@@ -6787,7 +6787,7 @@ msgstr "Es ist momentan nicht Ihre Runde zum Unterschreiben. Bitte schauen Sie b
 
 #: apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
 msgid "It's currently not your turn to sign. You will receive an email with instructions once it's your turn to sign the document."
-msgstr "Es ist derzeit nicht deine Reihe zu unterschreiben. Du erhältst eine E-Mail mit Anweisungen, sobald es deine Reihe ist, das Dokument zu unterschreiben."
+msgstr "Sie sind derzeit noch nicht an der Reihe. Sie erhalten eine E-Mail mit Anweisungen, sobald Sie das Dokument unterschreiben können."
 
 #: packages/lib/constants/i18n.ts
 msgid "Italian"
@@ -8492,11 +8492,11 @@ msgstr "Tarife ohne Transport verwenden den systemweiten Standard-Mailer."
 #. placeholder {0}: _(actionVerb).toLowerCase()
 #: packages/email/template-components/template-document-invite.tsx
 msgid "Please {0} your document<0/>\"{documentName}\""
-msgstr "Bitte {0} dein Dokument<0/>\"{documentName}\""
+msgstr "Bitte {0} Sie Ihr Dokument<0/>\"{documentName}\""
 
 #: packages/email/templates/document-invite.tsx
 msgid "Please {action} your document {documentName}"
-msgstr "Bitte {action} dein Dokument {documentName}"
+msgstr "Bitte {action} Sie Ihr Dokument {documentName}"
 
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 msgid "Please {recipientActionVerb} this document"
@@ -8504,11 +8504,11 @@ msgstr "Bitte {recipientActionVerb} dieses Dokument"
 
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 msgid "Please {recipientActionVerb} this document created by your direct template"
-msgstr "Bitte {recipientActionVerb} dieses Dokument, das von deiner direkten Vorlage erstellt wurde"
+msgstr "Bitte {recipientActionVerb} Sie dieses Dokument, das aus Ihrer direkten Vorlage erstellt wurde"
 
 #: packages/lib/jobs/definitions/emails/send-signing-email.handler.ts
 msgid "Please {recipientActionVerb} your document"
-msgstr "Bitte {recipientActionVerb} dein Dokument"
+msgstr "Bitte {recipientActionVerb} Sie Ihr Dokument"
 
 #: apps/remix/app/components/dialogs/organisation-member-invite-dialog.tsx
 msgid "Please check the CSV file and make sure it is according to our format"
@@ -8521,7 +8521,7 @@ msgstr "Bitte überprüfen Sie bei der übergeordneten Anwendung weitere Informa
 
 #: apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
 msgid "Please check your email for updates."
-msgstr "Bitte überprüfe deine E-Mail auf Updates."
+msgstr "Bitte sehen Sie in Ihrem Postfach nach."
 
 #: apps/remix/app/routes/_unauthenticated+/reset-password.$token.tsx
 msgid "Please choose your new password"
@@ -8546,11 +8546,11 @@ msgstr "Bitte konfigurieren Sie zuerst das Dokument"
 
 #: packages/lib/server-only/auth/send-confirmation-email.ts
 msgid "Please confirm your email"
-msgstr "Bitte bestätige deine E-Mail"
+msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse"
 
 #: packages/email/templates/confirm-email.tsx
 msgid "Please confirm your email address"
-msgstr "Bitte bestätige deine E-Mail-Adresse"
+msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse"
 
 #: apps/remix/app/components/embed/embed-paywall.tsx
 msgid "Please contact <0>support</0> if you have any questions."
@@ -8558,7 +8558,7 @@ msgstr "Bitte kontaktieren Sie <0>den Support</0>, wenn Sie Fragen haben."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "Please contact support at {SUPPORT_EMAIL} and we will review your account."
-msgstr "Bitte kontaktiere den Support unter {SUPPORT_EMAIL}, und wir werden dein Konto überprüfen."
+msgstr "Bitte wenden Sie sich an den Support unter {SUPPORT_EMAIL}, wir prüfen dann Ihr Konto."
 
 #: apps/remix/app/components/dialogs/envelope-delete-dialog.tsx
 msgid "Please contact support if you would like to revert this action."
@@ -8586,11 +8586,11 @@ msgstr "Bitte gib einen Wert ein"
 
 #: apps/remix/app/components/dialogs/sign-field-email-dialog.tsx
 msgid "Please enter your email address"
-msgstr "Bitte gib deine E-Mail-Adresse ein"
+msgstr "Bitte geben Sie Ihre E-Mail-Adresse ein"
 
 #: apps/remix/app/components/dialogs/sign-field-name-dialog.tsx
 msgid "Please enter your full name"
-msgstr "Bitte gib deinen vollständigen Namen ein"
+msgstr "Bitte geben Sie Ihren vollständigen Namen ein"
 
 #: apps/remix/app/components/dialogs/sign-field-initials-dialog.tsx
 msgid "Please enter your initials"
@@ -9251,12 +9251,12 @@ msgstr "Erinnerung: {0}"
 #: packages/lib/jobs/definitions/internal/process-signing-reminder.handler.ts
 #: packages/lib/server-only/document/resend-document.ts
 msgid "Reminder: {0} invited you to {recipientActionVerb} a document"
-msgstr "Erinnerung: {0} hat dich eingeladen, ein Dokument {recipientActionVerb}"
+msgstr "Erinnerung: {0} hat Sie eingeladen, ein Dokument zu {recipientActionVerb}"
 
 #. placeholder {0}: _(actionVerb).toLowerCase()
 #: packages/email/template-components/template-document-reminder.tsx
 msgid "Reminder: Please {0} your document<0/>\"{documentName}\""
-msgstr "Erinnerung: Bitte {0} dein Dokument<0/>\"{documentName}\""
+msgstr "Erinnerung: Bitte {0} Sie Ihr Dokument<0/>\"{documentName}\""
 
 #. placeholder {0}: envelope.title
 #: packages/lib/jobs/definitions/internal/process-signing-reminder.handler.ts
@@ -10171,7 +10171,7 @@ msgstr "Richten Sie Ihre Vorlageneigenschaften und Empfängerinformationen ein"
 
 #: packages/email/templates/admin-user-created.tsx
 msgid "Set your password for Documenso"
-msgstr "Lege dein Passwort für Documenso fest"
+msgstr "Legen Sie Ihr Passwort für Documenso fest"
 
 #: apps/remix/app/components/general/app-command-menu.tsx
 #: apps/remix/app/components/general/app-command-menu.tsx
@@ -11355,7 +11355,7 @@ msgstr "Vielen Dank, dass Sie Documenso zur elektronischen Unterzeichnung Ihrer 
 
 #: packages/email/template-components/template-forgot-password.tsx
 msgid "That's okay, it happens! Click the button below to reset your password."
-msgstr "Das ist in Ordnung, das passiert! Klicke auf den Button unten, um dein Passwort zurückzusetzen."
+msgstr "Das kommt vor. Klicken Sie auf die Schaltfläche unten, um Ihr Passwort zurückzusetzen."
 
 #: apps/remix/app/components/dialogs/admin-user-delete-dialog.tsx
 msgid "The account has been deleted successfully."
@@ -11894,7 +11894,7 @@ msgstr ""
 
 #: packages/email/template-components/template-document-super-delete.tsx
 msgid "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
-msgstr "Dieses Dokument kann nicht wiederhergestellt werden. Wenn du den Grund für zukünftige Dokumente anfechten möchtest, kontaktiere bitte den Support."
+msgstr "Dieses Dokument kann nicht wiederhergestellt werden. Wenn Sie den Grund für künftige Dokumente anfechten möchten, wenden Sie sich bitte an den Support."
 
 #: apps/remix/app/components/embed/authoring/configure-document-upload.tsx
 msgid "This document cannot be changed"
@@ -11976,7 +11976,7 @@ msgstr "Dieses Dokument wurde mit einem direkten Link erstellt."
 
 #: packages/email/template-components/template-footer.tsx
 msgid "This document was sent using <0>Documenso</0>."
-msgstr "Dieses Dokument wurde mit <0>Documenso</0> versendet."
+msgstr "Dieses Dokument wurde mit <0>Documenso</0> verarbeitet."
 
 #: apps/remix/app/components/dialogs/envelope-duplicate-dialog.tsx
 msgid "This document will be duplicated."
@@ -12294,7 +12294,7 @@ msgstr "Um Zugang zu Ihrem Konto zu erhalten, bestätigen Sie bitte Ihre E-Mail-
 
 #: packages/email/template-components/template-admin-user-created.tsx
 msgid "To get started, please set your password by clicking the button below:"
-msgstr "Um zu beginnen, lege bitte dein Passwort fest, indem du auf den Button unten klickst:"
+msgstr "Legen Sie zu Beginn Ihr Passwort fest, indem Sie auf die Schaltfläche unten klicken:"
 
 #. placeholder {0}: recipient.email
 #: apps/remix/app/components/general/document-signing/document-signing-auth-account.tsx
@@ -13342,12 +13342,12 @@ msgstr "Warten auf andere, um zu unterschreiben"
 #: apps/remix/app/components/embed/embed-document-waiting-for-turn.tsx
 #: apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
 msgid "Waiting for Your Turn"
-msgstr "Warten auf deine Reihe"
+msgstr "Warten, bis Sie an der Reihe sind"
 
 #: apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
 #: apps/remix/app/routes/_recipient+/sign.$token+/_index.tsx
 msgid "Want to send slick signing links like this one? <0>Check out Documenso</0>."
-msgstr "Möchtest du schicke Signatur-Links wie diesen versenden? <0>Sieh dir Documenso an</0>."
+msgstr "Möchten Sie schicke Signatur-Links wie diesen versenden? <0>Sehen Sie sich Documenso an</0>."
 
 #: apps/remix/app/routes/_profile+/_layout.tsx
 msgid "Want your own public profile?"
@@ -13751,23 +13751,23 @@ msgstr "Wir sind alle leer"
 
 #: packages/email/template-components/template-document-pending.tsx
 msgid "We're still waiting for other signers to sign this document.<0/>We'll notify you as soon as it's ready."
-msgstr "Wir warten noch darauf, dass andere Unterzeichner dieses Dokument unterzeichnen.<0/>Wir benachrichtigen dich, sobald es bereit ist."
+msgstr "Wir warten noch darauf, dass andere Unterzeichner dieses Dokument unterzeichnen.<0/>Wir benachrichtigen Sie, sobald es bereit ist."
 
 #: packages/email/templates/reset-password.tsx
 msgid "We've changed your password as you asked. You can now sign in with your new password."
-msgstr "Wir haben dein Passwort wie gewünscht geändert. Du kannst dich jetzt mit deinem neuen Passwort anmelden."
+msgstr "Wir haben Ihr Passwort wie gewünscht geändert. Sie können sich jetzt mit dem neuen Passwort anmelden."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "We've noticed API activity on your account that exceeds the fair use limits of your current plan. As a precaution, new API activity has been temporarily paused pending review."
-msgstr "Wir haben API-Aktivitäten in deinem Konto festgestellt, die die Fair-Use-Grenzen deines aktuellen Tarifs überschreiten. Vorsorglich wurde neue API-Aktivität vorübergehend bis zur Überprüfung pausiert."
+msgstr "Wir haben in Ihrem Konto API-Aktivitäten festgestellt, die die Fair-Use-Grenzen Ihres Tarifs überschreiten. Vorsorglich wurde neue API-Aktivität vorübergehend bis zur Überprüfung pausiert."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "We've noticed document activity on your account that exceeds the fair use limits of your current plan. As a precaution, new document activity has been temporarily paused pending review."
-msgstr "Wir haben Dokumentenaktivitäten in deinem Konto festgestellt, die die Fair-Use-Grenzen deines aktuellen Tarifs überschreiten. Vorsorglich wurde neue Dokumentenaktivität vorübergehend bis zur Überprüfung pausiert."
+msgstr "Wir haben in Ihrem Konto Dokumentenaktivitäten festgestellt, die die Fair-Use-Grenzen Ihres Tarifs überschreiten. Vorsorglich wurde die Erstellung neuer Dokumente vorübergehend bis zur Überprüfung pausiert."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "We've noticed email sending activity on your account that exceeds the fair use limits of your current plan. As a precaution, new email activity has been temporarily paused pending review."
-msgstr "Wir haben E-Mail-Versandaktivitäten in deinem Konto festgestellt, die die Fair-Use-Grenzen deines aktuellen Tarifs überschreiten. Vorsorglich wurde neue E-Mail-Aktivität vorübergehend bis zur Überprüfung pausiert."
+msgstr "Wir haben in Ihrem Konto E-Mail-Versandaktivitäten festgestellt, die die Fair-Use-Grenzen Ihres Tarifs überschreiten. Vorsorglich wurde neue E-Mail-Aktivität vorübergehend bis zur Überprüfung pausiert."
 
 #: apps/remix/app/components/general/document-signing/access-auth-2fa-form.tsx
 msgid "We've sent a 6-digit verification code to your email. Please enter it below to complete the document."
@@ -13849,7 +13849,7 @@ msgstr "Bekannte URL ist erforderlich"
 
 #: apps/remix/app/routes/_recipient+/sign.$token+/waiting.tsx
 msgid "Were you trying to edit this document instead?"
-msgstr "Hast du stattdessen versucht, dieses Dokument zu bearbeiten?"
+msgstr "Wollten Sie dieses Dokument stattdessen bearbeiten?"
 
 #: apps/remix/app/routes/_authenticated+/o.$orgUrl._index.tsx
 msgid "What you can do with teams:"
@@ -14143,11 +14143,11 @@ msgstr "Sie können im Editor manuell Empfänger hinzufügen."
 
 #: packages/email/template-components/template-confirmation-email.tsx
 msgid "You can also copy and paste this link into your browser: {confirmationLink} (link expires in 1 hour)"
-msgstr "Du kannst diesen Link auch kopieren und in deinen Browser einfügen: {confirmationLink} (Link läuft in 1 Stunde ab)"
+msgstr "Sie können diesen Link auch kopieren und in Ihrem Browser öffnen: {confirmationLink} (Link läuft in 1 Stunde ab)"
 
 #: packages/email/template-components/template-admin-user-created.tsx
 msgid "You can also copy and paste this link into your browser: {resetPasswordLink} (link expires in 24 hours)"
-msgstr "Du kannst diesen Link auch kopieren und in deinen Browser einfügen: {resetPasswordLink} (Link läuft in 24 Stunden ab)"
+msgstr "Sie können diesen Link auch kopieren und in Ihrem Browser öffnen: {resetPasswordLink} (Link läuft in 24 Stunden ab)"
 
 #: apps/remix/app/routes/_authenticated+/t.$teamUrl+/settings.public-profile.tsx
 msgid "You can choose to enable or disable the profile for public view."
@@ -14311,7 +14311,7 @@ msgstr "Sie verwalten die Abrechnung für keine Organisation."
 
 #: packages/email/template-components/template-document-cancel.tsx
 msgid "You don't need to sign it anymore."
-msgstr "Du musst es nicht mehr unterschreiben."
+msgstr "Sie müssen es nicht mehr unterschreiben."
 
 #: packages/lib/utils/document-audit-logs.ts
 msgid "You failed to validate a 2FA token for the document"
@@ -14345,7 +14345,7 @@ msgstr "Sie wurden eingeladen, der folgenden Organisation beizutreten"
 
 #: packages/lib/jobs/definitions/emails/send-recipient-removed-email.handler.ts
 msgid "You have been removed from a document"
-msgstr "Du wurdest von einem Dokument entfernt"
+msgstr "Sie wurden von einem Dokument entfernt"
 
 #: apps/remix/app/components/embed/multisign/multi-sign-document-list.tsx
 msgid "You have been requested to sign the following documents. Review each document carefully and complete the signing process."
@@ -14419,7 +14419,7 @@ msgstr "Sie haben dieses Dokument abgelehnt"
 
 #: packages/email/template-components/template-document-self-signed.tsx
 msgid "You have signed “{documentName}”"
-msgstr "Du hast „{documentName}“ unterzeichnet"
+msgstr "Sie haben „{documentName}“ unterzeichnet"
 
 #: apps/remix/app/components/dialogs/organisation-leave-dialog.tsx
 msgid "You have successfully left this organisation."
@@ -14847,7 +14847,7 @@ msgstr "Ihr Dokument wurde erfolgreich erstellt"
 
 #: packages/email/template-components/template-document-super-delete.tsx
 msgid "Your document has been deleted by an admin!"
-msgstr "Dein Dokument wurde von einem Administrator gelöscht!"
+msgstr "Ihr Dokument wurde von einem Administrator gelöscht!"
 
 #: apps/remix/app/components/dialogs/envelope-redistribute-dialog.tsx
 msgid "Your document has been resent successfully."
@@ -14944,7 +14944,7 @@ msgstr "Ihre Organisation wurde erstellt."
 #: packages/email/templates/organisation-delete.tsx
 #: packages/email/templates/organisation-delete.tsx
 msgid "Your organisation has been deleted"
-msgstr "Deine Organisation wurde gelöscht"
+msgstr "Ihre Organisation wurde gelöscht"
 
 #: apps/remix/app/components/dialogs/organisation-delete-dialog.tsx
 msgid "Your organisation has been successfully deleted."
@@ -14976,15 +14976,15 @@ msgstr "Ihre Organisation nähert sich einem Fair-Use-Limit. Wenn Sie höhere Li
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "Your organisation is generating API requests faster than normal, so some requests are being temporarily throttled."
-msgstr "Deine Organisation erzeugt API-Anfragen schneller als gewöhnlich, daher werden einige Anfragen vorübergehend gedrosselt."
+msgstr "Ihre Organisation erzeugt API-Anfragen schneller als gewöhnlich, daher werden einige Anfragen vorübergehend gedrosselt."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "Your organisation is generating documents faster than normal, so some requests are being temporarily throttled."
-msgstr "Deine Organisation erzeugt Dokumente schneller als gewöhnlich, daher werden einige Anfragen vorübergehend gedrosselt."
+msgstr "Ihre Organisation erzeugt Dokumente schneller als gewöhnlich, daher werden einige Anfragen vorübergehend gedrosselt."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "Your organisation is generating emails faster than normal, so some requests are being temporarily throttled."
-msgstr "Deine Organisation erzeugt E-Mails schneller als gewöhnlich, daher werden einige Anfragen vorübergehend gedrosselt."
+msgstr "Ihre Organisation erzeugt E-Mails schneller als gewöhnlich, daher werden einige Anfragen vorübergehend gedrosselt."
 
 #: packages/email/templates/organisation-limit-alert.tsx
 msgid "Your organisation is nearing its fair use limits for creating documents on your current plan. Once the limit is reached, new document activity will be temporarily paused."
@@ -15005,7 +15005,7 @@ msgstr "Ihr Passwort wurde erfolgreich aktualisiert."
 
 #: packages/email/template-components/template-reset-password.tsx
 msgid "Your password has been updated."
-msgstr "Dein Passwort wurde aktualisiert."
+msgstr "Ihr Passwort wurde aktualisiert."
 
 #: apps/remix/app/components/general/organisations/organisation-billing-banner.tsx
 msgid "Your payment is overdue. Please settle the payment to avoid any service disruptions."


### PR DESCRIPTION
## Description

Switches the German **customer-facing** texts — email templates, the signing page and the transactional mails around them — from informal "du" to formal "Sie". 57 strings in `packages/lib/translations/de/web.po`, nothing else touched.

### Why this matters

German distinguishes formal and informal address, and business correspondence is formal. Today the two are mixed inside a single email: the template says *"{inviterName} hat **dich** eingeladen"* while the sender's own subject and message, passed through `meta.subject` / `meta.message`, address the recipient with *"Sie"*. The result reads to a German customer roughly like an invoice that switches between "Dear Mr. Smith" and "hey buddy" mid-sentence.

This is not configurable — there is no `de-formal` locale, no environment variable, no team setting — so the only place to fix it is the translation file.

### Also fixed: broken infinitive in the invitation

The invitation line inserts the action verb via a placeholder:

```
msgid  "{inviterName} on behalf of \"{teamName}\" has invited you to {0}<0/>\"{documentName}\""
msgstr "{inviterName} im Namen von \"{teamName}\" hat dich eingeladen, {0}<0/>\"{documentName}\""
```

German requires the infinitive marker *zu* in this construction. With `{0}` = "unterschreiben" the current translation renders as *"hat dich eingeladen, unterschreiben"*, which is ungrammatical — comparable to "has invited you sign". Reordering the placeholders fixes it:

```
msgstr "{inviterName} im Namen von \"{teamName}\" hat Sie eingeladen,<0/>\"{documentName}\" zu {0}"
```

→ *"… hat Sie eingeladen, „Angebot 2026-0815" zu unterschreiben"*

### Scope

Deliberately limited to what a **recipient** sees:

- `packages/email/**` — all templates and template components
- `packages/lib/jobs/definitions/emails/**` — subjects and preview lines
- signing pages and the confirmation/reset mails

The admin interface keeps informal address. Inside a team that is a matter of taste; in a document sent to a customer it is a defect.

### Relation to #2827

@flowq-C proposed the same direction in #2827 back in May, and credit for spotting it goes there. That PR covers 24 strings and is blocked on the CLA, with the stale bot scheduled to close it. This one signs the CLA, extends the change to all 57 customer-facing strings — notably the invitation family, which #2827 does not touch and which is the single most visible one — and keeps the footer wording change from #2827 ("versendet" → "verarbeitet"), which is more accurate for self-hosted instances where documents never leave the server.

### Verification

Checked with hunspell and LanguageTool (`de-DE`); remaining hits are placeholder artefacts, no grammar or spelling findings. Verified against a live self-hosted instance where the mixed address showed up in production invitations.
