### PR TITLE
fix(envelope): flip the envelope to REJECTED in the rejection transaction

### DIFF
--- a/packages/lib/server-only/document/reject-document-on-behalf-of.test.ts
+++ b/packages/lib/server-only/document/reject-document-on-behalf-of.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The rejection handlers must write `Envelope.status = REJECTED` inside the
+ * SAME `$transaction` that flips the recipient — previously only the async
+ * seal job wrote it, so a 200 from the reject endpoint left the envelope
+ * PENDING and the PENDING-keyed guards kept letting other recipients act
+ * (#3287).
+ *
+ * These are source-contract tests: the transaction composition is what the
+ * fix is, and it is directly inspectable in the handler source (the module
+ * needs a generated prisma client to import, which unit CI doesn't have).
+ */
+describe('rejection writes the envelope status in the same transaction (#3287)', () => {
+  const read = (p: string) =>
+    readFileSync(resolve(__dirname, p), 'utf-8');
+
+  it('the behalf-of path includes an envelope.update to REJECTED in the transaction', () => {
+    const src = read('./reject-document-on-behalf-of.ts');
+    const tx = src.slice(src.indexOf('$transaction'), src.indexOf(']);', src.indexOf('$transaction')));
+    expect(tx).toContain('prisma.envelope.update');
+    expect(tx).toContain('status: DocumentStatus.REJECTED');
+    // The envelope flip precedes the recipient flip (same transaction; order
+    // is not semantic but keeps the diff readable).
+    expect(tx.indexOf('prisma.envelope.update')).toBeLessThan(tx.indexOf('prisma.recipient.update'));
+  });
+
+  it('the recipient-token path includes the same flip', () => {
+    const src = read('./reject-document-with-token.ts');
+    const tx = src.slice(src.indexOf('$transaction'), src.indexOf(']);', src.indexOf('$transaction')));
+    expect(tx).toContain('prisma.envelope.update');
+    expect(tx).toContain('status: DocumentStatus.REJECTED');
+  });
+
+  it('the seal job remains the stamped-PDF producer (idempotent status write)', () => {
+    const src = read('../../jobs/definitions/internal/seal-document.handler.ts');
+    expect(src).toContain('finalEnvelopeStatus');
+    expect(src).toContain('DocumentStatus.REJECTED');
+  });
+});

--- a/packages/lib/server-only/document/reject-document-on-behalf-of.ts
+++ b/packages/lib/server-only/document/reject-document-on-behalf-of.ts
@@ -113,6 +113,25 @@ export async function rejectDocumentOnBehalfOf({
   // Update the recipient status to rejected and record an external rejection
   // audit log within the same transaction.
   const [updatedRecipient] = await prisma.$transaction([
+    // Flip the envelope to REJECTED in the SAME transaction as the recipient
+    // row. The status was previously written only by the async seal job —
+    // after the whole PDF pipeline — so a 200 from this endpoint left the
+    // envelope PENDING, and every `status === PENDING` guard
+    // (sign-field-with-token, complete-document-with-token) kept letting the
+    // OTHER recipients act on a document the product had already cancelled
+    // (the cancellation emails are queued by this very request). When the
+    // seal job fails — and it demonstrably does — the window never closed.
+    // The seal job's own status write is idempotent (it writes REJECTED
+    // again) and the stamped PDF/certificate reflect the rejection either
+    // way (#3287).
+    prisma.envelope.update({
+      where: {
+        id: envelope.id,
+      },
+      data: {
+        status: DocumentStatus.REJECTED,
+      },
+    }),
     prisma.recipient.update({
       where: {
         id: recipient.id,

--- a/packages/lib/server-only/document/reject-document-with-token.ts
+++ b/packages/lib/server-only/document/reject-document-with-token.ts
@@ -55,6 +55,17 @@ export async function rejectDocumentWithToken({ token, id, reason, requestMetada
 
   // Update the recipient status to rejected
   const [updatedRecipient] = await prisma.$transaction([
+    // Same-transaction envelope flip as the API path: the document is
+    // Rejected the moment the rejection lands, and the PENDING-keyed
+    // guards close immediately (#3287).
+    prisma.envelope.update({
+      where: {
+        id: envelope.id,
+      },
+      data: {
+        status: DocumentStatus.REJECTED,
+      },
+    }),
     prisma.recipient.update({
       where: {
         id: recipient.id,


### PR DESCRIPTION
Fixes #3287 — the issue's "Fix shape" implemented: the status flip moves into the rejection's own transaction; the seal job keeps only the PDF work.

## Root cause (as diagnosed, verified)

`rejectDocumentOnBehalfOf` commits exactly two rows — the recipient (`signedAt`, `REJECTED`, `rejectionReason`) and a `DOCUMENT_RECIPIENT_REJECTED` audit log — then fires three jobs and returns. **`Envelope.status` is never touched.** The only production writer of `DocumentStatus.REJECTED` is the `internal.seal-document` job, after loading every envelope item's PDF, stamping the rejection, generating the certificate and audit-log PDFs, signing and uploading — and the local job provider dispatches it un-awaited against a 150ms timeout. Consequences, exactly as the issue lays out:

1. **Stale read**: the very next `GET /api/v2/envelope/{id}` after a 200 still says `"status": "PENDING"`.
2. **Open action window**: every `status === PENDING` guard (`sign-field-with-token`, `complete-document-with-token`, further rejections) keeps admitting the OTHER recipients — on a document the product has already cancelled, since `send.document.cancelled.emails` is queued by the rejection request itself.
3. **Permanent window on seal failure**: when the seal job fails (#2921, #3092, #3191), the sweep retries only between 15min and 6h after the last recipient action and then gives up — a terminal legal state dependent on a PDF pipeline that can fail.

## The fix

Both rejection paths — the public API's `reject-document-on-behalf-of` and the recipient-token `reject-document-with-token` (the issue notes the identical shape) — now include:

```ts
prisma.envelope.update({
  where: { id: envelope.id },
  data: { status: DocumentStatus.REJECTED },
}),
```

**inside the same `$transaction`** as the recipient flip. The documented lifecycle ("the document immediately moves to Rejected; other pending recipients can no longer act; the owner is notified") becomes true at the moment the rejection lands, and the read-after-write gap closes.

The seal job is unchanged and remains the stamped-PDF/certificate producer; its own status write is idempotent (it writes `REJECTED` again — the pre-existing `finalEnvelopeStatus` computation and the documents it produces are untouched).

## Tests

Source-contract tests (`reject-document-on-behalf-of.test.ts`) pin the transaction composition of both handlers — the `prisma.envelope.update` + `status: DocumentStatus.REJECTED` pair present in the `$transaction` of each — and that the seal job still owns the stamped-PDF path. **Both handler tests fail on `main`** (no envelope write in either transaction); the seal-job contract passes on both sides (its behavior is deliberately unchanged).