### PR TITLE
fix(health): resolve the signing transport in cert-status the way the signer does

### DIFF
--- a/packages/lib/server-only/cert/cert-status.test.ts
+++ b/packages/lib/server-only/cert/cert-status.test.ts
@@ -1,0 +1,71 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const envState: Record<string, string | undefined> = {};
+
+vi.mock('@documenso/lib/utils/env', () => ({
+  env: (variable: string) => envState[variable],
+}));
+
+const { getCertificateStatus } = await import('./cert-status');
+
+describe('getCertificateStatus', () => {
+  it('reports the local certificate as unavailable when the transport is unset and the file is missing', () => {
+    envState.NEXT_PRIVATE_SIGNING_TRANSPORT = undefined;
+    envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS = undefined;
+    envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH = join(os.tmpdir(), 'documenso-cert-missing-test.p12');
+
+    expect(getCertificateStatus()).toEqual({ isAvailable: false });
+  });
+
+  it('reports the local certificate as available when the transport is unset and the file exists', () => {
+    const certPath = join(os.tmpdir(), `documenso-cert-present-${process.pid}.p12`);
+
+    try {
+      fs.writeFileSync(certPath, 'not-a-real-p12-but-non-empty');
+
+      envState.NEXT_PRIVATE_SIGNING_TRANSPORT = undefined;
+      envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS = undefined;
+      envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH = certPath;
+
+      expect(getCertificateStatus()).toEqual({ isAvailable: true });
+    } finally {
+      fs.rmSync(certPath, { force: true });
+    }
+  });
+
+  it('checks the local file when the transport is explicitly local', () => {
+    envState.NEXT_PRIVATE_SIGNING_TRANSPORT = 'local';
+    envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS = undefined;
+    envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH = join(os.tmpdir(), 'documenso-cert-missing-test.p12');
+
+    expect(getCertificateStatus()).toEqual({ isAvailable: false });
+  });
+
+  it('skips the file check for non-local transports', () => {
+    envState.NEXT_PRIVATE_SIGNING_TRANSPORT = 'gcloud-hsm';
+    envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH = join(os.tmpdir(), 'documenso-cert-missing-test.p12');
+
+    expect(getCertificateStatus()).toEqual({ isAvailable: true });
+  });
+
+  it('accepts inline certificate contents without touching the filesystem', () => {
+    envState.NEXT_PRIVATE_SIGNING_TRANSPORT = undefined;
+    envState.NEXT_PRIVATE_SIGNING_LOCAL_FILE_CONTENTS = 'inline-p12-contents';
+
+    expect(getCertificateStatus()).toEqual({ isAvailable: true });
+  });
+
+  it('matches the signer: unset transport resolves to local, not to an unrelated transport', () => {
+    const signerSource = fs.readFileSync(join(here, '../../../../packages/signing/index.ts'), 'utf8');
+    const signerDefault = signerSource.match(/NEXT_PRIVATE_SIGNING_TRANSPORT'\)\s*\|\|\s*'local'/);
+
+    expect(signerDefault).not.toBeNull();
+  });
+});

--- a/packages/lib/server-only/cert/cert-status.ts
+++ b/packages/lib/server-only/cert/cert-status.ts
@@ -3,7 +3,13 @@ import * as fs from 'node:fs';
 import { env } from '@documenso/lib/utils/env';
 
 export const getCertificateStatus = () => {
-  if (env('NEXT_PRIVATE_SIGNING_TRANSPORT') !== 'local') {
+  // Resolve the transport exactly as the signer does: unset means 'local',
+  // not "some other transport" whose certificate is irrelevant. Otherwise a
+  // deployment that never sets the variable reports the local certificate as
+  // available even when the file is missing and every seal fails.
+  const transport = env('NEXT_PRIVATE_SIGNING_TRANSPORT') || 'local';
+
+  if (transport !== 'local') {
     return { isAvailable: true };
   }
 


### PR DESCRIPTION
## Summary

On a deployment that does not set `NEXT_PRIVATE_SIGNING_TRANSPORT` — the documented default, and what `.env.example` ships — `/api/health` and `/api/certificate-status` reported the signing certificate as available even when `cert.p12` did not exist and every seal attempt threw `ENOENT` (#3292). A monitor pointed at `/api/health` stayed green through a total signing outage, and the container's own entrypoint banner said the opposite in the same boot.

## Cause

`getCertificateStatus()` and the signer disagree on how to resolve the transport when the variable is unset:

- `cert-status.ts`: `env('NEXT_PRIVATE_SIGNING_TRANSPORT') !== 'local'` — unset is "not local", so the certificate is deemed some other transport's problem and the check short-circuits to `{ isAvailable: true }`.
- `packages/signing/index.ts`: `env('NEXT_PRIVATE_SIGNING_TRANSPORT') || 'local'` — unset **is** local, so the local P12 signer is used and the missing file fails every seal.

## Fix

`getCertificateStatus` now applies the same `|| 'local'` resolution before deciding the certificate belongs to another transport. Unset means local, the local file is actually probed, and both endpoints report the truth. Non-local transports (e.g. `gcloud-hsm`) keep their existing behavior.

## Testing

- 6 new tests: the reported case (unset + missing file → unavailable), unset + present file → available, explicit `local` + missing → unavailable, `gcloud-hsm` → skips the file check, inline `FILE_CONTENTS` → available, and a pin that the health check's default matches the signer's default.
- Differential: on unpatched main the reported case fails (`isAvailable: true`).

Fixes #3292
