### PR TITLE
fix(pdf): handle owner-password encrypted PDFs in normalizePdf (#3303)

### DIFF
--- a/packages/lib/server-only/pdf/normalize-pdf.ts
+++ b/packages/lib/server-only/pdf/normalize-pdf.ts
@@ -5,7 +5,7 @@ import { AppError } from '../../errors/app-error';
 export const normalizePdf = async (pdf: Buffer, options: { flattenForm?: boolean } = {}) => {
   const shouldFlattenForm = options.flattenForm ?? true;
 
-  const pdfDoc = await PDF.load(pdf).catch((e) => {
+  let pdfDoc = await PDF.load(pdf).catch((e) => {
     console.error(`PDF normalization error: ${e.message}`);
 
     throw new AppError('INVALID_DOCUMENT_FILE', {
@@ -13,10 +13,14 @@ export const normalizePdf = async (pdf: Buffer, options: { flattenForm?: boolean
     });
   });
 
-  if (pdfDoc.isEncrypted) {
+  if (!pdfDoc.isAuthenticated) {
     throw new AppError('INVALID_DOCUMENT_FILE', {
       message: 'The document is encrypted',
     });
+  }
+
+  if (pdfDoc.isEncrypted && shouldFlattenForm) {
+    pdfDoc = await pdfDoc.extractPages([...Array(pdfDoc.getPageCount()).keys()]);
   }
 
   pdfDoc.flattenLayers();


### PR DESCRIPTION
## Description
\
ormalizePdf\ previously rejected any PDF where \pdfDoc.isEncrypted\ evaluated to true. However, PDFs with owner passwords (permissions/editing restrictions) can be opened and read without requiring a user password (\pdfDoc.isAuthenticated === true\), as is common with many government and institutional forms.

This change:
1. Replaces the blanket \pdfDoc.isEncrypted\ check with \!pdfDoc.isAuthenticated\ to only reject documents requiring an unprovided user password.
2. For owner-encrypted documents where authentication succeeded, rebuilds pages via \wait pdfDoc.extractPages([...Array(pdfDoc.getPageCount()).keys()])\ when \shouldFlattenForm\ is enabled so forms and annotations can be modified, flattened, and saved cleanly.

Fixes #3303