### PR TITLE
fix: enlarge envelope field resize handle hit area

### DIFF
--- a/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
+++ b/apps/remix/app/components/general/envelope-editor/envelope-editor-fields-page-renderer.tsx
@@ -37,6 +37,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { fieldButtonList } from './envelope-editor-fields-drag-drop';
 import { EnvelopeRecipientSelectorCommand } from './envelope-recipient-selector';
 
+/** How far past a resize handle you can still grab it, in screen pixels. */
+const TRANSFORMER_ANCHOR_HIT_STROKE_PX = 24;
+
 export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageRenderData }) => {
   const { t, i18n } = useLingui();
   const { envelope, editorFields, getRecipientColorKey } = useCurrentEnvelopeEditor();
@@ -350,6 +353,9 @@ export const EnvelopeEditorFieldsPageRenderer = ({ pageData }: { pageData: PageR
       shouldOverdrawWholeArea: true,
       ignoreStroke: true,
       flipEnabled: false,
+      anchorStyleFunc: (anchor) => {
+        anchor.hitStrokeWidth(TRANSFORMER_ANCHOR_HIT_STROKE_PX / scale);
+      },
       boundBoxFunc: (oldBox, newBox) => {
         // Enforce minimum size
         if (newBox.width < 30 || newBox.height < 20) {


### PR DESCRIPTION
To resize the fields, you had to click the resizing handles very precisely. Konva `hitStrokeWidth` is now 24 screen pixels, so the grab area extends past the resize handles.

If you watch the video, the resize cursor has some tolerance. You don't have to click the handles precisely.

Before, hovering just outside a handle dropped the resize cursor, which made fields hard to resize. The video from the issue shows that: https://github.com/documenso/documenso/issues/2934

https://github.com/user-attachments/assets/d881ff08-592a-4810-94e5-5a81adf092c6



