### PR TITLE
fix: position signing field dialogs within the visual viewport

### DIFF
--- a/packages/ui/lib/use-visual-viewport.ts
+++ b/packages/ui/lib/use-visual-viewport.ts
@@ -1,0 +1,66 @@
+import { useSyncExternalStore } from 'react';
+
+type VisualViewportRect = {
+  offsetLeft: number;
+  offsetTop: number;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+let cachedViewportRect: VisualViewportRect | null = null;
+
+const subscribe = (callback: () => void) => {
+  if (typeof window === 'undefined' || !window.visualViewport) {
+    return () => {};
+  }
+
+  window.visualViewport.addEventListener('resize', callback);
+  window.visualViewport.addEventListener('scroll', callback);
+  window.addEventListener('scroll', callback);
+  window.addEventListener('resize', callback);
+
+  return () => {
+    window.visualViewport?.removeEventListener('resize', callback);
+    window.visualViewport?.removeEventListener('scroll', callback);
+    window.removeEventListener('scroll', callback);
+    window.removeEventListener('resize', callback);
+  };
+};
+
+const getSnapshot = (): VisualViewportRect | null => {
+  const visualViewport = window.visualViewport;
+
+  if (!visualViewport) {
+    return null;
+  }
+
+  const nextViewportRect: VisualViewportRect = {
+    offsetLeft: visualViewport.offsetLeft,
+    offsetTop: visualViewport.offsetTop,
+    width: visualViewport.width,
+    height: visualViewport.height,
+    scale: visualViewport.scale,
+  };
+
+  if (
+    cachedViewportRect !== null &&
+    cachedViewportRect.offsetLeft === nextViewportRect.offsetLeft &&
+    cachedViewportRect.offsetTop === nextViewportRect.offsetTop &&
+    cachedViewportRect.width === nextViewportRect.width &&
+    cachedViewportRect.height === nextViewportRect.height &&
+    cachedViewportRect.scale === nextViewportRect.scale
+  ) {
+    return cachedViewportRect;
+  }
+
+  cachedViewportRect = nextViewportRect;
+
+  return cachedViewportRect;
+};
+
+const getServerSnapshot = (): null => null;
+
+export const useVisualViewport = () => {
+  return useSyncExternalStore<VisualViewportRect | null>(subscribe, getSnapshot, getServerSnapshot);
+};

--- a/packages/ui/primitives/dialog.tsx
+++ b/packages/ui/primitives/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import * as React from 'react';
 
+import { useVisualViewport } from '../lib/use-visual-viewport';
 import { cn } from '../lib/utils';
 
 const Dialog = DialogPrimitive.Root;
@@ -15,19 +16,44 @@ const DialogPortal = ({
   children,
   position = 'start',
   ...props
-}: DialogPrimitive.DialogPortalProps & { position?: 'start' | 'end' | 'center' }) => (
-  <DialogPrimitive.Portal {...props}>
-    <div
-      className={cn('fixed inset-0 z-[1000] flex justify-center sm:items-center', {
-        'items-start': position === 'start',
-        'items-end': position === 'end',
-        'items-center': position === 'center',
-      })}
-    >
-      {children}
-    </div>
-  </DialogPrimitive.Portal>
-);
+}: DialogPrimitive.DialogPortalProps & { position?: 'start' | 'end' | 'center' }) => {
+  const visualViewport = useVisualViewport();
+
+  // `position: fixed` resolves against the layout viewport, so when the page is
+  // pinch-zoomed on a touch device the dialog is placed relative to the full
+  // unzoomed page and lands outside the visible (visual) viewport. When the
+  // visual viewport differs from the layout viewport, pin the dialog to it so it
+  // renders within the region the signer is currently looking at.
+  const isZoomed = visualViewport !== null && visualViewport.scale !== 1;
+
+  const viewportStyle = isZoomed
+    ? {
+        top: visualViewport.offsetTop,
+        left: visualViewport.offsetLeft,
+        width: visualViewport.width,
+        height: visualViewport.height,
+      }
+    : undefined;
+
+  return (
+    <DialogPrimitive.Portal {...props}>
+      <div
+        className={cn(
+          'fixed z-[1000] flex justify-center sm:items-center',
+          !isZoomed && 'inset-0',
+          {
+            'items-start': position === 'start',
+            'items-end': position === 'end',
+            'items-center': position === 'center',
+          },
+        )}
+        style={viewportStyle}
+      >
+        {children}
+      </div>
+    </DialogPrimitive.Portal>
+  );
+};
 
 DialogPortal.displayName = DialogPrimitive.Portal.displayName;
 


### PR DESCRIPTION
## Problem

When a signer pinch-zooms into a document on a touch device and taps a field, the input dialog (Radix dialog used for text, date, name, and dropdown fields) renders outside the visible area, oversized and misaligned. This is because `position: fixed` resolves against the layout viewport, not the visual viewport that moves during pinch zoom.

## Solution
fixes #3333 
Track `window.visualViewport` scale and offset while the dialog is open, and adjust the dialog positioning to remain within the visible region. This fix is applied at the shared `dialog.tsx` primitive level, so all field types (text, date, name, dropdown) benefit automatically.

## Changes

- **`packages/ui/primitives/dialog.tsx`**: Added visual viewport tracking to position dialogs within the visible area during pinch zoom.

## Testing

- Open a signing link on a mobile device (or simulator)
- Pinch-zoom into the document
- Tap a field to open its input dialog
- Verify the dialog appears within the visible region, correctly sized

## Checklist

- [x] Code follows project conventions
- [x] Minimal, focused change
- [x] No unnecessary refactoring or formatting changes