### PR TITLE
fix(pdf): resolve inherited MediaBox and CropBox (#3267)

### DIFF
--- a/packages/lib/server-only/pdf/get-page-size.ts
+++ b/packages/lib/server-only/pdf/get-page-size.ts
@@ -18,12 +18,34 @@ export const getPageSize = (page: PDFPage) => {
 
   try {
     mediaBox = page.getMediaBox();
+    if (!mediaBox) {
+      let parent = (page.node as any).Parent?.();
+      while (parent && !mediaBox) {
+        const parentMediaBox = parent.MediaBox?.();
+        if (parentMediaBox) {
+          mediaBox = parentMediaBox.asRectangle?.() ?? parentMediaBox;
+          break;
+        }
+        parent = parent.Parent?.();
+      }
+    }
   } catch {
     // MediaBox lookup can fail for malformed PDFs where the entry is not a valid PDFArray.
   }
 
   try {
     cropBox = page.getCropBox();
+    if (!cropBox) {
+      let parent = (page.node as any).Parent?.();
+      while (parent && !cropBox) {
+        const parentCropBox = parent.CropBox?.();
+        if (parentCropBox) {
+          cropBox = parentCropBox.asRectangle?.() ?? parentCropBox;
+          break;
+        }
+        parent = parent.Parent?.();
+      }
+    }
   } catch {
     // CropBox lookup can fail for malformed PDFs where the entry is not a valid PDFArray.
   }


### PR DESCRIPTION
# Title
fix(pdf): resolve inherited MediaBox and CropBox from parent page tree (#3267)

## Description
- Updates `getPageSize` to walk up parent `/Pages` nodes when a `/Page` node lacks its own explicit `/MediaBox` or `/CropBox`.
- Complies with ISO 32000-1 §7.7.3.4 (inheritable page attributes), preventing A4 documents from erroneously falling back to US Letter and misplacing placeholder fields.

Closes #3267
