### PR TITLE
chore(prisma): remove unused logging client

### DIFF
--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -36,40 +36,6 @@ export const kyselyPrisma = remember('kyselyPrisma', () =>
   ),
 );
 
-export const prismaWithLogging = remember('prismaWithLogging', () => {
-  const client = new PrismaClient({
-    datasourceUrl: getDatabaseUrl(),
-    log: [
-      {
-        emit: 'event',
-        level: 'query',
-      },
-    ],
-  });
-
-  client.$on('query', (e) => {
-    console.log('query:', e.query);
-    console.log('params:', e.params);
-    console.log('duration:', e.duration);
-
-    const params = JSON.parse(e.params) as unknown[];
-
-    const query = e.query.replace(/\$\d+/g, (match) => {
-      const index = Number(match.replace('$', ''));
-
-      if (index > params.length) {
-        return match;
-      }
-
-      return String(params[index - 1]);
-    });
-
-    console.log('formatted query:', query);
-  });
-
-  return client;
-});
-
 export const prismaWithReplicas = remember('prismaWithReplicas', () => {
   if (!process.env.NEXT_PRIVATE_DATABASE_REPLICA_URLS) {
     return prisma;


### PR DESCRIPTION
## Description

The application uses the standard Prisma client, read replicas, and Kysely. No caller uses this separate query-logging client.

## Related Issue

None.

## Changes Made

The active client configuration and replica selection remain unchanged.

## Testing Performed

The Prisma type check reports the same errors as main. The database query check could not connect to the configured local database.

## Checklist

- [x] I have followed the project's coding style guidelines.

## Additional Notes

This cleanup targets main independently of the other cleanup PRs.