### PR TITLE
fix(api): reject forbidden field meta configurations on create

### DIFF
--- a/packages/lib/advanced-fields-validation/validate-field-meta-configuration.test.ts
+++ b/packages/lib/advanced-fields-validation/validate-field-meta-configuration.test.ts
@@ -1,0 +1,69 @@
+import { FieldType } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import { validateFieldMetaConfiguration } from './validate-field-meta-configuration';
+
+describe('validateFieldMetaConfiguration', () => {
+  it('rejects a field that is both required and read-only', () => {
+    const errors = validateFieldMetaConfiguration(FieldType.TEXT, {
+      required: true,
+      readOnly: true,
+      text: 'pre-filled',
+    });
+
+    expect(errors).toContain('A field cannot be both read-only and required');
+  });
+
+  it('rejects the combination for every documented field type', () => {
+    for (const type of [FieldType.TEXT, FieldType.NUMBER, FieldType.RADIO, FieldType.CHECKBOX, FieldType.DROPDOWN]) {
+      expect(
+        validateFieldMetaConfiguration(type, { required: true, readOnly: true }),
+      ).toContain('A field cannot be both read-only and required');
+    }
+  });
+
+  it('accepts required-only and read-only-with-default configurations', () => {
+    expect(validateFieldMetaConfiguration(FieldType.TEXT, { required: true })).toEqual([]);
+    expect(validateFieldMetaConfiguration(FieldType.TEXT, { readOnly: true, text: 'pre-filled' })).toEqual([]);
+    expect(validateFieldMetaConfiguration(FieldType.SIGNATURE, { required: true })).toEqual([]);
+    expect(validateFieldMetaConfiguration(FieldType.TEXT, undefined)).toEqual([]);
+  });
+
+  it('rejects a read-only text field without a default value', () => {
+    const errors = validateFieldMetaConfiguration(FieldType.TEXT, { readOnly: true });
+
+    expect(errors).toEqual(['A read-only field must have text']);
+  });
+
+  it('rejects a read-only number field without a usable default value', () => {
+    expect(validateFieldMetaConfiguration(FieldType.NUMBER, { readOnly: true })).toEqual([
+      'A read-only field must have a value greater than 0',
+    ]);
+    expect(validateFieldMetaConfiguration(FieldType.NUMBER, { readOnly: true, value: '0' })).toEqual([
+      'A read-only field must have a value greater than 0',
+    ]);
+    expect(validateFieldMetaConfiguration(FieldType.NUMBER, { readOnly: true, value: '42' })).toEqual([]);
+  });
+
+  it('rejects read-only choice fields with no option values', () => {
+    const expected = ['A read-only field must have at least one value'];
+
+    expect(validateFieldMetaConfiguration(FieldType.RADIO, { readOnly: true })).toEqual(expected);
+    expect(
+      validateFieldMetaConfiguration(FieldType.CHECKBOX, { readOnly: true, values: [] }),
+    ).toEqual(expected);
+    expect(validateFieldMetaConfiguration(FieldType.DROPDOWN, { readOnly: true, values: [] })).toEqual(expected);
+    expect(
+      validateFieldMetaConfiguration(FieldType.DROPDOWN, { readOnly: true, values: [{ value: 'a' }] }),
+    ).toEqual([]);
+  });
+
+  it('reports both violations together when a field breaks both rules', () => {
+    const errors = validateFieldMetaConfiguration(FieldType.TEXT, { required: true, readOnly: true });
+
+    expect(errors).toEqual([
+      'A field cannot be both read-only and required',
+      'A read-only field must have text',
+    ]);
+  });
+});

--- a/packages/lib/advanced-fields-validation/validate-field-meta-configuration.ts
+++ b/packages/lib/advanced-fields-validation/validate-field-meta-configuration.ts
@@ -1,0 +1,80 @@
+import { FieldType } from '@prisma/client';
+
+import type {
+  TCheckboxFieldMeta,
+  TDropdownFieldMeta,
+  TNumberFieldMeta,
+  TRadioFieldMeta,
+  TTextFieldMeta,
+} from '../types/field-meta';
+
+type ValueBearingFieldMeta =
+  | TTextFieldMeta
+  | TNumberFieldMeta
+  | TRadioFieldMeta
+  | TCheckboxFieldMeta
+  | TDropdownFieldMeta;
+
+/**
+ * Validates the configuration-only field meta rules the Field Types
+ * documentation promises, independent of any signer-supplied value.
+ *
+ * These are the rules the API create path can and must enforce upfront:
+ * the combination bans and the read-only default-value requirements.
+ * Value-dependent rules (character limits, signing-page requirements)
+ * remain with the signing-time validators.
+ *
+ * @param type The field's type.
+ * @param fieldMeta The field meta carried by the create request.
+ * @returns A list of rule violations, empty when the configuration is legal.
+ */
+export const validateFieldMetaConfiguration = (
+  type: FieldType,
+  fieldMeta: Partial<ValueBearingFieldMeta> | undefined,
+): string[] => {
+  if (!fieldMeta) {
+    return [];
+  }
+
+  const errors = [];
+
+  const { required, readOnly } = fieldMeta;
+
+  if (required && readOnly) {
+    errors.push('A field cannot be both read-only and required');
+  }
+
+  if (readOnly) {
+    switch (type) {
+      case FieldType.TEXT:
+        if (!fieldMeta.text) {
+          errors.push('A read-only field must have text');
+        }
+        break;
+
+      case FieldType.NUMBER: {
+        const value = (fieldMeta as TNumberFieldMeta).value;
+        const parsed = value !== undefined ? Number.parseFloat(value) : Number.NaN;
+
+        if (value === undefined || value === '' || parsed < 1) {
+          errors.push('A read-only field must have a value greater than 0');
+        }
+        break;
+      }
+
+      case FieldType.RADIO:
+      case FieldType.CHECKBOX:
+      case FieldType.DROPDOWN:
+        if (!fieldMeta.values || fieldMeta.values.length === 0) {
+          errors.push('A read-only field must have at least one value');
+        }
+        break;
+
+      default:
+        // Signature-style fields carry no value-bearing default to check.
+        break;
+    }
+  }
+
+  return errors;
+};

--- a/packages/lib/server-only/field/create-envelope-fields.test.ts
+++ b/packages/lib/server-only/field/create-envelope-fields.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, './create-envelope-fields.ts'), 'utf8');
+
+describe('createEnvelopeFields field meta validation', () => {
+  it('imports the configuration validator', () => {
+    expect(source).toMatch(
+      /import\s+\{[^}]*validateFieldMetaConfiguration[^}]*\}\s+from\s+'[^']*validate-field-meta-configuration'/,
+    );
+  });
+
+  it('runs the validator inside the per-field validation block', () => {
+    expect(source).toContain('validateFieldMetaConfiguration(field.type, field.fieldMeta)');
+  });
+
+  it('surfaces violations as a 400 INVALID_REQUEST, not a 500', () => {
+    const guard = source.match(
+      /const fieldMetaErrors = validateFieldMetaConfiguration[\s\S]{0,400}?AppErrorCode\.INVALID_REQUEST/,
+    );
+
+    expect(guard).not.toBeNull();
+  });
+});

--- a/packages/lib/server-only/field/create-envelope-fields.ts
+++ b/packages/lib/server-only/field/create-envelope-fields.ts
@@ -8,6 +8,7 @@ import { prisma } from '@documenso/prisma';
 import { PDF } from '@libpdf/core';
 import { EnvelopeType } from '@prisma/client';
 
+import { validateFieldMetaConfiguration } from '../../advanced-fields-validation/validate-field-meta-configuration';
 import { AppError, AppErrorCode } from '../../errors/app-error';
 import type { EnvelopeIdOptions } from '../../utils/envelope';
 import { mapFieldToLegacyField } from '../../utils/fields';
@@ -160,6 +161,19 @@ export const createEnvelopeFields = async ({
     if (!canRecipientFieldsBeModified(recipient, envelope.fields)) {
       throw new AppError(AppErrorCode.INVALID_REQUEST, {
         message: 'Recipient type cannot have fields, or they have already interacted with the document.',
+      });
+    }
+
+    // Enforce the documented field meta configuration rules upfront — the
+    // editor's setFields path and signing time both reject a field that is
+    // simultaneously required and read-only or a read-only field without a
+    // default value, so a configuration that would fail there must not be
+    // creatable over the API.
+    const fieldMetaErrors = validateFieldMetaConfiguration(field.type, field.fieldMeta);
+
+    if (fieldMetaErrors.length > 0) {
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: `Invalid field meta for recipient ${field.recipientId}: ${fieldMetaErrors.join(', ')}`,
       });
     }
 


### PR DESCRIPTION
## Summary

`POST /api/v2/envelope/field/create-many` (and the v1 document path that shares the service) validated recipients, item ownership and positions, but never inspected `fieldMeta` — so `{"required": true, "readOnly": true}` persisted with a 200 and only failed later, at signing time, as a signer-facing error the sender never saw (#3290).

This adds the configuration-only halves of the rules the [Field Types documentation](https://docs.documenso.com/docs/concepts/field-types) already promises, and enforces them at create:

- **A field cannot be both required and read-only** — for text, number, radio, checkbox and dropdown, the five types whose Rules lists state the invariant.
- **A read-only field must have a default value** — `text` for text fields, a value ≥ 1 for number fields, at least one option for radio/checkbox/dropdown, mirroring the messages the signing-time validators produce.

Value-dependent rules (character limits, signing-page requirements) deliberately stay with the existing validators; this guard only rejects configurations that can never become legal.

Violations answer `400 INVALID_REQUEST` (`AppError`) rather than the bare `Error` → 500 the `setFields` path throws, per the issue's request.

## Implementation

- `packages/lib/advanced-fields-validation/validate-field-meta-configuration.ts` — new pure validator returning the violation list for a `(type, fieldMeta)` pair; colocated unit tests cover every documented rule, both-violations-together, and the legal shapes.
- `packages/lib/server-only/field/create-envelope-fields.ts` — runs the validator inside the existing per-field validation block, after the recipient checks and before placeholder resolution/persistence, so placeholder-derived fields inherit the same gate. A colocated source-contract test pins the wiring and the 400 shape.

## Testing

- 10 new tests, all green.
- Differential: with the source changes stashed, the validator suite fails to import and all three contract tests fail on unpatched main.

Fixes #3290
