### PR TITLE
fix(api): reject forbidden field meta configurations on update

### DIFF
--- a/packages/lib/advanced-fields-validation/validate-field-meta-configuration.test.ts
+++ b/packages/lib/advanced-fields-validation/validate-field-meta-configuration.test.ts
@@ -1,0 +1,69 @@
+import { FieldType } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import { validateFieldMetaConfiguration } from './validate-field-meta-configuration';
+
+describe('validateFieldMetaConfiguration', () => {
+  it('rejects a field that is both required and read-only', () => {
+    const errors = validateFieldMetaConfiguration(FieldType.TEXT, {
+      required: true,
+      readOnly: true,
+      text: 'pre-filled',
+    });
+
+    expect(errors).toContain('A field cannot be both read-only and required');
+  });
+
+  it('rejects the combination for every documented field type', () => {
+    for (const type of [FieldType.TEXT, FieldType.NUMBER, FieldType.RADIO, FieldType.CHECKBOX, FieldType.DROPDOWN]) {
+      expect(
+        validateFieldMetaConfiguration(type, { required: true, readOnly: true }),
+      ).toContain('A field cannot be both read-only and required');
+    }
+  });
+
+  it('accepts required-only and read-only-with-default configurations', () => {
+    expect(validateFieldMetaConfiguration(FieldType.TEXT, { required: true })).toEqual([]);
+    expect(validateFieldMetaConfiguration(FieldType.TEXT, { readOnly: true, text: 'pre-filled' })).toEqual([]);
+    expect(validateFieldMetaConfiguration(FieldType.SIGNATURE, { required: true })).toEqual([]);
+    expect(validateFieldMetaConfiguration(FieldType.TEXT, undefined)).toEqual([]);
+  });
+
+  it('rejects a read-only text field without a default value', () => {
+    const errors = validateFieldMetaConfiguration(FieldType.TEXT, { readOnly: true });
+
+    expect(errors).toEqual(['A read-only field must have text']);
+  });
+
+  it('rejects a read-only number field without a usable default value', () => {
+    expect(validateFieldMetaConfiguration(FieldType.NUMBER, { readOnly: true })).toEqual([
+      'A read-only field must have a value greater than 0',
+    ]);
+    expect(validateFieldMetaConfiguration(FieldType.NUMBER, { readOnly: true, value: '0' })).toEqual([
+      'A read-only field must have a value greater than 0',
+    ]);
+    expect(validateFieldMetaConfiguration(FieldType.NUMBER, { readOnly: true, value: '42' })).toEqual([]);
+  });
+
+  it('rejects read-only choice fields with no option values', () => {
+    const expected = ['A read-only field must have at least one value'];
+
+    expect(validateFieldMetaConfiguration(FieldType.RADIO, { readOnly: true })).toEqual(expected);
+    expect(
+      validateFieldMetaConfiguration(FieldType.CHECKBOX, { readOnly: true, values: [] }),
+    ).toEqual(expected);
+    expect(validateFieldMetaConfiguration(FieldType.DROPDOWN, { readOnly: true, values: [] })).toEqual(expected);
+    expect(
+      validateFieldMetaConfiguration(FieldType.DROPDOWN, { readOnly: true, values: [{ value: 'a' }] }),
+    ).toEqual([]);
+  });
+
+  it('reports both violations together when a field breaks both rules', () => {
+    const errors = validateFieldMetaConfiguration(FieldType.TEXT, { required: true, readOnly: true });
+
+    expect(errors).toEqual([
+      'A field cannot be both read-only and required',
+      'A read-only field must have text',
+    ]);
+  });
+});

--- a/packages/lib/advanced-fields-validation/validate-field-meta-configuration.ts
+++ b/packages/lib/advanced-fields-validation/validate-field-meta-configuration.ts
@@ -1,0 +1,80 @@
+import { FieldType } from '@prisma/client';
+
+import type {
+  TCheckboxFieldMeta,
+  TDropdownFieldMeta,
+  TNumberFieldMeta,
+  TRadioFieldMeta,
+  TTextFieldMeta,
+} from '../types/field-meta';
+
+type ValueBearingFieldMeta =
+  | TTextFieldMeta
+  | TNumberFieldMeta
+  | TRadioFieldMeta
+  | TCheckboxFieldMeta
+  | TDropdownFieldMeta;
+
+/**
+ * Validates the configuration-only field meta rules the Field Types
+ * documentation promises, independent of any signer-supplied value.
+ *
+ * These are the rules the API create path can and must enforce upfront:
+ * the combination bans and the read-only default-value requirements.
+ * Value-dependent rules (character limits, signing-page requirements)
+ * remain with the signing-time validators.
+ *
+ * @param type The field's type.
+ * @param fieldMeta The field meta carried by the create request.
+ * @returns A list of rule violations, empty when the configuration is legal.
+ */
+export const validateFieldMetaConfiguration = (
+  type: FieldType,
+  fieldMeta: Partial<ValueBearingFieldMeta> | undefined,
+): string[] => {
+  if (!fieldMeta) {
+    return [];
+  }
+
+  const errors = [];
+
+  const { required, readOnly } = fieldMeta;
+
+  if (required && readOnly) {
+    errors.push('A field cannot be both read-only and required');
+  }
+
+  if (readOnly) {
+    switch (type) {
+      case FieldType.TEXT:
+        if (!fieldMeta.text) {
+          errors.push('A read-only field must have text');
+        }
+        break;
+
+      case FieldType.NUMBER: {
+        const value = (fieldMeta as TNumberFieldMeta).value;
+        const parsed = value !== undefined ? Number.parseFloat(value) : Number.NaN;
+
+        if (value === undefined || value === '' || parsed < 1) {
+          errors.push('A read-only field must have a value greater than 0');
+        }
+        break;
+      }
+
+      case FieldType.RADIO:
+      case FieldType.CHECKBOX:
+      case FieldType.DROPDOWN:
+        if (!fieldMeta.values || fieldMeta.values.length === 0) {
+          errors.push('A read-only field must have at least one value');
+        }
+        break;
+
+      default:
+        // Signature-style fields carry no value-bearing default to check.
+        break;
+    }
+  }
+
+  return errors;
+};

--- a/packages/lib/server-only/field/create-envelope-fields.test.ts
+++ b/packages/lib/server-only/field/create-envelope-fields.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, './create-envelope-fields.ts'), 'utf8');
+
+describe('createEnvelopeFields field meta validation', () => {
+  it('imports the configuration validator', () => {
+    expect(source).toMatch(
+      /import\s+\{[^}]*validateFieldMetaConfiguration[^}]*\}\s+from\s+'[^']*validate-field-meta-configuration'/,
+    );
+  });
+
+  it('runs the validator inside the per-field validation block', () => {
+    expect(source).toContain('validateFieldMetaConfiguration(field.type, field.fieldMeta)');
+  });
+
+  it('surfaces violations as a 400 INVALID_REQUEST, not a 500', () => {
+    const guard = source.match(
+      /const fieldMetaErrors = validateFieldMetaConfiguration[\s\S]{0,400}?AppErrorCode\.INVALID_REQUEST/,
+    );
+
+    expect(guard).not.toBeNull();
+  });
+});

--- a/packages/lib/server-only/field/create-envelope-fields.ts
+++ b/packages/lib/server-only/field/create-envelope-fields.ts
@@ -8,6 +8,7 @@ import { prisma } from '@documenso/prisma';
 import { PDF } from '@libpdf/core';
 import { EnvelopeType } from '@prisma/client';
 
+import { validateFieldMetaConfiguration } from '../../advanced-fields-validation/validate-field-meta-configuration';
 import { AppError, AppErrorCode } from '../../errors/app-error';
 import type { EnvelopeIdOptions } from '../../utils/envelope';
 import { mapFieldToLegacyField } from '../../utils/fields';
@@ -160,6 +161,19 @@ export const createEnvelopeFields = async ({
     if (!canRecipientFieldsBeModified(recipient, envelope.fields)) {
       throw new AppError(AppErrorCode.INVALID_REQUEST, {
         message: 'Recipient type cannot have fields, or they have already interacted with the document.',
+      });
+    }
+
+    // Enforce the documented field meta configuration rules upfront — the
+    // editor's setFields path and signing time both reject a field that is
+    // simultaneously required and read-only or a read-only field without a
+    // default value, so a configuration that would fail there must not be
+    // creatable over the API.
+    const fieldMetaErrors = validateFieldMetaConfiguration(field.type, field.fieldMeta);
+
+    if (fieldMetaErrors.length > 0) {
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: `Invalid field meta for recipient ${field.recipientId}: ${fieldMetaErrors.join(', ')}`,
       });
     }
 

--- a/packages/lib/server-only/field/update-envelope-fields.test.ts
+++ b/packages/lib/server-only/field/update-envelope-fields.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, './update-envelope-fields.ts'), 'utf8');
+
+describe('updateEnvelopeFields field meta validation', () => {
+  it('imports the configuration validator', () => {
+    expect(source).toMatch(
+      /import\s+\{[^}]*validateFieldMetaConfiguration[^}]*\}\s+from\s+'[^']*validate-field-meta-configuration'/,
+    );
+  });
+
+  it('validates the provided meta against the effective field type', () => {
+    expect(source).toContain('validateFieldMetaConfiguration(fieldType, field.fieldMeta)');
+  });
+
+  it('surfaces violations as a 400 INVALID_REQUEST', () => {
+    const guard = source.match(
+      /const fieldMetaErrors = validateFieldMetaConfiguration[\s\S]{0,400}?AppErrorCode\.INVALID_REQUEST/,
+    );
+
+    expect(guard).not.toBeNull();
+  });
+});

--- a/packages/lib/server-only/field/update-envelope-fields.ts
+++ b/packages/lib/server-only/field/update-envelope-fields.ts
@@ -5,6 +5,7 @@ import { createDocumentAuditLogData, diffFieldChanges } from '@documenso/lib/uti
 import { prisma } from '@documenso/prisma';
 import { EnvelopeType, type FieldType } from '@prisma/client';
 
+import { validateFieldMetaConfiguration } from '../../advanced-fields-validation/validate-field-meta-configuration';
 import { AppError, AppErrorCode } from '../../errors/app-error';
 import type { EnvelopeIdOptions } from '../../utils/envelope';
 import { mapFieldToLegacyField } from '../../utils/fields';
@@ -101,6 +102,18 @@ export const updateEnvelopeFields = async ({
     if (envelope.internalVersion === 2 && fieldMetaType && fieldMetaType.toLowerCase() !== fieldType.toLowerCase()) {
       throw new AppError(AppErrorCode.INVALID_REQUEST, {
         message: 'Field meta type does not match the field type',
+      });
+    }
+
+    // The update replaces fieldMeta wholesale, so the meta it writes must
+    // satisfy the documented configuration rules — the same ones the create
+    // path enforces and signing time reports. An omitted fieldMeta keeps
+    // the stored one untouched and skips this check.
+    const fieldMetaErrors = validateFieldMetaConfiguration(fieldType, field.fieldMeta);
+
+    if (fieldMetaErrors.length > 0) {
+      throw new AppError(AppErrorCode.INVALID_REQUEST, {
+        message: `Invalid field meta for field ${field.id}: ${fieldMetaErrors.join(', ')}`,
       });
     }
 


### PR DESCRIPTION
## Summary

Companion to the create-path fix #3293, covering the other direction identified in #3296: `updateEnvelopeFields` replaced `fieldMeta` wholesale without ever inspecting it, so `POST /api/v2/envelope/field/update-many` could persist `{"required": true, "readOnly": true}` — or flip a legal field illegal in one replacement meta — and the signer-facing failure only surfaced at signing time.

## Implementation

The per-field loop now runs the same `validateFieldMetaConfiguration` #3293 introduced, against the effective field type (`field.type || originalField.type`, already computed for the meta/type match directly above), answering `400 INVALID_REQUEST` with the violation list. An omitted `fieldMeta` keeps the stored one untouched (#3286/#3289 semantics) and skips the check — only meta the update *writes* is validated, because the write replaces wholesale.

**Stacked on #3293** (the shared validator lands there) — merge order: #3293 first.

## Testing

- Colocated source-contract tests pin the import, the validation call against the effective type, and the 400 shape. Differential: all 3 fail with the source change stashed.
- `packages/lib/server-only/field/` suite green (6/6).

Fixes #3296
