### PR TITLE
fix(i18n): add missing plural in bulk template upload error handling

### DIFF
--- a/apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
+++ b/apps/remix/app/components/dialogs/template-bulk-send-dialog.tsx
@@ -18,7 +18,7 @@ import { useToast } from '@documenso/ui/primitives/use-toast';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { Trans } from '@lingui/react/macro';
+import { Plural, Trans } from '@lingui/react/macro';
 import { File as FileIcon, Upload, X } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -271,7 +271,12 @@ export const TemplateBulkSendDialog = ({ templateId, recipients, trigger, onSucc
                     ))
                     .with({ type: 'ROW_LIMIT_EXCEEDED' }, ({ rowCount, maxRows }) => (
                       <Trans>
-                        The CSV contains {rowCount} rows. A maximum of {maxRows} rows is allowed per upload.
+                        <Plural value={rowCount} one="The CSV contains # row." other="The CSV contains # rows." />{' '}
+                        <Plural
+                          value={maxRows}
+                          one="A maximum of # row is allowed per upload."
+                          other="A maximum of # rows is allowed per upload."
+                        />
                       </Trans>
                     ))
                     .with({ type: 'MISSING_COLUMNS' }, ({ missingColumns }) => (


### PR DESCRIPTION
## Description

Add missing support for plural from #3326 changes

## Changes Made

- Add plurals to handle all cases (some languages have more than one plural forms)

ex. in Polish:
2 rows: `2 wiersze`
5 rows: `5 wierszy`

## Testing Performed

- Check regenerated web.po file

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

I wrapped `<Plural>` tags with `<Trans>` tags to get just one string and full context for localization.
