### PR TITLE
chore(lib): remove unused timezone labels

### DIFF
--- a/packages/lib/constants/time-zones.ts
+++ b/packages/lib/constants/time-zones.ts
@@ -1,44 +1,5 @@
-import { rawTimeZones, timeZonesNames } from '@vvo/tzdb';
-
-export const TIME_ZONE_DATA = rawTimeZones;
+import { timeZonesNames } from '@vvo/tzdb';
 
 export const DEFAULT_DOCUMENT_TIME_ZONE = 'Etc/UTC';
-
-export type TimeZone = {
-  name: string;
-  rawOffsetInMinutes: number;
-};
-
-export const minutesToHours = (minutes: number): string => {
-  const hours = Math.abs(Math.floor(minutes / 60));
-  const min = Math.abs(minutes % 60);
-  const sign = minutes >= 0 ? '+' : '-';
-
-  return `${sign}${String(hours).padStart(2, '0')}:${String(min).padStart(2, '0')}`;
-};
-
-const getGMTOffsets = (timezones: TimeZone[]): string[] => {
-  const gmtOffsets: string[] = [];
-
-  for (const timezone of timezones) {
-    const offsetValue = minutesToHours(timezone.rawOffsetInMinutes);
-    const gmtText = `(${offsetValue})`;
-
-    gmtOffsets.push(`${timezone.name} ${gmtText}`);
-  }
-
-  return gmtOffsets;
-};
-
-export const splitTimeZone = (input: string | null): string => {
-  if (input === null) {
-    return '';
-  }
-  const [timeZone] = input.split('(');
-
-  return timeZone.trim();
-};
-
-export const TIME_ZONES_FULL = getGMTOffsets(TIME_ZONE_DATA);
 
 export const TIME_ZONES = ['Etc/UTC', ...timeZonesNames];


### PR DESCRIPTION
## Description

Document settings keep the same timezone choices and UTC default. No caller uses the GMT-offset labels.

## Related Issue

None.

## Changes Made

The timezone identifiers and their order remain unchanged.

## Testing Performed

All 419 timezone entries matched the original list. The library type check reports the same five errors as main.

## Checklist

- [x] I have followed the project's coding style guidelines.

## Additional Notes

This cleanup targets main independently of the other cleanup PRs.