### PR TITLE
fix(lib): resolve inherited MediaBox and CropBox page dimensions

### DIFF
--- a/packages/lib/server-only/pdf/get-page-size.test.ts
+++ b/packages/lib/server-only/pdf/get-page-size.test.ts
@@ -1,0 +1,88 @@
+﻿import { describe, expect, it } from 'vitest';
+import { PDF_SIZE_A4_72PPI } from '../../constants/pdf';
+import { getPageSize, getLastPageDimensions } from './get-page-size';
+
+describe('getPageSize', () => {
+  it('returns page MediaBox when present on page object', () => {
+    const mockPage = {
+      getMediaBox: () => ({ x: 0, y: 0, width: 595.28, height: 841.89 }),
+      getCropBox: () => undefined,
+      node: {},
+    } as any;
+
+    const size = getPageSize(mockPage);
+    expect(size.width).toBeCloseTo(595.28);
+    expect(size.height).toBeCloseTo(841.89);
+  });
+
+  it('resolves inherited MediaBox from parent /Pages node when absent on page', () => {
+    const mockPage = {
+      getMediaBox: () => {
+        throw new Error('No direct media box');
+      },
+      getCropBox: () => undefined,
+      node: {
+        MediaBox: () => undefined,
+        Parent: () => ({
+          MediaBox: () => ({
+            asArray: () => [
+              { asNumber: () => 0 },
+              { asNumber: () => 0 },
+              { asNumber: () => 595.28 },
+              { asNumber: () => 841.89 },
+            ],
+          }),
+        }),
+      },
+    } as any;
+
+    const size = getPageSize(mockPage);
+    expect(size.width).toBeCloseTo(595.28);
+    expect(size.height).toBeCloseTo(841.89);
+  });
+
+  it('uses CropBox when smaller than MediaBox', () => {
+    const mockPage = {
+      getMediaBox: () => ({ x: 0, y: 0, width: 600, height: 800 }),
+      getCropBox: () => ({ x: 10, y: 10, width: 500, height: 700 }),
+      node: {},
+    } as any;
+
+    const size = getPageSize(mockPage);
+    expect(size.width).toBe(500);
+    expect(size.height).toBe(700);
+  });
+
+  it('falls back to A4 when both MediaBox and CropBox are missing', () => {
+    const mockPage = {
+      getMediaBox: () => undefined,
+      getCropBox: () => undefined,
+      node: {},
+    } as any;
+
+    const size = getPageSize(mockPage);
+    expect(size).toEqual(PDF_SIZE_A4_72PPI);
+  });
+});
+
+describe('getLastPageDimensions', () => {
+  it('returns last page dimensions when valid', () => {
+    const mockPdf = {
+      getPageCount: () => 2,
+      getPage: (index: number) => ({ width: 595.28, height: 841.89 }),
+    } as any;
+
+    const dims = getLastPageDimensions(mockPdf);
+    expect(dims).toEqual({ width: 595, height: 842 });
+  });
+
+  it('falls back to A4 when page dimensions are below minimum threshold', () => {
+    const mockPdf = {
+      getPageCount: () => 1,
+      getPage: () => ({ width: 100, height: 100 }),
+    } as any;
+
+    const dims = getLastPageDimensions(mockPdf);
+    expect(dims).toEqual(PDF_SIZE_A4_72PPI);
+  });
+});

--- a/packages/lib/server-only/pdf/get-page-size.ts
+++ b/packages/lib/server-only/pdf/get-page-size.ts
@@ -7,25 +7,104 @@ const MIN_CERT_PAGE_WIDTH = 300;
 const MIN_CERT_PAGE_HEIGHT = 300;
 
 /**
+ * Extracts normalized bounding box dimensions from a PDFArray or rectangle.
+ */
+const extractBoxDimensions = (box?: any): { x: number; y: number; width: number; height: number } | undefined => {
+  if (!box) {
+    return undefined;
+  }
+
+  if (typeof box.width === 'number' && typeof box.height === 'number') {
+    return {
+      x: box.x ?? 0,
+      y: box.y ?? 0,
+      width: box.width,
+      height: box.height,
+    };
+  }
+
+  if (typeof box.asArray === 'function') {
+    const arr = box.asArray();
+    if (arr.length >= 4) {
+      const [x1, y1, x2, y2] = arr.map((n: any) =>
+        typeof n.asNumber === 'function' ? n.asNumber() : Number(n),
+      );
+      return {
+        x: Math.min(x1, x2),
+        y: Math.min(y1, y2),
+        width: Math.abs(x2 - x1),
+        height: Math.abs(y2 - y1),
+      };
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Resolves inherited page attributes by walking up the /Pages node tree (PDF 32000-1:2008 §7.7.3.4).
+ */
+const getInheritedBox = (
+  page: PDFPage,
+  boxName: 'MediaBox' | 'CropBox',
+): { x: number; y: number; width: number; height: number } | undefined => {
+  try {
+    let currentNode: any = page.node;
+    while (currentNode) {
+      if (typeof currentNode[boxName] === 'function') {
+        const box = currentNode[boxName]();
+        const dimensions = extractBoxDimensions(box);
+        if (dimensions) {
+          return dimensions;
+        }
+      }
+
+      if (typeof currentNode.lookup === 'function') {
+        const box = currentNode.lookup(boxName);
+        const dimensions = extractBoxDimensions(box);
+        if (dimensions) {
+          return dimensions;
+        }
+      }
+
+      currentNode = typeof currentNode.Parent === 'function' ? currentNode.Parent() : currentNode.parent;
+    }
+  } catch {
+    // Ignore resolution errors on malformed trees.
+  }
+
+  return undefined;
+};
+
+/**
  * Gets the effective page size for PDF operations.
  *
  * Uses CropBox by default to handle rare cases where MediaBox is larger than CropBox.
  * Falls back to MediaBox when it's smaller than CropBox, following typical PDF reader behavior.
+ * Resolves inherited MediaBox/CropBox from parent /Pages nodes when not defined directly on the page.
  */
 export const getPageSize = (page: PDFPage) => {
   let mediaBox;
   let cropBox;
 
   try {
-    mediaBox = page.getMediaBox();
+    mediaBox = extractBoxDimensions(page.getMediaBox());
   } catch {
     // MediaBox lookup can fail for malformed PDFs where the entry is not a valid PDFArray.
   }
 
+  if (!mediaBox) {
+    mediaBox = getInheritedBox(page, 'MediaBox');
+  }
+
   try {
-    cropBox = page.getCropBox();
+    cropBox = extractBoxDimensions(page.getCropBox());
   } catch {
     // CropBox lookup can fail for malformed PDFs where the entry is not a valid PDFArray.
+  }
+
+  if (!cropBox) {
+    cropBox = getInheritedBox(page, 'CropBox');
   }
 
   if (mediaBox && cropBox) {


### PR DESCRIPTION
## Description

Fixes #3267

Resolves inherited \/MediaBox\ and \/CropBox\ attributes by traversing up the \/Pages\ node tree per PDF 32000-1:2008 §7.7.3.4 when attributes are omitted on individual \/Page\ dictionaries.

### Changes
- Added \getInheritedBox\ in \packages/lib/server-only/pdf/get-page-size.ts\ to walk parent \/Pages\ nodes.
- Added \extractBoxDimensions\ to normalize \PDFArray\ and rectangle dimensions.
- Added unit tests in \packages/lib/server-only/pdf/get-page-size.test.ts\ verifying direct, inherited, and fallback page dimension behaviors.