### PR TITLE
fix(api): keep a field's stored fieldMeta when update-many omits it

### DIFF
--- a/packages/lib/server-only/field/update-envelope-fields.ts
+++ b/packages/lib/server-only/field/update-envelope-fields.ts
@@ -133,7 +133,11 @@ export const updateEnvelopeFields = async ({
             positionY: updateData.pageY,
             width: updateData.width,
             height: updateData.height,
-            fieldMeta: updateData.fieldMeta,
+            // undefined (omitted) leaves the stored fieldMeta untouched —
+            // the update schema no longer defaults them, and Prisma skips
+            // undefined keys in update data. Resending a complete fieldMeta
+            // still replaces it (#3286).
+            ...(updateData.fieldMeta !== undefined ? { fieldMeta: updateData.fieldMeta } : {}),
             envelopeItemId: updateData.envelopeItemId,
           },
         });

--- a/packages/lib/types/field-meta.ts
+++ b/packages/lib/types/field-meta.ts
@@ -448,3 +448,66 @@ export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
 ]);
 
 export type TEnvelopeFieldAndMeta = z.infer<typeof ZEnvelopeFieldAndMetaSchema>;
+
+/**
+ * The update counterpart of {@link ZEnvelopeFieldAndMetaSchema}: identical
+ * shape but `fieldMeta` is OPTIONAL WITH NO DEFAULT, so an update request
+ * that omits `fieldMeta` yields `undefined` instead of the create-time
+ * defaults — and the service leaves the stored configuration untouched.
+ *
+ * The create schema's defaults are correct for create; on update they made
+ * every partial `update-many` call that didn't resend the complete
+ * `fieldMeta` wipe the field's configuration to the type defaults behind a
+ * 200 (a TEXT field lost its label/placeholder/required/character limit; a
+ * RADIO's option list collapsed to one blank option). `type` is the union
+ * discriminator and mandatory, so the default was always materialised and
+ * the wipe was unavoidable from the client side (#3286).
+ */
+export const ZEnvelopeFieldUpdateAndMetaSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal(FieldType.SIGNATURE),
+    fieldMeta: ZSignatureFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.FREE_SIGNATURE),
+    fieldMeta: z.undefined(),
+  }),
+  z.object({
+    type: z.literal(FieldType.INITIALS),
+    fieldMeta: ZInitialsFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.NAME),
+    fieldMeta: ZNameFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.EMAIL),
+    fieldMeta: ZEmailFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.DATE),
+    fieldMeta: ZDateFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.TEXT),
+    fieldMeta: ZTextFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.NUMBER),
+    fieldMeta: ZNumberFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.RADIO),
+    fieldMeta: ZRadioFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.CHECKBOX),
+    fieldMeta: ZCheckboxFieldMeta.optional(),
+  }),
+  z.object({
+    type: z.literal(FieldType.DROPDOWN),
+    fieldMeta: ZDropdownFieldMeta.optional(),
+  }),
+]);
+
+export type TEnvelopeFieldUpdateAndMeta = z.infer<typeof ZEnvelopeFieldUpdateAndMetaSchema>;

--- a/packages/lib/types/field-meta.update.test.ts
+++ b/packages/lib/types/field-meta.update.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ZEnvelopeFieldAndMetaSchema,
+  ZEnvelopeFieldUpdateAndMetaSchema,
+} from '@documenso/lib/types/field-meta';
+
+describe('the update schema keeps an omitted fieldMeta undefined (#3286)', () => {
+  it('create schema still materialises the type default (create behavior unchanged)', () => {
+    const parsed = ZEnvelopeFieldAndMetaSchema.parse({ type: 'TEXT' });
+    expect(parsed.fieldMeta).toBeDefined();
+    expect(parsed.fieldMeta?.type).toBe('text');
+  });
+
+  it('update schema leaves an omitted fieldMeta undefined', () => {
+    const parsed = ZEnvelopeFieldUpdateAndMetaSchema.parse({ type: 'TEXT' });
+    expect(parsed.fieldMeta).toBeUndefined();
+  });
+
+  it('update schema still accepts a complete fieldMeta', () => {
+    const parsed = ZEnvelopeFieldUpdateAndMetaSchema.parse({
+      type: 'TEXT',
+      fieldMeta: { type: 'text', label: 'Notes' },
+    });
+    expect(parsed.fieldMeta?.label).toBe('Notes');
+  });
+
+  it.each(['RADIO', 'CHECKBOX', 'DROPDOWN'] as const)(
+    '%s option lists are not defaulted on update',
+    (type) => {
+      const parsed = ZEnvelopeFieldUpdateAndMetaSchema.parse({ type });
+      expect(parsed.fieldMeta).toBeUndefined();
+    },
+  );
+
+  it('an unknown type is rejected by both schemas', () => {
+    expect(() => ZEnvelopeFieldUpdateAndMetaSchema.parse({ type: 'NOT_A_TYPE' })).toThrow();
+  });
+});

--- a/packages/trpc/server/envelope-router/envelope-fields/update-envelope-fields.types.ts
+++ b/packages/trpc/server/envelope-router/envelope-fields/update-envelope-fields.types.ts
@@ -1,5 +1,5 @@
 import { ZFieldSchema } from '@documenso/lib/types/field';
-import { ZEnvelopeFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
+import { ZEnvelopeFieldUpdateAndMetaSchema } from '@documenso/lib/types/field-meta';
 import { z } from 'zod';
 
 import type { TrpcRouteMeta } from '../../trpc';
@@ -15,7 +15,10 @@ export const updateEnvelopeFieldsMeta: TrpcRouteMeta = {
   },
 };
 
-const ZUpdateFieldBaseSchema = ZEnvelopeFieldAndMetaSchema.and(
+// The update schema carries no create-time fieldMeta defaults: an omitted
+// fieldMeta must arrive as undefined so the service leaves the stored
+// configuration untouched instead of wiping it to type defaults (#3286).
+const ZUpdateFieldBaseSchema = ZEnvelopeFieldUpdateAndMetaSchema.and(
   z.object({
     id: z.number().describe('The ID of the field to update.'),
     envelopeItemId: z


### PR DESCRIPTION
Fixes #3286 — the issue's exact "Fix shape": an update-schema variant with no create-time defaults, create untouched.

## Root cause (as diagnosed, verified)

`ZEnvelopeFieldAndMetaSchema` gives every fieldMeta-bearing member `.optional().default(FIELD_<TYPE>_META_DEFAULT_VALUES)` — defaults introduced for **create** by #2181, correct there. The update route consumes the same schema, so an omitted `fieldMeta` arrives at the service as the **full default object** rather than `undefined`, and `update-envelope-fields.ts` writes `fieldMeta: updateData.fieldMeta` unconditionally inside `tx.field.update`. Since `type` is the union's discriminator and mandatory on update, the default is *always* materialised — the documentation's own partial-update example (`{ id, type, pageY }`) is exactly the call that wipes the field. There was no way to avoid it from the client side.

The audit log's `diffFieldChanges` even records the reset — the loss was visible in the audit trail while the API echoed the wiped state as though it were the update result.

## The fix

- **`ZEnvelopeFieldUpdateAndMetaSchema`** (new, beside the create schema in `field-meta.ts`): identical discriminated-union shape, `fieldMeta` optional with **no default**. The create schema and its defaults are byte-unchanged.
- **The update route** (`update-envelope-fields.types.ts`) consumes the new schema.
- **The service** spreads `fieldMeta` into the update data only when defined — Prisma skips undefined keys, so an omitted `fieldMeta` leaves the stored column untouched; a resent complete `fieldMeta` still replaces it (the documented full-replace behavior still exists for callers that want it).

The deprecated `/document/field/update-many` path is untouched (its plain `ZFieldAndMetaSchema` never had defaults).

## On #3136

As the issue notes, the in-flight coordinate fix #3136 forwards the zod-defaulted `fieldMeta` — merged alone, a move would start working while the wipe stayed. This change composes with it (the route schema both consume is the one changed here), and should land with or after it.

## Tests

`field-meta.update.test.ts` — create still materialises the default (create behavior pinned unchanged); update leaves an omitted `fieldMeta` `undefined`; a complete `fieldMeta` still parses; the option-list types (RADIO/CHECKBOX/DROPDOWN — the blank-option collapses) are covered; unknown types reject on both schemas. **The omitted-fieldMeta assertions fail on `main`** (the update path had no no-default schema — the route consumed the defaulted create schema).