### PR TITLE
fix(web): autofocus text/number field inputs when their dialog opens

### DIFF
--- a/apps/remix/app/components/dialogs/sign-field-text-dialog.tsx
+++ b/apps/remix/app/components/dialogs/sign-field-text-dialog.tsx
@@ -60,6 +60,8 @@ export const SignFieldTextDialog = createCallable<SignFieldTextDialogProps, stri
                     <FormControl>
                       <Textarea
                         id="custom-text"
+                        // Focus on open — the v2 flow shares the v1 friction (#3280).
+                        autoFocus
                         placeholder={fieldMeta?.placeholder ?? t`Enter your text here`}
                         className={cn('w-full rounded-md', {
                           'border-2 border-red-300 text-left ring-2 ring-red-200 ring-offset-2 ring-offset-red-200 focus-visible:border-red-400 focus-visible:ring-4 focus-visible:ring-red-200 focus-visible:ring-offset-2 focus-visible:ring-offset-red-200':

--- a/apps/remix/app/components/general/document-signing/document-signing-number-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-number-field.tsx
@@ -251,6 +251,8 @@ export const DocumentSigningNumberField = ({ field, onSignField, onUnsignField }
           <div>
             <Input
               type="text"
+              // Same friction as the text field: focus on open (#3280).
+              autoFocus
               placeholder={parsedFieldMeta?.placeholder ?? ''}
               className={cn('mt-2 w-full rounded-md', {
                 'border-2 border-red-300 ring-2 ring-red-200 ring-offset-2 ring-offset-red-200 focus-visible:border-red-400 focus-visible:ring-4 focus-visible:ring-red-200 focus-visible:ring-offset-2 focus-visible:ring-offset-red-200':

--- a/apps/remix/app/components/general/document-signing/document-signing-text-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-text-field.tsx
@@ -246,6 +246,10 @@ export const DocumentSigningTextField = ({ field, onSignField, onUnsignField }: 
           <div>
             <Textarea
               id="custom-text"
+              // Focus the input the moment the dialog opens: on documents with
+              // many fields, making the signer click into the textarea before
+              // typing is pure friction (#3280).
+              autoFocus
               placeholder={parsedFieldMeta?.placeholder ?? _(msg`Enter your text here`)}
               className={cn('mt-2 w-full rounded-md', {
                 'border-2 border-red-300 text-left ring-2 ring-red-200 ring-offset-2 ring-offset-red-200 focus-visible:border-red-400 focus-visible:ring-4 focus-visible:ring-red-200 focus-visible:ring-offset-2 focus-visible:ring-offset-red-200':


### PR DESCRIPTION
Fixes #3280.

## The friction

Clicking a document text field opens the value dialog with the textarea **unfocused** — the signer clicks the field, then must click *into* the input before typing. On documents with many fields that double-click tax is exactly the novice-user slowdown the issue reports (the screenshots show the empty textarea sitting unfocused after open).

## The fix

`autoFocus` on the dialog input, in the three places a text-like value dialog opens:

- `document-signing-text-field.tsx` — the v1 text field dialog's `Textarea` (the issue's exact repro);
- `document-signing-number-field.tsx` — the number field's dialog `Input`, identical shape and identical friction;
- `sign-field-text-dialog.tsx` — the shared dialog the v2 signing flow uses.

The codebase already uses this pattern where a dialog's whole purpose is receiving a typed value (the 2FA code input, the envelope-rename dialog); these three were simply missing it.

Deliberately untouched: the **dropdown** field's select trigger is focused on open by Radix, and the **email** field prefills and signs without opening an input dialog — no other field type opens a value-input dialog.

Typed on the `Textarea`/`Input` primitives directly (both forward `autoFocus` to the underlying element as a standard HTML attribute — no primitive changes needed).