### PR TITLE
fix(emails): remove trailing period from pending document email subject (#3212)

### DIFF
--- a/packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts
+++ b/packages/lib/jobs/definitions/emails/send-document-pending-email.handler.ts
@@ -93,7 +93,7 @@ export const run = async ({ payload }: { payload: TSendDocumentPendingEmailJobDe
     },
     from: senderEmail,
     replyTo: replyToEmail,
-    subject: i18n._(msg`Waiting for others to complete signing.`),
+    subject: i18n._(msg`Waiting for others to complete signing`),
     html,
     text,
   });


### PR DESCRIPTION
# Title
fix(emails): remove trailing period from pending document email subject (#3212)

## Description
- Removes trailing period from subject string `Waiting for others to complete signing.` in `send-document-pending-email.handler.ts`.
- Ensures consistency with email subject lines and notification typography guidelines across Documenso.

Closes #3212
