### PR TITLE
fix(i18n): add support for plural in app-command-menu.tsx

### DIFF
--- a/apps/remix/app/components/general/app-command-menu.tsx
+++ b/apps/remix/app/components/general/app-command-menu.tsx
@@ -597,7 +597,11 @@ export const AppCommandMenu = ({ open, onOpenChange }: AppCommandMenuProps) => {
             <span className="ml-auto text-muted-foreground text-xs">
               {hasValidSearch ? (
                 isVisibleCountCapped ? (
-                  <Trans>{formatChipCount(totalVisibleCount, isVisibleCountCapped)} results</Trans>
+                  <Plural
+                    value={totalVisibleCount}
+                    one="≥# result"
+                    other="≥# results"
+                  />
                 ) : (
                   <Plural
                     value={totalVisibleCount}


### PR DESCRIPTION
## Description

I added missing support for plural in app-command-menu.tsx. Someone fixed some issues in #3262 but forgot to fix this tag.

## Related Issue

#3262

## Changes Made

- Add plural tag

## Testing Performed


- Check web.po file

```
#: apps/remix/app/components/general/app-command-menu.tsx
msgid "{totalVisibleCount, plural, one {≥# result} other {≥# results}}"
```

## Checklist

<!--- Please check the boxes that apply to this pull request. -->
<!--- You can add or remove items as needed. -->

- [x] I have tested these changes locally and they work as expected.
- [ ] I have added/updated tests that prove the effectiveness of these changes.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.
- [ ] I have addressed the code review feedback from the previous submission, if applicable.

## Additional Notes

Orginial variable contains `≥` so I added it also to translation for better context

` const formatChipCount = (count: number, isCapped: boolean) => (isCapped ? `≥${count}` : `${count}`);`

Plural is needed also when value is always larger than 1. Polish langauage:
2 results -> 2 wynik**i**
5 results -> 5 wynik**ów**
