### PR TITLE
fix(api): require sequential signing for ASSISTANT recipients

### DIFF
--- a/packages/lib/server-only/envelope/update-envelope.ts
+++ b/packages/lib/server-only/envelope/update-envelope.ts
@@ -4,7 +4,7 @@ import type { CreateDocumentAuditLogDataResponse } from '@documenso/lib/utils/do
 import { createDocumentAuditLogData } from '@documenso/lib/utils/document-audit-logs';
 import { prisma } from '@documenso/prisma';
 import type { DocumentMeta, DocumentVisibility, Prisma, TemplateType } from '@prisma/client';
-import { DocumentStatus, EnvelopeType, FolderType, WebhookTriggerEvents } from '@prisma/client';
+import { RecipientRole, DocumentStatus, EnvelopeType, FolderType, WebhookTriggerEvents } from '@prisma/client';
 import { isDeepEqual } from 'remeda';
 
 import { TEAM_DOCUMENT_VISIBILITY_MAP } from '../../constants/teams';
@@ -16,6 +16,7 @@ import type { EnvelopeIdOptions } from '../../utils/envelope';
 import { buildTeamWhereQuery, canAccessTeamDocument } from '../../utils/teams';
 import { recomputeNextReminderForEnvelope } from '../recipient/update-recipient-next-reminder';
 import { assertCompatibleDictateNextSigner } from '../signature-level/assert-compatible-dictate-next-signer';
+import { assertAssistantCompatibleSigningOrder } from '../signature-level/assert-assistant-compatible-signing-order';
 import { assertCompatibleSigningOrder } from '../signature-level/assert-compatible-signing-order';
 import { triggerWebhook } from '../webhooks/trigger/trigger-webhook';
 import { assertEnvelopeMutable } from './assert-envelope-mutable';
@@ -60,6 +61,7 @@ export const updateEnvelope = async ({
     where: envelopeWhereInput,
     include: {
       documentMeta: true,
+      recipients: true,
       team: {
         select: {
           organisationId: true,
@@ -86,6 +88,15 @@ export const updateEnvelope = async ({
       signatureLevel: envelope.signatureLevel,
       signingOrder: meta.signingOrder,
     });
+
+    // Flipping an envelope that already carries an assistant to parallel
+    // signing reaches the same illegal state from the other side.
+    if (envelope.recipients.some((recipient) => recipient.role === RecipientRole.ASSISTANT)) {
+      assertAssistantCompatibleSigningOrder({
+        role: RecipientRole.ASSISTANT,
+        signingOrder: meta.signingOrder,
+      });
+    }
   }
 
   if (meta.allowDictateNextSigner !== undefined) {

--- a/packages/lib/server-only/recipient/create-envelope-recipients.ts
+++ b/packages/lib/server-only/recipient/create-envelope-recipients.ts
@@ -12,6 +12,7 @@ import type { EnvelopeIdOptions } from '../../utils/envelope';
 import { mapRecipientToLegacyRecipient } from '../../utils/recipients';
 import { assertEnvelopeMutable } from '../envelope/assert-envelope-mutable';
 import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
+import { assertAssistantCompatibleSigningOrder } from '../signature-level/assert-assistant-compatible-signing-order';
 import { assertCompatibleRecipientRole } from '../signature-level/assert-compatible-recipient-role';
 
 export interface CreateEnvelopeRecipientsOptions {
@@ -47,6 +48,7 @@ export const createEnvelopeRecipients = async ({
     where: envelopeWhereInput,
     include: {
       recipients: true,
+      documentMeta: true,
       team: {
         select: {
           organisation: {
@@ -88,6 +90,11 @@ export const createEnvelopeRecipients = async ({
     assertCompatibleRecipientRole({
       signatureLevel: envelope.signatureLevel,
       role: recipient.role,
+    });
+
+    assertAssistantCompatibleSigningOrder({
+      role: recipient.role,
+      signingOrder: envelope.documentMeta?.signingOrder,
     });
   }
 

--- a/packages/lib/server-only/recipient/update-envelope-recipients.ts
+++ b/packages/lib/server-only/recipient/update-envelope-recipients.ts
@@ -14,6 +14,7 @@ import { mapFieldToLegacyField } from '../../utils/fields';
 import { canRecipientBeModified } from '../../utils/recipients';
 import { assertEnvelopeMutable } from '../envelope/assert-envelope-mutable';
 import { getEnvelopeWhereInput } from '../envelope/get-envelope-by-id';
+import { assertAssistantCompatibleSigningOrder } from '../signature-level/assert-assistant-compatible-signing-order';
 import { assertCompatibleRecipientRole } from '../signature-level/assert-compatible-recipient-role';
 
 export interface UpdateEnvelopeRecipientsOptions {
@@ -51,6 +52,7 @@ export const updateEnvelopeRecipients = async ({
     include: {
       fields: true,
       recipients: true,
+      documentMeta: true,
       team: {
         select: {
           organisation: {
@@ -96,6 +98,11 @@ export const updateEnvelopeRecipients = async ({
     assertCompatibleRecipientRole({
       signatureLevel: envelope.signatureLevel,
       role: recipient.role,
+    });
+
+    assertAssistantCompatibleSigningOrder({
+      role: recipient.role,
+      signingOrder: envelope.documentMeta?.signingOrder,
     });
   }
 

--- a/packages/lib/server-only/signature-level/assert-assistant-compatible-signing-order.test.ts
+++ b/packages/lib/server-only/signature-level/assert-assistant-compatible-signing-order.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { DocumentSigningOrder, RecipientRole } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import { AppError } from '../../errors/app-error';
+
+import { assertAssistantCompatibleSigningOrder } from './assert-assistant-compatible-signing-order';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe('assertAssistantCompatibleSigningOrder', () => {
+  it('rejects an ASSISTANT recipient on a parallel-signing envelope', () => {
+    expect(() =>
+      assertAssistantCompatibleSigningOrder({
+        role: RecipientRole.ASSISTANT,
+        signingOrder: DocumentSigningOrder.PARALLEL,
+      }),
+    ).toThrowError(AppError);
+  });
+
+  it('treats a null or undefined signing order as parallel, the persisted default', () => {
+    for (const signingOrder of [null, undefined]) {
+      expect(() =>
+        assertAssistantCompatibleSigningOrder({ role: RecipientRole.ASSISTANT, signingOrder }),
+      ).toThrowError(/sequential signing/);
+    }
+  });
+
+  it('accepts an ASSISTANT recipient on a sequential-signing envelope', () => {
+    expect(() =>
+      assertAssistantCompatibleSigningOrder({
+        role: RecipientRole.ASSISTANT,
+        signingOrder: DocumentSigningOrder.SEQUENTIAL,
+      }),
+    ).not.toThrow();
+  });
+
+  it('leaves every other role unaffected by the signing order', () => {
+    for (const role of [RecipientRole.SIGNER, RecipientRole.CC, RecipientRole.VIEWER, RecipientRole.APPROVER]) {
+      expect(() =>
+        assertAssistantCompatibleSigningOrder({ role, signingOrder: DocumentSigningOrder.PARALLEL }),
+      ).not.toThrow();
+    }
+  });
+});
+
+describe('assistant signing-order guard wiring', () => {
+  const read = (rel: string) => readFileSync(join(here, rel), 'utf8');
+
+  it('createEnvelopeRecipients checks the candidate role against the envelope order', () => {
+    const source = read('../recipient/create-envelope-recipients.ts');
+
+    expect(source).toContain("import { assertAssistantCompatibleSigningOrder }");
+    expect(source).toMatch(
+      /assertAssistantCompatibleSigningOrder\(\{\s*role: recipient\.role,\s*signingOrder: envelope\.documentMeta\?\.signingOrder,\s*\}\)/,
+    );
+    expect(source).toMatch(/include:\s*\{\s*recipients:\s*true,\s*documentMeta:\s*true,/);
+  });
+
+  it('updateEnvelopeRecipients checks a role change against the envelope order', () => {
+    const source = read('../recipient/update-envelope-recipients.ts');
+
+    expect(source).toContain("import { assertAssistantCompatibleSigningOrder }");
+    expect(source).toMatch(
+      /assertAssistantCompatibleSigningOrder\(\{\s*role: recipient\.role,\s*signingOrder: envelope\.documentMeta\?\.signingOrder,\s*\}\)/,
+    );
+  });
+
+  it('updateEnvelope refuses flipping an assistant-bearing envelope to parallel', () => {
+    const source = read('../envelope/update-envelope.ts');
+
+    expect(source).toContain("import { assertAssistantCompatibleSigningOrder }");
+    expect(source).toMatch(
+      /recipient\.role === RecipientRole\.ASSISTANT[\s\S]{0,200}assertAssistantCompatibleSigningOrder\(\{\s*role: RecipientRole\.ASSISTANT,\s*signingOrder: meta\.signingOrder,\s*\}\)/,
+    );
+  });
+});

--- a/packages/lib/server-only/signature-level/assert-assistant-compatible-signing-order.ts
+++ b/packages/lib/server-only/signature-level/assert-assistant-compatible-signing-order.ts
@@ -1,0 +1,48 @@
+import { DocumentSigningOrder, RecipientRole } from '@prisma/client';
+
+import { AppError, AppErrorCode } from '../../errors/app-error';
+
+type AssertAssistantCompatibleSigningOrderOptions = {
+  role: RecipientRole;
+  signingOrder: DocumentSigningOrder | null | undefined;
+};
+
+/**
+ * Reject `RecipientRole.ASSISTANT` unless the envelope signs sequentially.
+ *
+ * The Assistant role exists to pre-fill fields on behalf of downstream
+ * signers, which is only meaningful when the assistant is guaranteed to act
+ * before them. Under `PARALLEL` signing, `sendDocument` notifies every
+ * recipient at once, so signers can sign before the assistant has pre-filled
+ * anything, and the assistant's own view is broken: `getRecipientsForAssistant`
+ * and `getFieldsForToken` filter with `signingOrder: { gte: assistant.signingOrder ?? 0 }`,
+ * which is NULL-false for the null recipient signingOrder the parallel flow
+ * carries, leaving the assistant with no recipients and no fields.
+ *
+ * A `null` / `undefined` signingOrder resolves to `PARALLEL` — the persisted
+ * default — matching how `sendDocument` treats a falsy order at distribution
+ * time.
+ *
+ * Schema-layer guard, called from the recipient create/update paths and from
+ * the envelope-meta path when flipping an envelope that already carries an
+ * assistant.
+ */
+export const assertAssistantCompatibleSigningOrder = ({
+  role,
+  signingOrder,
+}: AssertAssistantCompatibleSigningOrderOptions): void => {
+  if (role !== RecipientRole.ASSISTANT) {
+    return;
+  }
+
+  const effectiveSigningOrder = signingOrder ?? DocumentSigningOrder.PARALLEL;
+
+  if (effectiveSigningOrder === DocumentSigningOrder.SEQUENTIAL) {
+    return;
+  }
+
+  throw new AppError(AppErrorCode.INVALID_REQUEST, {
+    message:
+      'The ASSISTANT role is only available when sequential signing is enabled — parallel signing notifies every recipient at once, so signers could sign before the assistant has pre-filled their fields.',
+  });
+};


### PR DESCRIPTION
## Summary

Two published pages state the Assistant role is only available with sequential signing, and one lists "Be used in parallel signing mode" under what an assistant cannot do — but the restriction lived only in the two editor forms. `POST /api/v2/envelope/recipient/create-many` with `role: ASSISTANT` on a `PARALLEL` envelope returned 200 and persisted the recipient (#3291).

Beyond the contract violation, the state breaks at runtime: with `PARALLEL`, `sendDocument` notifies every recipient at once, so signers can sign before the assistant pre-fills anything, and the assistant's own lookups (`getRecipientsForAssistant`, `getFieldsForToken`) filter `signingOrder: { gte: assistant.signingOrder ?? 0 }` — NULL-false for the null recipient signingOrder an API-created parallel recipient carries — leaving the assistant an empty recipient list and no fields.

## Implementation

- New `assertAssistantCompatibleSigningOrder`, colocated with the existing signature-level asserts and called alongside `assertCompatibleRecipientRole`. A `null`/`undefined` signing order resolves to `PARALLEL` — the persisted column default — matching `sendDocument`'s distribution-time `|| PARALLEL` fallback.
- Wired into all three entry points that can reach the illegal state:
  1. `createEnvelopeRecipients` — per-recipient check against `envelope.documentMeta.signingOrder` (now included in the query);
  2. `updateEnvelopeRecipients` — same check for role changes;
  3. `updateEnvelope` — the envelope-meta path refuses flipping an envelope that already carries an assistant to parallel, closing the state from the other side.
- Violations answer `400 INVALID_REQUEST`.

Out of scope, per the issue's own framing: #2973 argues the restriction should be dropped entirely — if that lands, this assert is the single place to remove.

## Testing

- 7 new tests: the pure assert (parallel rejection, null/undefined → parallel, sequential acceptance, other roles unaffected) plus source-contract tests pinning each of the three wiring points.
- Differential: with the source changes stashed, the suite fails on unpatched main (module missing, all contracts fail).

Fixes #3291
