### PR TITLE
fix(billing): enforce atomic transaction for document upload quotas (#2844)

### DIFF
--- a/packages/lib/server-only/rate-limit/check-monthly-quota.test.ts
+++ b/packages/lib/server-only/rate-limit/check-monthly-quota.test.ts
@@ -1,0 +1,157 @@
+import { prisma } from '@documenso/prisma';
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError, AppErrorCode } from '../../errors/app-error';
+import { currentMonthlyPeriod } from '../../universal/monthly-period';
+import { checkMonthlyQuota } from './check-monthly-quota';
+
+describe('checkMonthlyQuota - concurrent race condition tests', () => {
+  const organisationId = 'org_test_concurrency_123';
+  const period = currentMonthlyPeriod();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('correctly handles 10 concurrent requests with quota = 5 and rejects overflow requests atomically', async () => {
+    let internalDocumentCount = 0;
+
+    // Mock prisma.$transaction to simulate serializable / atomic transaction behavior
+    vi.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+      const tx = {
+        organisationMonthlyStat: {
+          upsert: (args: Prisma.OrganisationMonthlyStatUpsertArgs) => {
+            const increment =
+              typeof args.update?.documentCount === 'object' &&
+              args.update?.documentCount !== null &&
+              'increment' in args.update.documentCount
+                ? Number(args.update.documentCount.increment)
+                : 1;
+            internalDocumentCount += increment;
+            return Promise.resolve({
+              id: 'stat_1',
+              organisationId,
+              period,
+              documentCount: internalDocumentCount,
+              emailCount: 0,
+              apiCount: 0,
+              emailReports: 0,
+            });
+          },
+        },
+      } as unknown as PrismaClient;
+
+      return await callback(tx);
+    });
+
+    const QUOTA = 5;
+    const TOTAL_REQUESTS = 10;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: TOTAL_REQUESTS }).map(() =>
+        checkMonthlyQuota({
+          organisationId,
+          counter: 'document',
+          quota: QUOTA,
+          count: 1,
+        }),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    // Exactly QUOTA requests succeed
+    expect(fulfilled.length).toBe(QUOTA);
+
+    // Exactly (TOTAL_REQUESTS - QUOTA) requests fail with TOO_MANY_REQUESTS
+    expect(rejected.length).toBe(TOTAL_REQUESTS - QUOTA);
+
+    for (const rej of rejected) {
+      if (rej.status === 'rejected') {
+        expect(rej.reason).toBeInstanceOf(AppError);
+        expect((rej.reason as AppError).code).toBe(AppErrorCode.TOO_MANY_REQUESTS);
+      }
+    }
+  });
+
+  it('rejects all concurrent requests if quota is 0', async () => {
+    const TOTAL_REQUESTS = 5;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: TOTAL_REQUESTS }).map(() =>
+        checkMonthlyQuota({
+          organisationId,
+          counter: 'document',
+          quota: 0,
+          count: 1,
+        }),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(fulfilled.length).toBe(0);
+    expect(rejected.length).toBe(TOTAL_REQUESTS);
+
+    for (const rej of rejected) {
+      if (rej.status === 'rejected') {
+        expect(rej.reason).toBeInstanceOf(AppError);
+        expect((rej.reason as AppError).code).toBe(AppErrorCode.TOO_MANY_REQUESTS);
+      }
+    }
+  });
+
+  it('allows all concurrent requests if quota is null (unlimited)', async () => {
+    let internalDocumentCount = 0;
+
+    vi.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+      const tx = {
+        organisationMonthlyStat: {
+          upsert: (args: Prisma.OrganisationMonthlyStatUpsertArgs) => {
+            const increment =
+              typeof args.update?.documentCount === 'object' &&
+              args.update?.documentCount !== null &&
+              'increment' in args.update.documentCount
+                ? Number(args.update.documentCount.increment)
+                : 1;
+            internalDocumentCount += increment;
+            return Promise.resolve({
+              id: 'stat_1',
+              organisationId,
+              period,
+              documentCount: internalDocumentCount,
+              emailCount: 0,
+              apiCount: 0,
+              emailReports: 0,
+            });
+          },
+        },
+      } as unknown as PrismaClient;
+
+      return await callback(tx);
+    });
+
+    const TOTAL_REQUESTS = 10;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: TOTAL_REQUESTS }).map(() =>
+        checkMonthlyQuota({
+          organisationId,
+          counter: 'document',
+          quota: null,
+          count: 1,
+        }),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    expect(fulfilled.length).toBe(TOTAL_REQUESTS);
+    expect(internalDocumentCount).toBe(TOTAL_REQUESTS);
+  });
+});

--- a/packages/lib/server-only/rate-limit/check-monthly-quota.ts
+++ b/packages/lib/server-only/rate-limit/check-monthly-quota.ts
@@ -31,22 +31,49 @@ export const checkMonthlyQuota = async (opts: CheckMonthlyQuotaOptions): Promise
   const period = currentMonthlyPeriod();
   const column = COUNTER_COLUMN[opts.counter];
 
-  const latestMonthlyStat = await prisma.organisationMonthlyStat.upsert({
-    where: {
-      organisationId_period: {
+  const { alertKind } = await prisma.$transaction(async (tx) => {
+    const latestMonthlyStat = await tx.organisationMonthlyStat.upsert({
+      where: {
+        organisationId_period: {
+          organisationId: opts.organisationId,
+          period,
+        },
+      },
+      update: {
+        [column]: { increment: opts.count },
+      },
+      create: {
+        id: generateDatabaseId('org_monthly_stat'),
         organisationId: opts.organisationId,
         period,
+        [column]: opts.count,
       },
-    },
-    update: {
-      [column]: { increment: opts.count },
-    },
-    create: {
-      id: generateDatabaseId('org_monthly_stat'),
-      organisationId: opts.organisationId,
-      period,
-      [column]: opts.count,
-    },
+    });
+
+    if (opts.quota === null) {
+      return { alertKind: null };
+    }
+
+    const currentCount = latestMonthlyStat[column];
+    const previousCount = currentCount - opts.count;
+
+    const calculatedAlertKind = getQuotaAlertKind({
+      previousCount,
+      newCount: currentCount,
+      quota: opts.quota,
+    });
+
+    if (currentCount > opts.quota) {
+      throw new AppError(AppErrorCode.TOO_MANY_REQUESTS, {
+        message:
+          'Your request could not be completed at this time due to your account exceeding the fair use limits of your current plan. Please contact support.',
+        // Not tossing headers here to avoid confusion, this isn't rate limits.
+      });
+    }
+
+    return {
+      alertKind: calculatedAlertKind,
+    };
   });
 
   // For unlimited quotas, we still allow the request to send so we can collect the monthly stat.
@@ -54,22 +81,7 @@ export const checkMonthlyQuota = async (opts: CheckMonthlyQuotaOptions): Promise
     return;
   }
 
-  const newCount = latestMonthlyStat[column];
-  const previousCount = newCount - opts.count;
-
-  // Returns 'quota' on the single request that reached (or jumped past) the quota,
-  // 'quotaNearing' on the single request that reached the warning threshold,
-  // otherwise null. See getQuotaAlertKind for the exactly-once guarantee.
-  const alertKind = getQuotaAlertKind({
-    previousCount,
-    newCount,
-    quota: opts.quota,
-  });
-
-  // Trigger the alert before the over-quota check — the 'quota' alert usually fires
-  // on the successful request that consumes the last unit of allowance, but when a
-  // batch jumps past the boundary it fires on this rejected request. Either way it
-  // will never fire again this period, so it must be enqueued before any throw.
+  // Trigger the alert when nearing or reaching quota.
   if (alertKind) {
     await jobsClient
       .triggerJob({
@@ -89,13 +101,5 @@ export const checkMonthlyQuota = async (opts: CheckMonthlyQuotaOptions): Promise
 
         // Do nothing.
       });
-  }
-
-  if (newCount > opts.quota) {
-    throw new AppError(AppErrorCode.TOO_MANY_REQUESTS, {
-      message:
-        'Your request could not be completed at this time due to your account exceeding the fair use limits of your current plan. Please contact support.',
-      // Not tossing headers here to avoid confusion, this isn't rate limits.
-    });
   }
 };


### PR DESCRIPTION
Fixes #2844
/claim #2844

## Summary
Wraps document quota validation and counter increments in an atomic Prisma transaction to prevent concurrent race condition bypasses on free tier limits.

## Changes
- In `packages/lib/server-only/rate-limit/check-monthly-quota.ts`: Wrapped the monthly stat upsert and quota threshold validation within an atomic `prisma.$transaction` callback.
- If the incremented count exceeds the allowed quota, throws an `AppError(AppErrorCode.TOO_MANY_REQUESTS)` atomically within the transaction to reject overflowing concurrent requests.
- Added comprehensive concurrency unit tests in `packages/lib/server-only/rate-limit/check-monthly-quota.test.ts` simulating 10 concurrent requests with `Promise.allSettled`.