### PR TITLE
Add RepoCloud to One-Click Deploys section

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ For full instructions, requirements, and configuration details, see the [Self Ho
 
 [![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/documenso)
 
+#### RepoCloud
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Documenso/)
+
 ## Security
 
 If you believe you have found a security vulnerability in Documenso, please report it through our [Security Policy](https://github.com/documenso/documenso/security/policy). We prioritize private reports via [GitHub Security Advisories](https://github.com/documenso/documenso/security/advisories/new). See [SECURITY.md](./SECURITY.md) for scope and details.


### PR DESCRIPTION
Adds RepoCloud as an additional one-click deploy option in the Self Hosting section, alongside Railway, Render, Koyeb, and Elestio. Uses the same markdown image button format as the existing entries.