### PR TITLE
fix(trpc): update-many no longer resets fieldMeta to type defaults when omitted

### DIFF
--- a/packages/lib/types/field-meta.test.ts
+++ b/packages/lib/types/field-meta.test.ts
@@ -1,0 +1,62 @@
+import { FieldType } from '@prisma/client';
+import { describe, expect, it } from 'vitest';
+
+import {
+  FIELD_TEXT_META_DEFAULT_VALUES,
+  ZEnvelopeFieldAndMetaSchema,
+  ZEnvelopeFieldAndMetaUpdateSchema,
+} from './field-meta';
+
+describe('ZEnvelopeFieldAndMetaSchema', () => {
+  it('applies create-time meta defaults when fieldMeta is omitted', () => {
+    const result = ZEnvelopeFieldAndMetaSchema.parse({ type: FieldType.TEXT });
+
+    expect(result).toEqual({
+      type: FieldType.TEXT,
+      fieldMeta: FIELD_TEXT_META_DEFAULT_VALUES,
+    });
+  });
+});
+
+describe('ZEnvelopeFieldAndMetaUpdateSchema', () => {
+  it('keeps an omitted fieldMeta undefined so updates do not reset stored meta', () => {
+    const result = ZEnvelopeFieldAndMetaUpdateSchema.parse({ type: FieldType.TEXT });
+
+    expect(result).toEqual({
+      type: FieldType.TEXT,
+      fieldMeta: undefined,
+    });
+  });
+
+  it('still validates a provided fieldMeta', () => {
+    const meta = { type: 'text', label: 'Work email', required: true };
+
+    const result = ZEnvelopeFieldAndMetaUpdateSchema.parse({
+      type: FieldType.TEXT,
+      fieldMeta: meta,
+    });
+
+    expect(result.fieldMeta).toEqual(meta);
+  });
+
+  it('keeps every member optional without defaults', () => {
+    const members = [
+      FieldType.SIGNATURE,
+      FieldType.INITIALS,
+      FieldType.NAME,
+      FieldType.EMAIL,
+      FieldType.DATE,
+      FieldType.TEXT,
+      FieldType.NUMBER,
+      FieldType.RADIO,
+      FieldType.CHECKBOX,
+      FieldType.DROPDOWN,
+    ];
+
+    for (const type of members) {
+      const result = ZEnvelopeFieldAndMetaUpdateSchema.parse({ type });
+
+      expect(result).toEqual({ type, fieldMeta: undefined });
+    }
+  });
+});

--- a/packages/lib/types/field-meta.ts
+++ b/packages/lib/types/field-meta.ts
@@ -400,51 +400,85 @@ export const FIELD_META_DEFAULT_VALUES: Record<FieldType, TFieldMetaSchema> = {
   [FieldType.DROPDOWN]: FIELD_DROPDOWN_META_DEFAULT_VALUES,
 } as const;
 
-export const ZEnvelopeFieldAndMetaSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal(FieldType.SIGNATURE),
-    fieldMeta: ZSignatureFieldMeta.optional().default(FIELD_SIGNATURE_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.FREE_SIGNATURE),
-    fieldMeta: z.undefined(),
-  }),
-  z.object({
-    type: z.literal(FieldType.INITIALS),
-    fieldMeta: ZInitialsFieldMeta.optional().default(FIELD_INITIALS_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.NAME),
-    fieldMeta: ZNameFieldMeta.optional().default(FIELD_NAME_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.EMAIL),
-    fieldMeta: ZEmailFieldMeta.optional().default(FIELD_EMAIL_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.DATE),
-    fieldMeta: ZDateFieldMeta.optional().default(FIELD_DATE_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.TEXT),
-    fieldMeta: ZTextFieldMeta.optional().default(FIELD_TEXT_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.NUMBER),
-    fieldMeta: ZNumberFieldMeta.optional().default(FIELD_NUMBER_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.RADIO),
-    fieldMeta: ZRadioFieldMeta.optional().default(FIELD_RADIO_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.CHECKBOX),
-    fieldMeta: ZCheckboxFieldMeta.optional().default(FIELD_CHECKBOX_META_DEFAULT_VALUES),
-  }),
-  z.object({
-    type: z.literal(FieldType.DROPDOWN),
-    fieldMeta: ZDropdownFieldMeta.optional().default(FIELD_DROPDOWN_META_DEFAULT_VALUES),
-  }),
-]);
+const buildEnvelopeFieldAndMetaSchema = (options: { applyMetaDefaults: boolean }) =>
+  z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal(FieldType.SIGNATURE),
+      fieldMeta: options.applyMetaDefaults
+        ? ZSignatureFieldMeta.optional().default(FIELD_SIGNATURE_META_DEFAULT_VALUES)
+        : ZSignatureFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.FREE_SIGNATURE),
+      fieldMeta: z.undefined(),
+    }),
+    z.object({
+      type: z.literal(FieldType.INITIALS),
+      fieldMeta: options.applyMetaDefaults
+        ? ZInitialsFieldMeta.optional().default(FIELD_INITIALS_META_DEFAULT_VALUES)
+        : ZInitialsFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.NAME),
+      fieldMeta: options.applyMetaDefaults
+        ? ZNameFieldMeta.optional().default(FIELD_NAME_META_DEFAULT_VALUES)
+        : ZNameFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.EMAIL),
+      fieldMeta: options.applyMetaDefaults
+        ? ZEmailFieldMeta.optional().default(FIELD_EMAIL_META_DEFAULT_VALUES)
+        : ZEmailFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.DATE),
+      fieldMeta: options.applyMetaDefaults
+        ? ZDateFieldMeta.optional().default(FIELD_DATE_META_DEFAULT_VALUES)
+        : ZDateFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.TEXT),
+      fieldMeta: options.applyMetaDefaults
+        ? ZTextFieldMeta.optional().default(FIELD_TEXT_META_DEFAULT_VALUES)
+        : ZTextFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.NUMBER),
+      fieldMeta: options.applyMetaDefaults
+        ? ZNumberFieldMeta.optional().default(FIELD_NUMBER_META_DEFAULT_VALUES)
+        : ZNumberFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.RADIO),
+      fieldMeta: options.applyMetaDefaults
+        ? ZRadioFieldMeta.optional().default(FIELD_RADIO_META_DEFAULT_VALUES)
+        : ZRadioFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.CHECKBOX),
+      fieldMeta: options.applyMetaDefaults
+        ? ZCheckboxFieldMeta.optional().default(FIELD_CHECKBOX_META_DEFAULT_VALUES)
+        : ZCheckboxFieldMeta.optional(),
+    }),
+    z.object({
+      type: z.literal(FieldType.DROPDOWN),
+      fieldMeta: options.applyMetaDefaults
+        ? ZDropdownFieldMeta.optional().default(FIELD_DROPDOWN_META_DEFAULT_VALUES)
+        : ZDropdownFieldMeta.optional(),
+    }),
+  ]);
+
+export const ZEnvelopeFieldAndMetaSchema = buildEnvelopeFieldAndMetaSchema({
+  applyMetaDefaults: true,
+});
+
+/**
+ * Same shape as `ZEnvelopeFieldAndMetaSchema` but without create-time defaults.
+ * For update routes: an omitted `fieldMeta` must stay `undefined` so the stored
+ * metadata is left untouched instead of being reset to the type defaults.
+ */
+export const ZEnvelopeFieldAndMetaUpdateSchema = buildEnvelopeFieldAndMetaSchema({
+  applyMetaDefaults: false,
+});
 
 export type TEnvelopeFieldAndMeta = z.infer<typeof ZEnvelopeFieldAndMetaSchema>;

--- a/packages/trpc/server/envelope-router/envelope-fields/update-envelope-fields.types.ts
+++ b/packages/trpc/server/envelope-router/envelope-fields/update-envelope-fields.types.ts
@@ -1,5 +1,5 @@
 import { ZFieldSchema } from '@documenso/lib/types/field';
-import { ZEnvelopeFieldAndMetaSchema } from '@documenso/lib/types/field-meta';
+import { ZEnvelopeFieldAndMetaUpdateSchema } from '@documenso/lib/types/field-meta';
 import { z } from 'zod';
 
 import type { TrpcRouteMeta } from '../../trpc';
@@ -15,7 +15,7 @@ export const updateEnvelopeFieldsMeta: TrpcRouteMeta = {
   },
 };
 
-const ZUpdateFieldBaseSchema = ZEnvelopeFieldAndMetaSchema.and(
+const ZUpdateFieldBaseSchema = ZEnvelopeFieldAndMetaUpdateSchema.and(
   z.object({
     id: z.number().describe('The ID of the field to update.'),
     envelopeItemId: z


### PR DESCRIPTION
## Problem

`POST /api/v2/envelope/field/update-many` is documented as a partial update, but any call that omits `fieldMeta` resets the field's stored metadata to the type defaults behind a 200. The documented example `{ id, type, pageY }` is itself a call that wipes a TEXT field's label, placeholder, required flag and character limit.

## Cause

`ZEnvelopeFieldAndMetaSchema` gives every meta-bearing member a create-time default (#2181). The update route consumes that schema, so an omitted `fieldMeta` arrives at the service as the full default object and `tx.field.update` writes it unconditionally.

## Fix

Give the update route a schema with the same members but no create-time defaults: `ZEnvelopeFieldAndMetaUpdateSchema`, built in `field-meta.ts` next to the existing union. An omitted `fieldMeta` now parses to `undefined` and Prisma leaves the column untouched; a provided `fieldMeta` still validates as before. Create routes keep their defaults.

## Testing

- Added `packages/lib/types/field-meta.test.ts`: the create schema still materialises defaults; the update schema keeps an omitted `fieldMeta` undefined for all 10 meta-bearing types and still validates provided metadata.
- Verified through `ZUpdateEnvelopeFieldsRequestSchema` with `{ id, type: 'TEXT', pageY: 85 }`: parses to `fieldMeta: undefined` with this change. With the previous schema, the same parse returns the full TEXT default object (empty label, empty placeholder, default font size), which is the wipe from the issue.
- `vitest run` in `@documenso/lib`: 198 passed. Biome clean on the touched files.

## Related

- #3136 covers the coordinate half of this endpoint (position fields silently dropped). Its current diff forwards `fieldMeta: field.fieldMeta`, the zod-defaulted value, so it would still wipe metadata on a move. This PR closes that half. Happy to rebase if #3136 lands first.

Fixes #3286
