### PR TITLE
fix(fields): resolve inherited /MediaBox for placeholder coordinates

### DIFF
--- a/packages/lib/server-only/field/create-envelope-fields.ts
+++ b/packages/lib/server-only/field/create-envelope-fields.ts
@@ -15,6 +15,11 @@ import { canRecipientFieldsBeModified } from '../../utils/recipients';
 import { assertEnvelopeMutable } from '../envelope/assert-envelope-mutable';
 import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
 import { type BoundingBox, whiteoutRegions } from '../pdf/auto-place-fields';
+import {
+  mapBoundingBoxToFieldPosition,
+  pickPageSize,
+  resolveEffectivePageSizes,
+} from './placeholder-page-size';
 
 type CoordinatePosition = {
   page: number;
@@ -119,6 +124,10 @@ export const createEnvelopeFields = async ({
     over resolved placeholders before saving back.
   */
   const pdfCache = new Map<string, PDF>();
+  // Inheritance-resolved page sizes (see resolveEffectivePageSizes): the
+  // percentage math below divides by the size the viewer shows, not the
+  // US-Letter fallback a /Pages-declared MediaBox reads as (#3267).
+  const pageSizeCache = new Map<string, Awaited<ReturnType<typeof resolveEffectivePageSizes>>>();
 
   if (hasPlaceholderFields) {
     for (const item of envelope.envelopeItems) {
@@ -126,6 +135,13 @@ export const createEnvelopeFields = async ({
       const pdfDoc = await PDF.load(new Uint8Array(bytes));
 
       pdfCache.set(item.id, pdfDoc);
+
+      try {
+        pageSizeCache.set(item.id, await resolveEffectivePageSizes(new Uint8Array(bytes)));
+      } catch {
+        // Size resolution is advisory: a PDF pdf-lib cannot parse for sizing
+        // keeps @libpdf/core's page dimensions, the pre-fix behavior.
+      }
     }
   }
 
@@ -189,9 +205,14 @@ export const createEnvelopeFields = async ({
 
       const matchesToProcess = field.matchAll ? matches : [matches[0]];
       const pages = pdfDoc.getPages();
+      const effectiveSizes = pageSizeCache.get(envelopeItemId);
 
       return matchesToProcess.map((match) => {
         const page = pages[match.pageIndex];
+        const pageSize = pickPageSize(effectiveSizes?.[match.pageIndex], {
+          width: page.width,
+          height: page.height,
+        });
 
         /*
           Record this placeholder's bounding box for whiteout. The bbox is in
@@ -210,10 +231,11 @@ export const createEnvelopeFields = async ({
           Convert point-based coordinates (bottom-left origin) to percentage-based
           coordinates (top-left origin) matching the system's field coordinate format.
         */
-        const topLeftY = page.height - match.bbox.y - match.bbox.height;
-
-        const widthPercent = field.width ?? (match.bbox.width / page.width) * 100;
-        const heightPercent = field.height ?? (match.bbox.height / page.height) * 100;
+        const { positionX, positionY, width, height } = mapBoundingBoxToFieldPosition(
+          match.bbox,
+          pageSize,
+          { width: field.width, height: field.height },
+        );
 
         return {
           type: field.type,
@@ -222,10 +244,10 @@ export const createEnvelopeFields = async ({
           envelopeItemId,
           recipientEmail: recipient.email,
           page: match.pageIndex + 1,
-          positionX: (match.bbox.x / page.width) * 100,
-          positionY: (topLeftY / page.height) * 100,
-          width: widthPercent,
-          height: heightPercent,
+          positionX,
+          positionY,
+          width,
+          height,
         };
       });
     }

--- a/packages/lib/server-only/field/placeholder-page-size.test.ts
+++ b/packages/lib/server-only/field/placeholder-page-size.test.ts
@@ -1,0 +1,108 @@
+import { PDFDocument, PDFName } from '@cantoo/pdf-lib';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapBoundingBoxToFieldPosition,
+  pickPageSize,
+  resolveEffectivePageSizes,
+} from './placeholder-page-size';
+
+/**
+ * Build a single-page PDF whose MediaBox lives ONLY on the /Pages node —
+ * the inherited-MediaBox shape fpdf2 emits by default for same-size pages,
+ * and the exact document class that mis-sized placeholder fields (#3267).
+ */
+async function inheritedMediaBoxPdf(width: number, height: number): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  doc.addPage([width, height]);
+
+  // pdf-lib writes the MediaBox onto each page; move it up to the parent
+  // /Pages node so the page inherits it, per PDF 32000-1:2008 §7.7.3.4.
+  const page = doc.getPage(0);
+  const pagesNode = page.node.Parent();
+  if (!pagesNode) throw new Error('fixture: page has no /Parent');
+  pagesNode.set(
+    PDFName.of('MediaBox'),
+    doc.context.obj([0, 0, width, height]),
+  );
+  page.node.delete(PDFName.of('MediaBox'));
+
+  return doc.save();
+}
+
+async function explicitMediaBoxPdf(width: number, height: number): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  doc.addPage([width, height]);
+  return doc.save();
+}
+
+const A4 = { width: 595.28, height: 841.89 };
+
+describe('resolveEffectivePageSizes', () => {
+  it('resolves a MediaBox declared only on the /Pages node (A4, not US Letter)', async () => {
+    const sizes = await resolveEffectivePageSizes(await inheritedMediaBoxPdf(A4.width, A4.height));
+
+    expect(sizes).toHaveLength(1);
+    expect(sizes[0]!.width).toBeCloseTo(A4.width, 2);
+    expect(sizes[0]!.height).toBeCloseTo(A4.height, 2);
+  });
+
+  it('resolves an explicit per-page MediaBox identically', async () => {
+    const sizes = await resolveEffectivePageSizes(await explicitMediaBoxPdf(A4.width, A4.height));
+
+    expect(sizes[0]!.width).toBeCloseTo(A4.width, 2);
+    expect(sizes[0]!.height).toBeCloseTo(A4.height, 2);
+  });
+});
+
+describe('mapBoundingBoxToFieldPosition', () => {
+  // A placeholder at 16mm on 210mm-wide A4 sits at 16/210 = 7.619% from the
+  // left. With the US-Letter fallback (215.9mm) the same point computes as
+  // 16/215.9 = 7.411% — the 0.97267 stretch ratio from the issue.
+  it('maps coordinates against the A4 size, not the Letter fallback', () => {
+    const bbox = { x: 45.35, y: 790, width: 100, height: 20 }; // 16mm ≈ 45.35pt
+    const position = mapBoundingBoxToFieldPosition(bbox, A4);
+
+    expect(position.positionX).toBeCloseTo((45.35 / 595.28) * 100, 3);
+  });
+
+  it('keeps the historical math for explicit sizes (regression guard)', () => {
+    const bbox = { x: 100, y: 700, width: 120, height: 40 };
+    const position = mapBoundingBoxToFieldPosition(bbox, { width: 612, height: 792 });
+
+    expect(position.positionX).toBeCloseTo((100 / 612) * 100, 3);
+    expect(position.positionY).toBeCloseTo(((792 - 700 - 40) / 792) * 100, 3);
+    expect(position.width).toBeCloseTo((120 / 612) * 100, 3);
+    expect(position.height).toBeCloseTo((40 / 792) * 100, 3);
+  });
+
+  it('honors explicit field width/height over bbox-derived percentages', () => {
+    const position = mapBoundingBoxToFieldPosition(
+      { x: 0, y: 0, width: 50, height: 10 },
+      A4,
+      { width: 15, height: 5 },
+    );
+
+    expect(position.width).toBe(15);
+    expect(position.height).toBe(5);
+  });
+});
+
+describe('pickPageSize', () => {
+  it('prefers the resolved size when it differs (the inherited case)', () => {
+    const picked = pickPageSize(A4, { width: 612, height: 792 });
+    expect(picked).toBe(A4);
+  });
+
+  it('keeps the text-layer size when they agree (rotation semantics intact)', () => {
+    const libpdf = { width: 792, height: 612 }; // rotated page: swapped
+    const picked = pickPageSize({ width: 792, height: 612 }, libpdf);
+    expect(picked).toBe(libpdf);
+  });
+
+  it('falls back to the text-layer size when resolution has no entry', () => {
+    const libpdf = { width: 612, height: 792 };
+    expect(pickPageSize(undefined, libpdf)).toBe(libpdf);
+  });
+});

--- a/packages/lib/server-only/field/placeholder-page-size.ts
+++ b/packages/lib/server-only/field/placeholder-page-size.ts
@@ -1,0 +1,79 @@
+import { PDFDocument } from '@cantoo/pdf-lib';
+
+import { getPageSize } from '../pdf/get-page-size';
+
+export type EffectivePageSize = { width: number; height: number };
+
+/**
+ * Resolve each page's effective size with PDF-spec MediaBox inheritance.
+ *
+ * `@libpdf/core`'s page width/height reads the page's own `MediaBox` entry
+ * only: a `MediaBox` declared on the `/Pages` node — legal per PDF
+ * 32000-1:2008 §7.7.3.4 and what fpdf2 emits by default for same-size pages —
+ * reads as missing and falls back to US Letter, stretching every
+ * placeholder-derived coordinate by the Letter/A4 ratio and silently dropping
+ * fields that land outside the assumed page (#3267). pdf-lib's lookup walks
+ * `/Parent`, so sizes resolved here are the ones the viewer shows.
+ *
+ * @param bytes The PDF bytes to resolve sizes for.
+ * @returns Effective `{ width, height }` per page, in points.
+ */
+export async function resolveEffectivePageSizes(bytes: Uint8Array): Promise<EffectivePageSize[]> {
+  const doc = await PDFDocument.load(bytes, { ignoreEncryption: true });
+  return doc.getPages().map((page) => {
+    const box = getPageSize(page);
+    return { width: box.width, height: box.height };
+  });
+}
+
+/**
+ * Map a text-search bounding box to percentage-based field coordinates.
+ *
+ * Pure so the Letter/A4 regression (#3267) is unit-testable without the
+ * envelope/prisma harness: the caller supplies the effective page size
+ * (see {@link resolveEffectivePageSizes}), and this does the point →
+ * percent math exactly as the placeholder flow always has.
+ *
+ * @param bbox The match's bounding box in PDF points (bottom-left origin).
+ * @param pageSize The effective page size in points.
+ * @param fieldSize Optional explicit width/height percentages; when absent
+ * they derive from the bounding box.
+ * @returns Percentage coordinates in the system's top-left-origin format.
+ */
+export function mapBoundingBoxToFieldPosition(
+  bbox: { x: number; y: number; width: number; height: number },
+  pageSize: EffectivePageSize,
+  fieldSize?: { width?: number; height?: number },
+): { positionX: number; positionY: number; width: number; height: number } {
+  const topLeftY = pageSize.height - bbox.y - bbox.height;
+
+  return {
+    positionX: (bbox.x / pageSize.width) * 100,
+    positionY: (topLeftY / pageSize.height) * 100,
+    width: fieldSize?.width ?? (bbox.width / pageSize.width) * 100,
+    height: fieldSize?.height ?? (bbox.height / pageSize.height) * 100,
+  };
+}
+
+/**
+ * Pick the page size a placeholder coordinate mapping should use.
+ *
+ * Prefers the inheritance-resolved size but keeps `@libpdf/core`'s
+ * (rotation-aware) value whenever the two agree, so rotated pages and
+ * explicit-MediaBox documents take exactly their current path.
+ *
+ * @param resolved Inheritance-resolved size (may be missing for a page the
+ * resolver could not load).
+ * @param libpdfSize The text layer's own page width/height.
+ * @returns The size to divide coordinates by.
+ */
+export function pickPageSize(
+  resolved: EffectivePageSize | undefined,
+  libpdfSize: EffectivePageSize,
+): EffectivePageSize {
+  if (resolved === undefined) return libpdfSize;
+  if (resolved.width === libpdfSize.width && resolved.height === libpdfSize.height) {
+    return libpdfSize;
+  }
+  return resolved;
+}


### PR DESCRIPTION
Fixes #3267.

## Root cause — verified down to the library line

The placeholder flow divides match coordinates by `@libpdf/core`'s `page.width`/`page.height`. In `@libpdf/core`'s `pdf-page.ts`, `getBox()` reads **the page's own dictionary entry only** — the inheritance its `getMediaBox()` docstring promises ("accounting for inheritance from parent pages") is not implemented — and a missing MediaBox returns the **US Letter default** (`{ 612, 792 }`). So a MediaBox declared only on the `/Pages` node (legal per PDF 32000-1:2008 §7.7.3.4; fpdf2's default for same-size pages) silently measures every page as Letter:

```
x: 210/215.9 = 0.97267  ← the issue's measured 0.97250…0.97321
y: 297/279.4 = 1.06299  ← the issue's measured 1.06292
```

I reproduced that ratio exactly from the math before touching any code.

## Fix

Resolve the effective page size through **pdf-lib**, whose MediaBox lookup walks `/Parent` (verified in `@cantoo/pdf-lib`'s `PDFPageLeaf.MediaBox()` → `getInheritableAttribute`):

- `resolveEffectivePageSizes(bytes)` — one pdf-lib parse per envelope item, mapping each page through the existing `getPageSize` helper (CropBox/MediaBox semantics preserved).
- `pickPageSize(resolved, libpdfSize)` — prefer the resolved size **only when it differs** from the text layer's own value, so rotated pages (where `@libpdf/core` swaps width/height) and explicit-MediaBox documents keep exactly their current path.
- `mapBoundingBoxToFieldPosition(bbox, pageSize, fieldSize)` — the point→percent math moved unchanged into a pure function, making the A4/Letter regression unit-testable without the envelope/prisma harness.
- Resolution is advisory: a PDF pdf-lib can't parse for sizing falls back to the text-layer dimensions (pre-fix behavior) rather than failing the field creation.

## Tests (`placeholder-page-size.test.ts`)

- **Inherited-MediaBox fixture built in-test**: a pdf-lib page whose MediaBox is moved up to the `/Pages` node (deleting the per-page entry) — resolves as A4, not Letter. **This is the document class from the issue.**
- Explicit per-page MediaBox resolves identically (no behavior change for the common case).
- `mapBoundingBoxToFieldPosition`: 16mm on A4 → 7.619% (the issue's expected value); a Letter regression guard pins the historical math; explicit field width/height overrides bbox-derived percentages.
- `pickPageSize`: prefers the resolved size on mismatch, keeps the text-layer size on agreement (rotation) and on missing resolution.

(The silent field-drop side effect — placeholders pushed past 279.4mm by the stretch — disappears with the size fix: A4 coordinates no longer exceed the A4 page.)

Upstream note: the inheritance walk belongs in `@libpdf/core`'s `getBox()`; this PR is the defensive fix for documents already in the wild and can slim down once the upstream lands.