### PR TITLE
fix(ui): keep branding logo aspect ratio on the signing page

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
@@ -182,7 +182,7 @@ export const DocumentSigningPageViewV1 = ({
           <img
             src={`/api/branding/logo/team/${document.teamId}`}
             alt={`${document.team.name}'s Logo`}
-            className="mb-4 h-12 w-12 md:mb-2"
+            className="mb-4 h-12 w-auto max-w-[16rem] object-contain md:mb-2"
           />
         )}
         <h1


### PR DESCRIPTION
## Problem

On the signing page the custom branding logo is rendered inside a fixed 48 × 48 box with `object-fit: fill`, so any non-square logo is squashed:

```tsx
// apps/remix/app/components/general/document-signing/document-signing-page-view-v1.tsx
<img
  src={`/api/branding/logo/team/${document.teamId}`}
  alt={`${document.team.name}'s Logo`}
  className="mb-4 h-12 w-12 md:mb-2"   // ← fixed width next to fixed height
/>
```

Measured on a self-hosted instance with a wordmark logo:

| | aspect ratio |
|---|---|
| uploaded file (512 × 108) | 4.74 : 1 |
| rendered on the signing page (48 × 48) | 1.00 : 1 |

The result is a logo compressed to roughly a fifth of its width — the first thing a signer sees, right above the document title.

This does not show up with a square logo, which is presumably why it went unnoticed: Documenso's own mark is square. It affects every organisation whose logo is a wordmark, which is most of them.

## Consistency

The email templates already do it correctly — `TemplateBrandingLogo` uses `className = 'mb-4 h-6'`, height only, so the logo keeps its proportions. The branding settings page renders the same image with `object-contain`. Only the signing page pins both dimensions.

## Fix

```diff
-className="mb-4 h-12 w-12 md:mb-2"
+className="mb-4 h-12 w-auto max-w-[16rem] object-contain md:mb-2"
```

Height stays at 3rem, width follows the aspect ratio, and `max-w-[16rem]` keeps an extremely wide logo from pushing into the layout. Square logos are unaffected — they still render 48 × 48.
