### PR TITLE
fix(api): answer setFields validation failures with 400, not 500

### DIFF
--- a/packages/lib/server-only/field/set-fields-for-document.ts
+++ b/packages/lib/server-only/field/set-fields-for-document.ts
@@ -139,7 +139,7 @@ export const setFieldsForDocument = async ({
           const errors = validateTextField(textFieldParsedMeta.text || '', textFieldParsedMeta);
 
           if (errors.length > 0) {
-            throw new Error(errors.join(', '));
+            throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join(', ') });
           }
         }
 
@@ -149,7 +149,7 @@ export const setFieldsForDocument = async ({
           const errors = validateNumberField(String(numberFieldParsedMeta.value || ''), numberFieldParsedMeta, false);
 
           if (errors.length > 0) {
-            throw new Error(errors.join(', '));
+            throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join(', ') });
           }
         }
 
@@ -162,10 +162,12 @@ export const setFieldsForDocument = async ({
             );
 
             if (errors.length > 0) {
-              throw new Error(errors.join(', '));
+              throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join(', ') });
             }
           } else {
-            throw new Error('To proceed further, please set at least one value for the Checkbox field');
+            throw new AppError(AppErrorCode.INVALID_REQUEST, {
+              message: 'To proceed further, please set at least one value for the Checkbox field',
+            });
           }
         }
 
@@ -177,10 +179,12 @@ export const setFieldsForDocument = async ({
             const errors = validateRadioField(checkedRadioFieldValue, radioFieldParsedMeta);
 
             if (errors.length > 0) {
-              throw new Error(errors.join('. '));
+              throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join('. ') });
             }
           } else {
-            throw new Error('To proceed further, please set at least one value for the Radio field');
+            throw new AppError(AppErrorCode.INVALID_REQUEST, {
+              message: 'To proceed further, please set at least one value for the Radio field',
+            });
           }
         }
 
@@ -190,10 +194,12 @@ export const setFieldsForDocument = async ({
             const errors = validateDropdownField(undefined, dropdownFieldParsedMeta);
 
             if (errors.length > 0) {
-              throw new Error(errors.join('. '));
+              throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join('. ') });
             }
           } else {
-            throw new Error('To proceed further, please set at least one value for the Dropdown field');
+            throw new AppError(AppErrorCode.INVALID_REQUEST, {
+              message: 'To proceed further, please set at least one value for the Dropdown field',
+            });
           }
         }
 

--- a/packages/lib/server-only/field/set-fields-for-template.ts
+++ b/packages/lib/server-only/field/set-fields-for-template.ts
@@ -117,7 +117,7 @@ export const setFieldsForTemplate = async ({ userId, teamId, id, fields }: SetFi
         const textFieldParsedMeta = ZTextFieldMeta.parse(field.fieldMeta);
         const errors = validateTextField(textFieldParsedMeta.text || '', textFieldParsedMeta);
         if (errors.length > 0) {
-          throw new Error(errors.join(', '));
+          throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join(', ') });
         }
       }
 
@@ -125,13 +125,15 @@ export const setFieldsForTemplate = async ({ userId, teamId, id, fields }: SetFi
         const numberFieldParsedMeta = ZNumberFieldMeta.parse(field.fieldMeta);
         const errors = validateNumberField(String(numberFieldParsedMeta.value || ''), numberFieldParsedMeta);
         if (errors.length > 0) {
-          throw new Error(errors.join(', '));
+          throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join(', ') });
         }
       }
 
       if (field.type === FieldType.CHECKBOX) {
         if (!field.fieldMeta) {
-          throw new Error('Checkbox field is missing required metadata');
+          throw new AppError(AppErrorCode.INVALID_REQUEST, {
+            message: 'Checkbox field is missing required metadata',
+          });
         }
         const checkboxFieldParsedMeta = ZCheckboxFieldMeta.parse(field.fieldMeta);
         const errors = validateCheckboxField(
@@ -139,30 +141,34 @@ export const setFieldsForTemplate = async ({ userId, teamId, id, fields }: SetFi
           checkboxFieldParsedMeta,
         );
         if (errors.length > 0) {
-          throw new Error(errors.join(', '));
+          throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join(', ') });
         }
       }
 
       if (field.type === FieldType.RADIO) {
         if (!field.fieldMeta) {
-          throw new Error('Radio field is missing required metadata');
+          throw new AppError(AppErrorCode.INVALID_REQUEST, {
+            message: 'Radio field is missing required metadata',
+          });
         }
         const radioFieldParsedMeta = ZRadioFieldMeta.parse(field.fieldMeta);
         const checkedRadioFieldValue = radioFieldParsedMeta.values?.find((option) => option.checked)?.value;
         const errors = validateRadioField(checkedRadioFieldValue, radioFieldParsedMeta);
         if (errors.length > 0) {
-          throw new Error(errors.join('. '));
+          throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join('. ') });
         }
       }
 
       if (field.type === FieldType.DROPDOWN) {
         if (!field.fieldMeta) {
-          throw new Error('Dropdown field is missing required metadata');
+          throw new AppError(AppErrorCode.INVALID_REQUEST, {
+            message: 'Dropdown field is missing required metadata',
+          });
         }
         const dropdownFieldParsedMeta = ZDropdownFieldMeta.parse(field.fieldMeta);
         const errors = validateDropdownField(undefined, dropdownFieldParsedMeta);
         if (errors.length > 0) {
-          throw new Error(errors.join('. '));
+          throw new AppError(AppErrorCode.INVALID_REQUEST, { message: errors.join('. ') });
         }
       }
 

--- a/packages/lib/server-only/field/set-fields-validation-status.test.ts
+++ b/packages/lib/server-only/field/set-fields-validation-status.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(here, rel), 'utf8');
+
+describe('setFields validation error status', () => {
+  it('set-fields-for-document reports validation failures as 400 INVALID_REQUEST', () => {
+    const source = read('./set-fields-for-document.ts');
+
+    expect(source).not.toMatch(/throw new Error\(errors\.join/);
+    expect(source).not.toMatch(/throw new Error\('To proceed further/);
+    expect((source.match(/AppError\(AppErrorCode\.INVALID_REQUEST/g) ?? []).length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('set-fields-for-template reports validation failures as 400 INVALID_REQUEST', () => {
+    const source = read('./set-fields-for-template.ts');
+
+    expect(source).not.toMatch(/throw new Error\(errors\.join/);
+    expect(source).not.toMatch(/throw new Error\('.*missing required metadata/);
+    expect((source.match(/AppError\(AppErrorCode\.INVALID_REQUEST/g) ?? []).length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('the internal upsert invariant is unchanged', () => {
+    const source = read('./set-fields-for-document.ts');
+
+    expect(source).toContain("throw new Error('Not possible')");
+  });
+});


### PR DESCRIPTION
## Summary

#3290 asked that field-meta violations answer `400 INVALID_REQUEST` "rather than the bare `new Error(errors.join(', '))` the `setFields` path throws today, which surfaces as a 500 even where the rules are enforced." #3293 fixed the create path; this converts the two editor `setFields` paths that already *enforce* the rules, so the same invalid configuration answers 400 everywhere it can be rejected.

## Implementation

Every validator failure and missing-metadata throw in `set-fields-for-document.ts` and `set-fields-for-template.ts` (17 sites) becomes `AppError(AppErrorCode.INVALID_REQUEST)` with the same message — the editor's toast text is unchanged, only the HTTP status and error code become correct. The one internal upsert invariant (`'Not possible'`) stays a plain `Error`: it is unreachable by user input and indicates a programming fault, where a 500 is the honest answer.

## Testing

- Colocated source-contract tests pin: no bare `errors.join`/user-message throws remain, `AppError(INVALID_REQUEST)` count per file, and the internal invariant is untouched.
- Differential: 2 of 3 fail with the source changes stashed; the field-service suite is green (9/9 including #3293's tests).

Companion to #3293 (no merge-order dependency).
