### PR TITLE
fix(lib): prevent field from being both required and read-only (#3296)

### DIFF
--- a/packages/lib/types/field-meta.test.ts
+++ b/packages/lib/types/field-meta.test.ts
@@ -1,0 +1,104 @@
+import { FieldType } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+import {
+  ZEnvelopeFieldAndMetaSchema,
+  ZFieldMetaNotOptionalSchema,
+  ZFieldMetaSchema,
+  ZTextFieldMeta,
+} from './field-meta';
+
+describe('ZFieldMetaSchema - required and readOnly mutual exclusivity', () => {
+  it('rejects fieldMeta when both required and readOnly are true via ZFieldMetaNotOptionalSchema for text', () => {
+    const result = ZFieldMetaNotOptionalSchema.safeParse({
+      type: 'text',
+      required: true,
+      readOnly: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects fieldMeta when both required and readOnly are true via ZFieldMetaNotOptionalSchema for number', () => {
+    const result = ZFieldMetaNotOptionalSchema.safeParse({
+      type: 'number',
+      required: true,
+      readOnly: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects fieldMeta when both required and readOnly are true via ZFieldMetaNotOptionalSchema for checkbox', () => {
+    const result = ZFieldMetaNotOptionalSchema.safeParse({
+      type: 'checkbox',
+      required: true,
+      readOnly: true,
+      values: [{ id: 1, checked: false, value: 'opt1' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects fieldMeta when both required and readOnly are true via ZFieldMetaNotOptionalSchema for radio', () => {
+    const result = ZFieldMetaNotOptionalSchema.safeParse({
+      type: 'radio',
+      required: true,
+      readOnly: true,
+      values: [{ id: 1, checked: false, value: 'opt1' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects fieldMeta when both required and readOnly are true via ZFieldMetaNotOptionalSchema for dropdown', () => {
+    const result = ZFieldMetaNotOptionalSchema.safeParse({
+      type: 'dropdown',
+      required: true,
+      readOnly: true,
+      values: [{ value: 'opt1' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects fieldMeta when both required and readOnly are true via ZFieldMetaSchema', () => {
+    const result = ZFieldMetaSchema.safeParse({
+      type: 'text',
+      required: true,
+      readOnly: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects fieldMeta when both required and readOnly are true via ZEnvelopeFieldAndMetaSchema', () => {
+    const result = ZEnvelopeFieldAndMetaSchema.safeParse({
+      type: FieldType.TEXT,
+      fieldMeta: {
+        type: 'text',
+        required: true,
+        readOnly: true,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts fieldMeta when only required is true', () => {
+    const result = ZTextFieldMeta.safeParse({
+      type: 'text',
+      required: true,
+      readOnly: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts fieldMeta when only readOnly is true', () => {
+    const result = ZTextFieldMeta.safeParse({
+      type: 'text',
+      required: false,
+      readOnly: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts fieldMeta when both required and readOnly are omitted or false', () => {
+    const result = ZTextFieldMeta.safeParse({
+      type: 'text',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/lib/types/field-meta.ts
+++ b/packages/lib/types/field-meta.ts
@@ -185,18 +185,28 @@ export const ZSignatureFieldMeta = ZBaseFieldMeta.extend({
 
 export type TSignatureFieldMeta = z.infer<typeof ZSignatureFieldMeta>;
 
-export const ZFieldMetaNotOptionalSchema = z.discriminatedUnion('type', [
-  ZSignatureFieldMeta,
-  ZInitialsFieldMeta,
-  ZNameFieldMeta,
-  ZEmailFieldMeta,
-  ZDateFieldMeta,
-  ZTextFieldMeta,
-  ZNumberFieldMeta,
-  ZRadioFieldMeta,
-  ZCheckboxFieldMeta,
-  ZDropdownFieldMeta,
-]);
+export const ZFieldMetaNotOptionalSchema = z
+  .discriminatedUnion('type', [
+    ZSignatureFieldMeta,
+    ZInitialsFieldMeta,
+    ZNameFieldMeta,
+    ZEmailFieldMeta,
+    ZDateFieldMeta,
+    ZTextFieldMeta,
+    ZNumberFieldMeta,
+    ZRadioFieldMeta,
+    ZCheckboxFieldMeta,
+    ZDropdownFieldMeta,
+  ])
+  .superRefine((data, ctx) => {
+    if (data.required && data.readOnly) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A field cannot be both read-only and required',
+        path: ['required'],
+      });
+    }
+  });
 
 export type TFieldMetaNotOptionalSchema = z.infer<typeof ZFieldMetaNotOptionalSchema>;
 
@@ -255,52 +265,62 @@ export const ZFieldMetaSchema = z
 
 export type TFieldMetaSchema = z.infer<typeof ZFieldMetaSchema>;
 
-export const ZFieldAndMetaSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal(FieldType.SIGNATURE),
-    fieldMeta: ZSignatureFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.FREE_SIGNATURE),
-    fieldMeta: z.undefined(),
-  }),
-  z.object({
-    type: z.literal(FieldType.INITIALS),
-    fieldMeta: ZInitialsFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.NAME),
-    fieldMeta: ZNameFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.EMAIL),
-    fieldMeta: ZEmailFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.DATE),
-    fieldMeta: ZDateFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.TEXT),
-    fieldMeta: ZTextFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.NUMBER),
-    fieldMeta: ZNumberFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.RADIO),
-    fieldMeta: ZRadioFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.CHECKBOX),
-    fieldMeta: ZCheckboxFieldMeta.optional(),
-  }),
-  z.object({
-    type: z.literal(FieldType.DROPDOWN),
-    fieldMeta: ZDropdownFieldMeta.optional(),
-  }),
-]);
+export const ZFieldAndMetaSchema = z
+  .discriminatedUnion('type', [
+    z.object({
+      type: z.literal(FieldType.SIGNATURE),
+      fieldMeta: ZSignatureFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.FREE_SIGNATURE),
+      fieldMeta: z.undefined(),
+    }),
+    z.object({
+      type: z.literal(FieldType.INITIALS),
+      fieldMeta: ZInitialsFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.NAME),
+      fieldMeta: ZNameFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.EMAIL),
+      fieldMeta: ZEmailFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.DATE),
+      fieldMeta: ZDateFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.TEXT),
+      fieldMeta: ZTextFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.NUMBER),
+      fieldMeta: ZNumberFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.RADIO),
+      fieldMeta: ZRadioFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.CHECKBOX),
+      fieldMeta: ZCheckboxFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.DROPDOWN),
+      fieldMeta: ZDropdownFieldMeta.optional(),
+    }),
+  ])
+  .superRefine((data, ctx) => {
+    if (data.fieldMeta?.required && data.fieldMeta?.readOnly) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A field cannot be both read-only and required',
+        path: ['fieldMeta', 'required'],
+      });
+    }
+  });
 
 export type TFieldAndMeta = z.infer<typeof ZFieldAndMetaSchema>;
 
@@ -400,51 +420,61 @@ export const FIELD_META_DEFAULT_VALUES: Record<FieldType, TFieldMetaSchema> = {
   [FieldType.DROPDOWN]: FIELD_DROPDOWN_META_DEFAULT_VALUES,
 } as const;
 
-export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal(FieldType.SIGNATURE),
-    fieldMeta: ZSignatureFieldMeta.optional().default(FIELD_SIGNATURE_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.FREE_SIGNATURE),
-    fieldMeta: z.undefined(),
-  }),
-  z.object({
-    type: z.literal(FieldType.INITIALS),
-    fieldMeta: ZInitialsFieldMeta.optional().default(FIELD_INITIALS_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.NAME),
-    fieldMeta: ZNameFieldMeta.optional().default(FIELD_NAME_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.EMAIL),
-    fieldMeta: ZEmailFieldMeta.optional().default(FIELD_EMAIL_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.DATE),
-    fieldMeta: ZDateFieldMeta.optional().default(FIELD_DATE_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.TEXT),
-    fieldMeta: ZTextFieldMeta.optional().default(FIELD_TEXT_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.NUMBER),
-    fieldMeta: ZNumberFieldMeta.optional().default(FIELD_NUMBER_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.RADIO),
-    fieldMeta: ZRadioFieldMeta.optional().default(FIELD_RADIO_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.CHECKBOX),
-    fieldMeta: ZCheckboxFieldMeta.optional().default(FIELD_CHECKBOX_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.DROPDOWN),
-    fieldMeta: ZDropdownFieldMeta.optional().default(FIELD_DROPDOWN_META_DEFAULT_VALUES),
-  }),
-]);
+export const ZEnvelopeFieldAndMetaSchema = z
+  .discriminatedUnion('type', [
+    z.object({
+      type: z.literal(FieldType.SIGNATURE),
+      fieldMeta: ZSignatureFieldMeta.optional().default(FIELD_SIGNATURE_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.FREE_SIGNATURE),
+      fieldMeta: z.undefined(),
+    }),
+    z.object({
+      type: z.literal(FieldType.INITIALS),
+      fieldMeta: ZInitialsFieldMeta.optional().default(FIELD_INITIALS_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.NAME),
+      fieldMeta: ZNameFieldMeta.optional().default(FIELD_NAME_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.EMAIL),
+      fieldMeta: ZEmailFieldMeta.optional().default(FIELD_EMAIL_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.DATE),
+      fieldMeta: ZDateFieldMeta.optional().default(FIELD_DATE_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.TEXT),
+      fieldMeta: ZTextFieldMeta.optional().default(FIELD_TEXT_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.NUMBER),
+      fieldMeta: ZNumberFieldMeta.optional().default(FIELD_NUMBER_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.RADIO),
+      fieldMeta: ZRadioFieldMeta.optional().default(FIELD_RADIO_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.CHECKBOX),
+      fieldMeta: ZCheckboxFieldMeta.optional().default(FIELD_CHECKBOX_META_DEFAULT_VALUES),
+    }),
+    z.object({
+      type: z.literal(FieldType.DROPDOWN),
+      fieldMeta: ZDropdownFieldMeta.optional().default(FIELD_DROPDOWN_META_DEFAULT_VALUES),
+    }),
+  ])
+  .superRefine((data, ctx) => {
+    if (data.fieldMeta?.required && data.fieldMeta?.readOnly) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A field cannot be both read-only and required',
+        path: ['fieldMeta', 'required'],
+      });
+    }
+  });
 
 export type TEnvelopeFieldAndMeta = z.infer<typeof ZEnvelopeFieldAndMetaSchema>;


### PR DESCRIPTION
Fixes #3296
/claim #3296

## Summary
Enforces schema-level mutual exclusivity between `required: true` and `readOnly: true` on field metadata across envelope creation, update, and parsing paths.

## Changes
- Added `.superRefine()` validation to `ZFieldMetaNotOptionalSchema`, `ZFieldAndMetaSchema`, and `ZEnvelopeFieldAndMetaSchema` in `packages/lib/types/field-meta.ts`.
- Added comprehensive unit tests in `packages/lib/types/field-meta.test.ts` verifying that invalid combinations fail parsing with `'A field cannot be both read-only and required'` across all field types.