### PR TITLE
feat: add recipient filter to documents search in admin panel

### DIFF
--- a/apps/remix/app/routes/_authenticated+/admin+/documents._index.tsx
+++ b/apps/remix/app/routes/_authenticated+/admin+/documents._index.tsx
@@ -131,7 +131,7 @@ export default function AdminDocumentsPage() {
         <div>
           <Input
             type="search"
-            placeholder={_(msg`Search by document title, team:123 or user:123`)}
+            placeholder={_(msg`Search by document title, team:123, user:123 or recipient:email@example.com`)}
             value={term}
             onChange={(e) => setTerm(e.target.value)}
           />

--- a/packages/lib/constants/database.ts
+++ b/packages/lib/constants/database.ts
@@ -1,0 +1,6 @@
+/**
+ * The maximum value of a Postgres `INT4` (32-bit signed integer) column, which
+ * is what Prisma `Int` ID columns are stored as. Filtering an `Int` column by
+ * a larger value makes Prisma throw a conversion error at runtime.
+ */
+export const MAX_POSTGRES_INT = 2147483647;

--- a/packages/lib/server-only/admin/admin-find-documents.ts
+++ b/packages/lib/server-only/admin/admin-find-documents.ts
@@ -2,6 +2,7 @@ import { prisma } from '@documenso/prisma';
 import { EnvelopeType, type Prisma } from '@prisma/client';
 import { z } from 'zod';
 
+import { MAX_POSTGRES_INT } from '../../constants/database';
 import type { FindResultResponse } from '../../types/search-params';
 
 export interface AdminFindDocumentsOptions {
@@ -10,7 +11,7 @@ export interface AdminFindDocumentsOptions {
   perPage?: number;
 }
 
-const ZPositiveIntegerSchema = z.coerce.number().int().positive();
+const ZPositiveIntegerSchema = z.coerce.number().int().positive().max(MAX_POSTGRES_INT);
 
 const emptyResponse = {
   data: [],
@@ -56,6 +57,40 @@ export const adminFindDocuments = async ({ query, page = 1, perPage = 10 }: Admi
     } else {
       return emptyResponse;
     }
+  }
+
+  if (query?.startsWith('recipient:')) {
+    const recipientQuery = query.slice('recipient:'.length).trim();
+
+    if (!recipientQuery) {
+      return emptyResponse;
+    }
+
+    // Match admin-global-search semantics: only bare digit strings are ID
+    // lookups, so numeric-looking email fragments (1e3, 0x10, +40) stay text.
+    const isRecipientIdLookup = /^\d+$/.test(recipientQuery);
+
+    const parsedRecipientId = ZPositiveIntegerSchema.safeParse(recipientQuery);
+
+    termFilters =
+      isRecipientIdLookup && parsedRecipientId.success
+        ? {
+            recipients: {
+              some: {
+                id: parsedRecipientId.data,
+              },
+            },
+          }
+        : {
+            recipients: {
+              some: {
+                email: {
+                  contains: recipientQuery,
+                  mode: 'insensitive',
+                },
+              },
+            },
+          };
   }
 
   if (query && query?.startsWith('envelope_')) {

--- a/packages/lib/server-only/admin/admin-global-search.ts
+++ b/packages/lib/server-only/admin/admin-global-search.ts
@@ -1,9 +1,9 @@
 import { prisma } from '@documenso/prisma';
 import { EnvelopeType } from '@prisma/client';
 
-export const ADMIN_SEARCH_RESULTS_PER_TYPE = 5;
+import { MAX_POSTGRES_INT } from '../../constants/database';
 
-const MAX_POSTGRES_INT = 2147483647;
+export const ADMIN_SEARCH_RESULTS_PER_TYPE = 5;
 
 const GROUP_ORDER = ['document', 'user', 'organisation', 'team', 'recipient', 'subscription'] as const;
 


### PR DESCRIPTION
Allow admins to filter documents by recipient on the admin documents page. It uses the same prefix convention as the existing `user:` and `team:` filters.

Example:

```
recipient:john@example.com (case-insensitive contains) 

// or 

recipient:123 (exact recipient ID).
```

Useful when people receive signature requests from spam accounts and support needs to find the documents they're a recipient on.

<img width="1872" height="1500" alt="img" src="https://github.com/user-attachments/assets/5db6c440-4974-4356-8d1e-24dd2855271c" />

The PR also fixes a 500 error on this endpoint. Big numeric IDs like `user:99999999999999` passed validation and made Prisma throw a conversion error on INT4 columns (reproduced on production). 