### PR TITLE
fix: increase signature placeholder size when a timestamp authority is configured

### DIFF
--- a/packages/signing/index.ts
+++ b/packages/signing/index.ts
@@ -49,6 +49,11 @@ export const signPdf = async ({ pdf }: SignOptions) => {
     timestampAuthority: tsa ?? undefined,
     longTermValidation: !!tsa,
     archivalTimestamp: !!tsa,
+    // A B-LTA signature (signer chain + RFC 3161 timestamp token + LTV
+    // revocation data) can exceed the 12288-byte default placeholder,
+    // depending on the signing certificate chain and the TSA responder.
+    // The unused portion is zero-padding, so over-reserving is cheap.
+    estimatedSize: tsa ? 32768 : undefined,
   });
 
   return bytes;


### PR DESCRIPTION
## Description

When `NEXT_PRIVATE_SIGNING_TIMESTAMP_AUTHORITY` is set, `signPdf()` requests a B-LTA signature (`longTermValidation` + `archivalTimestamp`), but never passes `estimatedSize` to `pdf.sign()`, so @libpdf/core falls back to its 12288-byte default placeholder. A full B-LTA CMS structure (signer certificate chain + RFC 3161 timestamp token + LTV revocation data) can exceed that, depending on the signing CA chain and the TSA responder. Sealing then fails with `PLACEHOLDER_TOO_SMALL` and the envelope stays stuck in `PENDING` even though all recipients have signed.

Hit in production with a Certinomis (qualified EU CA) certificate chain + QuoVadis TSA: `Signature placeholder too small: need 12327 bytes, have 12288 bytes`. #3092 reports the same with a Certigna chain + DigiCert TSA (12465 bytes needed).

This reserves 32768 bytes when a TSA is configured. The unused portion of the placeholder is zero-padding, so the only cost is a slightly larger sealed PDF. Behavior is unchanged when no TSA is configured.

Fixes #3092
Likely also addresses #2215 (envelope stuck in PENDING).

## Testing

- Reproduced the failure on a self-hosted v2.x instance (Certinomis chain + QuoVadis TSA): seal-document fails with `PLACEHOLDER_TOO_SMALL` (need 12327, have 12288), envelope stuck in PENDING.
- #3092 includes a minimal reproduction with the bundled @libpdf/core showing `estimatedSize: 12288` → `PlaceholderError`, while 16384/20000 → valid B-LTA PDF verified in Adobe Acrobat.
- We are deploying this patch on our instance; I will report back here once real documents have been sealed with it.
- Without a TSA configured, `estimatedSize` is `undefined` and the library default applies, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)